### PR TITLE
Feature/azure additional ports fixes #85

### DIFF
--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -204,7 +204,9 @@
         'Wait-LabVMShutdown',
         'Get-LabBuildStep',
         'Get-LabReleaseStep',
-        'New-LabReleasePipeline'
+        'New-LabReleasePipeline',
+        'Get-LabAzureLoadBalancedPort',
+        'Open-LabTfsSite'
     )
     
     FileList               = @(

--- a/AutomatedLab/AutomatedLabDsc.psm1
+++ b/AutomatedLab/AutomatedLabDsc.psm1
@@ -162,7 +162,7 @@ function Install-LabDscPullServer
     }
 
 
-    $accessDbEngine = Get-LabInternetFile -Uri (Get-Module -Name AutomatedLab).PrivateData.AccessDatabaseEngine2016x86 -Path $labSources\SoftwarePackages -PassThru
+    $accessDbEngine = Get-LabInternetFile -Uri (Get-Module -Name AutomatedLab).PrivateData.AccessDatabaseEngine2016x86 -Path (Get-LabSourcesLocationInternal -Local)\SoftwarePackages -PassThru
     $jobs = @()
 
     foreach ($machine in $machines)
@@ -181,6 +181,12 @@ function Install-LabDscPullServer
         else
         {
             $databaseEngine = 'edb'
+        }
+
+        if ($machine.DefaultVirtualizationEngine -eq 'Azure')
+        {
+            Write-Verbose -Message ('Adding external port 8080 to Azure load balancer')
+            Add-LWAzureLoadBalancedPort -Port 8080 -ComputerName $machine -ErrorAction SilentlyContinue
         }
 
         Request-LabCertificate -Subject "CN=$machine" -TemplateName DscMofEncryption -ComputerName $machine -PassThru

--- a/AutomatedLab/AutomatedLabDsc.psm1
+++ b/AutomatedLab/AutomatedLabDsc.psm1
@@ -162,7 +162,7 @@ function Install-LabDscPullServer
     }
 
 
-    $accessDbEngine = Get-LabInternetFile -Uri (Get-Module -Name AutomatedLab).PrivateData.AccessDatabaseEngine2016x86 -Path (Get-LabSourcesLocationInternal -Local)\SoftwarePackages -PassThru
+    $accessDbEngine = Get-LabInternetFile -Uri (Get-Module -Name AutomatedLab).PrivateData.AccessDatabaseEngine2016x86 -Path $labsources\SoftwarePackages -PassThru
     $jobs = @()
 
     foreach ($machine in $machines)

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -185,13 +185,11 @@ function Install-LabBuildWorker
     ( )
 
     $buildWorkers = Get-LabVm -Role TfsBuildWorker
-    $locallabsources = Get-LabSourcesLocationInternal -Local
 
-    [void] (New-Item -Path (Join-Path -Path $locallabsources -ChildPath Tools\TFS) -ErrorAction SilentlyContinue -ItemType Directory)
     $buildWorkerUri = (Get-Module AutomatedLab -ListAvailable).PrivateData["BuildAgentUri"]
-    $buildWorkerPath = Join-Path -Path $locallabsources -ChildPath Tools\TFS\TfsBuildWorker.zip
-    Get-LabInternetFile -Uri $buildWorkerUri -Path $buildWorkerPath
-    Copy-LabFileItem -ComputerName $buildWorkers -Path $buildWorkerPath
+    $buildWorkerPath = Join-Path -Path $labsources -ChildPath Tools\TfsBuildWorker.zip
+    $download = Get-LabInternetFile -Uri $buildWorkerUri -Path $buildWorkerPath -PassThru
+    Copy-LabFileItem -ComputerName $buildWorkers -Path $download.FullName
 
     $installationJobs = @()
     foreach ( $machine in $buildWorkers)

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
@@ -1,6 +1,6 @@
 $PSDefaultParameterValues = @{
-    '*-Azure*:Verbose' = $false
-    '*-Azure*:Warning' = $false
+    '*-Azure*:Verbose'      = $false
+    '*-Azure*:Warning'      = $false
     'Import-Module:Verbose' = $false
 }
 
@@ -34,12 +34,12 @@ function New-LWAzureNetworkSwitch
         
              
         $azureNetworkParameters = @{
-            Name = $network.Name
+            Name              = $network.Name
             ResourceGroupName = (Get-LabAzureDefaultResourceGroup)
-            Location = (Get-LabAzureDefaultLocation)
-            AddressPrefix = $network.AddressSpace
-            ErrorAction = 'Stop'
-            Tag = @{ 
+            Location          = (Get-LabAzureDefaultLocation)
+            AddressPrefix     = $network.AddressSpace
+            ErrorAction       = 'Stop'
+            Tag               = @{ 
                 AutomatedLab = $script:lab.Name
                 CreationTime = Get-Date	
             }
@@ -63,10 +63,10 @@ function New-LWAzureNetworkSwitch
             # Do the subnets inside the job. Azure cmdlets don't work with deserialized PSSubnets...
             if ($Subnets)
             {
-				foreach ($subnet in $Subnets)
-				{
-					$azureSubnets += New-AzureRmVirtualNetworkSubnetConfig -Name $subnet.Name -AddressPrefix $subnet.AddressSpace.ToString()
-				}
+                foreach ($subnet in $Subnets)
+                {
+                    $azureSubnets += New-AzureRmVirtualNetworkSubnetConfig -Name $subnet.Name -AddressPrefix $subnet.AddressSpace.ToString()
+                }
             }
 
             if (-not $azureSubnets)
@@ -87,10 +87,10 @@ function New-LWAzureNetworkSwitch
     #Wait for network creation jobs and configure vnet peering    
     Wait-LWLabJob -Job $jobs
 
-	if($jobs.State -contains 'Failed')
-	{
-		throw ('Creation of at least one Azure Vnet failed. Examine the jobs output. Failed jobs: {0}' -f (($jobs | Where-Object State -EQ 'Failed').Id -join ','))
-	}
+    if ($jobs.State -contains 'Failed')
+    {
+        throw ('Creation of at least one Azure Vnet failed. Examine the jobs output. Failed jobs: {0}' -f (($jobs | Where-Object State -EQ 'Failed').Id -join ','))
+    }
 
     Write-ScreenInfo -Message "Done" -TaskEnd
     Write-ProgressIndicator
@@ -193,9 +193,9 @@ function Get-LWAzureNetworkSwitch
         Write-Verbose -Message "Locating Azure virtual network '$($network.Name)'"
          
         $azureNetworkParameters = @{
-            Name = $network.Name
+            Name              = $network.Name
             ResourceGroupName = (Get-LabAzureDefaultResourceGroup)
-            ErrorAction = 'SilentlyContinue'
+            ErrorAction       = 'SilentlyContinue'
         }
         
         Get-AzureRmVirtualNetwork @azureNetworkParameters
@@ -223,8 +223,8 @@ function New-LWAzureLoadBalancer
         if (-not $publicIp)
         {
             $publicIp = New-AzureRmPublicIpAddress -Name "$($resourceGroup)$($vNet.Name)lbfrontendip" -ResourceGroupName $resourceGroup `
-            -Location $location -AllocationMethod Static -IpAddressVersion IPv4 `
-            -DomainNameLabel "$($resourceGroup.ToLower())$($vNet.Name.ToLower())" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+                -Location $location -AllocationMethod Static -IpAddressVersion IPv4 `
+                -DomainNameLabel "$($resourceGroup.ToLower())$($vNet.Name.ToLower())" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
         }
 
         $frontendConfig = New-AzureRmLoadBalancerFrontendIpConfig -Name "$($resourceGroup)$($vNet.Name)lbfrontendconfig" -PublicIpAddress $publicIp
@@ -304,11 +304,12 @@ function Add-LWAzureLoadBalancedPort
         [int]
         $Port,
 
-        [AutomatedLab.Machine]
+        [Parameter(Mandatory)]
+        [string]
         $ComputerName
     )
 
-    if (Get-LWAzureLoadBalancedPort @PSBoundParameters)
+    if (Get-LabAzureLoadBalancedPort @PSBoundParameters)
     {
         Write-Verbose -Message ('Port {0} already configured for {1}' -f $Port, $ComputerName)
         return
@@ -316,8 +317,10 @@ function Add-LWAzureLoadBalancedPort
 
     $lab = Get-Lab
     $resourceGroup = $lab.Name
+    $machine = Get-LabVm -ComputerName $ComputerName
 
-    $lb = AzureRmLoadBalancer -ResourceGroupName $resourceGroup -WarningAction SilentlyContinue
+
+    $lb = Get-AzureRmLoadBalancer -ResourceGroupName $resourceGroup -WarningAction SilentlyContinue
     if (-not $lb)
     {
         Write-Verbose "No load balancer found to add port rules to"
@@ -328,44 +331,92 @@ function Add-LWAzureLoadBalancedPort
 
     $lab.AzureSettings.LoadBalancerPortCounter++
     $remotePort = $lab.AzureSettings.LoadBalancerPortCounter
-    $inboundRule= New-AzureRmLoadBalancerInboundNatRuleConfig -Name "$($machine.Name.ToLower())$Port" -FrontendIpConfiguration $frontendConfig -Protocol Tcp -FrontendPort $remotePort -BackendPort $Port
-    $inboundRule | Add-AzureRmLoadBalancerInboundNatRuleConfig -LoadBalancer $lb
+    $lb = Add-AzureRmLoadBalancerInboundNatRuleConfig -LoadBalancer $lb -Name "$($machine.Name.ToLower())$Port" -FrontendIpConfiguration $frontendConfig -Protocol Tcp -FrontendPort $remotePort -BackendPort $Port
+    $lb = $lb | Set-AzureRmLoadBalancer
 
-    if(-not $ComputerName.InternalNotes.AdditionalLoadBalancedPorts)
+    $vm = Get-AzureRmVm -ResourceGroupName $resourceGroup -Name $ComputerName
+    $nic = $vm.NetworkProfile.NetworkInterfaces | Get-AzureRmResource | Get-AzureRmNetworkInterface
+    $rules = Get-LWAzureLoadBalancedPort -ComputerName $ComputerName
+    $nic.IpConfigurations[0].LoadBalancerInboundNatRules = $rules
+    [void] ($nic | Set-AzureRmNetworkInterface)
+
+    if (-not $machine.InternalNotes."AdditionalPort$Port")
     {
-        $ComputerName.InternalNotes.AdditionalLoadBalancedPorts = @{}
+        $machine.InternalNotes.Add("AdditionalPort$Port", $remotePort)
     }
 
-    $ComputerName.InternalNotes.AdditionalLoadBalancedPorts.$Port = $remotePort
+    $machine.InternalNotes."AdditionalPort$Port" = $remotePort
+    
+    Export-Lab
 }
 
 function Get-LWAzureLoadBalancedPort
 {
     param
     (
+        
         [int]
         $Port,
 
-        [AutomatedLab.Machine]
+        [Parameter(Mandatory)]
+        [string]
         $ComputerName
     )
 
     $lab = Get-Lab
     $resourceGroup = $lab.Name
 
-    $lb = AzureRmLoadBalancer -ResourceGroupName $resourceGroup -WarningAction SilentlyContinue
+    $lb = Get-AzureRmLoadBalancer -ResourceGroupName $resourceGroup -WarningAction SilentlyContinue
     if (-not $lb)
     {
-        Write-Verbose "No load balancer found to add port rules to"
+        Write-Verbose "No load balancer found to list port rules of"
         return
     }
 
-    $existingConfiguration = $lb | Get-AzureRmLoadBalancerInboundNatRuleConfig
+    $existingConfiguration = $lb | Get-AzureRmLoadBalancerInboundNatRuleConfig | Where-Object -Property Name -eq "$ComputerName$Port"
 
-    if($Port)
+    if ($Port)
     {
         return ($existingConfiguration | Where-Object -Property BackendPort -eq $Port)
     }
     
     return $existingConfiguration
+}
+
+function Get-LabAzureLoadBalancedPort
+{
+    param
+    (
+        [int]
+        $Port,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ComputerName
+    )
+
+    $lab = Get-Lab -ErrorAction SilentlyContinue
+
+    if (-not $lab)
+    {
+        Write-ScreenInfo -Type Warning -Message 'Lab data not available. Cannot list ports. Use Import-Lab to import an existing lab'
+        return
+    }
+
+    $machine = Get-LabVm -ComputerName $ComputerName
+
+    if (-not $machine)
+    {
+        Write-Verbose -Message "$ComputerName not found. Cannot list ports."
+        return
+    }
+
+    if ($Port)
+    {
+        $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -eq "AdditionalPort$Port" | Select-Object -ExpandProperty Value
+    }
+    else
+    {
+        $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -like 'AdditionalPort*' | Select-Object -ExpandProperty Value
+    }
 }

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
@@ -373,7 +373,15 @@ function Get-LWAzureLoadBalancedPort
         return
     }
 
-    $existingConfiguration = $lb | Get-AzureRmLoadBalancerInboundNatRuleConfig | Where-Object -Property Name -eq "$ComputerName$Port"
+    $existingConfiguration = if ($Port)
+    {
+        $lb | Get-AzureRmLoadBalancerInboundNatRuleConfig | Where-Object -Property Name -eq "$ComputerName$Port"
+    }
+    else 
+    {
+        $lb | Get-AzureRmLoadBalancerInboundNatRuleConfig | Where-Object -Property Name -like "$ComputerName*"
+    }
+    
 
     if ($Port)
     {


### PR DESCRIPTION
Additional cmdlets (public):
- Get-LabAzureLoadBalancedPort: Gets one or all load-balanced ports of an Azure VM
- Open-LabTfsSite: Opens a browser with the lab TFS portal - now also on Azure

Additional cmdlets (internal):
- Add-LWAzureLoadBalancedPort: Adds a port to the lab load balancer and adds it to the machine's internal notes section. Uses Get-LWAzureLoadBalancedPort to check if a port is already load balanced.
- Get-LWAzureLoadBalancedPort: Returns the load balancer config entirely or filtered by port

Added load balanced port to TFS and DSC setup
Modified TFS setup to use the local lab sources for git and the Azure lab sources for the build agent