### PR TITLE
To support Windows 10 Enterprise Evaluation ISO

### DIFF
--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -212,6 +212,8 @@ namespace AutomatedLab
                         return "NPPR9-FWDCX-D2C8J-H872K-2YT43";
                     case "Windows 10 Enterprise Technical Preview":
                         return "NPPR9-FWDCX-D2C8J-H872K-2YT43";
+                    case "Windows 10 Enterprise Evaluation":
+                        return "NPPR9-FWDCX-D2C8J-H872K-2YT43";
                     case "Windows 10 Enterprise 2015 LTSB":
                         return "WNMTR-4C88C-JK8YV-HQ7T2-76DF9";
                     case "Windows 10 Enterprise 2016 LTSB":


### PR DESCRIPTION
Resolves error:
```
The product key is unknown for the OS 'Windows 10 Enterprise Evaluation' in ISO image ''. Cannot install lab until this problem is solved.
At C:\Program Files\WindowsPowerShell\Modules\AutomatedLab\AutomatedLabDisks.psm1:34 char:4
+             throw $message
+             ~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (The product key...blem is solved.:String) [], RuntimeException
    + FullyQualifiedErrorId : The product key is unknown for the OS 'Windows 10 Enterprise Evaluation' in ISO image ''. Cannot install lab until this problem is solved.
```