### PR TITLE
added "Done" Screen output to .Net install

### DIFF
--- a/AutomatedLab/AutomatedLabSQL.psm1
+++ b/AutomatedLab/AutomatedLabSQL.psm1
@@ -102,7 +102,8 @@ GO
             
             Write-ScreenInfo -Message "Waiting for pre-requisite .Net 3.5 Framework to finish installation on machines '$($machinesBatch -join ', ')'" -NoNewLine
             Wait-LWLabJob -Job $installFrameworkJobs -Timeout 10 -NoDisplay -ProgressIndicator 45
-            
+            Write-ScreenInfo -Message 'Done' -TaskEnd
+	    
             foreach ($machine in $machinesBatch)
             {
                 $role = $machine.Roles | Where-Object Name -like SQLServer*


### PR DESCRIPTION
Issue:
The next step written to screen after .Net install in a SQL Lab would not take a new line. 

Solution 
Added "Done" after .NET Screen output
![img_20171019_214139](https://user-images.githubusercontent.com/27346136/31885837-cfa718d6-b7e9-11e7-9fed-7c18c4234ad8.jpg)
