### PR TITLE
Update 07.2 Exchange 2016 Server and client, domain joined.ps1

### DIFF
--- a/LabSources/SampleScripts/Introduction/07.2 Exchange 2016 Server and client, domain joined.ps1
+++ b/LabSources/SampleScripts/Introduction/07.2 Exchange 2016 Server and client, domain joined.ps1
@@ -26,6 +26,9 @@ Add-LabMachineDefinition -Name Lab1Client1 -OperatingSystem 'Windows 10 Pro' -Me
 Install-Lab -NetworkSwitches -BaseImages -VMs -Domains -StartRemainingMachines
 
 Install-LabSoftwarePackage -Path $labSources\OSUpdates\2016\windows10.0-kb3206632-x64_b2e20b7e1aa65288007de21e88cd21c3ffb05110.msu -ComputerName (Get-LabVM -Role Exchange2016) -Timeout 60
+
+Invoke-LabCommand -ComputerName (Get-LabVM -Role Exchange2016) -ScriptBlock {restart-computer -force}
+
 Install-Lab -Exchange2016
 
 Show-LabDeploymentSummary -Detailed


### PR DESCRIPTION
Please add restart-computer after installing update.
Computers did not restart automattically after installing update, but it need to restart.
Installation of Exchange 2016 will fail if a computer need to be restarted.