### PR TITLE
Insider build added to Lab OSses (fixes #174)

### DIFF
--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1740,12 +1740,7 @@ function Add-LabMachineDefinition
                 'Windows Server 2016 Technical Preview 4 SERVERSTANDARDCORE', 'Windows Server 2016 Technical Preview 4 SERVERSTANDARD', 'Windows Server 2016 Technical Preview 4 SERVERDATACENTERCORE', 'Windows Server 2016 Technical Preview 4 SERVERDATACENTER',
                 'Windows Server 2016 Technical Preview 5 SERVERSTANDARDCORE', 'Windows Server 2016 Technical Preview 5 SERVERSTANDARD', 'Windows Server 2016 Technical Preview 5 SERVERDATACENTERCORE', 'Windows Server 2016 Technical Preview 5 SERVERDATACENTER',
                 'Windows Server 2016 SERVERDATACENTER', 'Windows Server 2016 SERVERDATACENTERCORE', 'Windows Server 2016 SERVERSTANDARD', 'Windows Server 2016 SERVERSTANDARDCORE',
-                'Windows Server 2016 SERVERSTANDARDNANO', 'Windows Server 2016 SERVERDATACENTERNANO',"Windows Server 2016 SERVERSTANDARDACORE",
-                "Windows Server 2016 SERVERSTANDARDA",
-                "Windows Server 2016 SERVERSTANDARDANANO",
-                "Windows Server 2016 SERVERDATACENTERACORE",
-                "Windows Server 2016 SERVERDATACENTERANANO",
-                "Windows Server 2016 SERVERDATACENTERA"
+                'Windows Server 2016 SERVERSTANDARDNANO', 'Windows Server 2016 SERVERDATACENTERNANO','Windows Server 2016 SERVERSTANDARDACORE', 'Windows Server 2016 SERVERDATACENTERACORE'
                 
         )]
         [Alias('OS')]

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1740,7 +1740,12 @@ function Add-LabMachineDefinition
                 'Windows Server 2016 Technical Preview 4 SERVERSTANDARDCORE', 'Windows Server 2016 Technical Preview 4 SERVERSTANDARD', 'Windows Server 2016 Technical Preview 4 SERVERDATACENTERCORE', 'Windows Server 2016 Technical Preview 4 SERVERDATACENTER',
                 'Windows Server 2016 Technical Preview 5 SERVERSTANDARDCORE', 'Windows Server 2016 Technical Preview 5 SERVERSTANDARD', 'Windows Server 2016 Technical Preview 5 SERVERDATACENTERCORE', 'Windows Server 2016 Technical Preview 5 SERVERDATACENTER',
                 'Windows Server 2016 SERVERDATACENTER', 'Windows Server 2016 SERVERDATACENTERCORE', 'Windows Server 2016 SERVERSTANDARD', 'Windows Server 2016 SERVERSTANDARDCORE',
-                'Windows Server 2016 SERVERSTANDARDNANO', 'Windows Server 2016 SERVERDATACENTERNANO'
+                'Windows Server 2016 SERVERSTANDARDNANO', 'Windows Server 2016 SERVERDATACENTERNANO',"Windows Server 2016 SERVERSTANDARDACORE",
+                "Windows Server 2016 SERVERSTANDARDA",
+                "Windows Server 2016 SERVERSTANDARDANANO",
+                "Windows Server 2016 SERVERDATACENTERACORE",
+                "Windows Server 2016 SERVERDATACENTERANANO",
+                "Windows Server 2016 SERVERDATACENTERA"
                 
         )]
         [Alias('OS')]

--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -258,16 +258,7 @@ namespace AutomatedLab
                     // Server 2016 Insider Preview
                     case "Windows Server 2016 SERVERSTANDARDACORE":
                         return "DPCNP-XQFKJ-BJF7R-FRC8D-GF6G4";
-                    case "Windows Server 2016 SERVERSTANDARDA":
-                        return "DPCNP-XQFKJ-BJF7R-FRC8D-GF6G4";
-                    case "Windows Server 2016 SERVERSTANDARDANANO":
-                        return "DPCNP-XQFKJ-BJF7R-FRC8D-GF6G4";
-
                     case "Windows Server 2016 SERVERDATACENTERACORE":
-                        return "6Y6KB-N82V8-D8CQV-23MJW-BWTG6";
-                    case "Windows Server 2016 SERVERDATACENTERANANO":
-                        return "6Y6KB-N82V8-D8CQV-23MJW-BWTG6";
-                    case "Windows Server 2016 SERVERDATACENTERA":
                         return "6Y6KB-N82V8-D8CQV-23MJW-BWTG6";
 
                     default:

--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -107,7 +107,7 @@ namespace AutomatedLab
 
                     case "Windows Server 2016 SERVERSTANDARDNANO":
                         return "2016-Nano-Server";
-                        
+
                     case "Windows 8.1 Enterprise":
                         return "Win8.1-Ent-N";
 
@@ -254,6 +254,21 @@ namespace AutomatedLab
                         return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
                     case "Windows Server 2016 SERVERDATACENTERNANO":
                         return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
+
+                    // Server 2016 Insider Preview
+                    case "Windows Server 2016 SERVERSTANDARDACORE":
+                        return "DPCNP-XQFKJ-BJF7R-FRC8D-GF6G4";
+                    case "Windows Server 2016 SERVERSTANDARDA":
+                        return "DPCNP-XQFKJ-BJF7R-FRC8D-GF6G4";
+                    case "Windows Server 2016 SERVERSTANDARDANANO":
+                        return "DPCNP-XQFKJ-BJF7R-FRC8D-GF6G4";
+
+                    case "Windows Server 2016 SERVERDATACENTERACORE":
+                        return "6Y6KB-N82V8-D8CQV-23MJW-BWTG6";
+                    case "Windows Server 2016 SERVERDATACENTERANANO":
+                        return "6Y6KB-N82V8-D8CQV-23MJW-BWTG6";
+                    case "Windows Server 2016 SERVERDATACENTERA":
+                        return "6Y6KB-N82V8-D8CQV-23MJW-BWTG6";
 
                     default:
                         return string.Empty;


### PR DESCRIPTION
Added Server 2016 1709 Standard Core and Datacenter Core to the list of available OSses.