### PR TITLE
Update AutomatedLabInternals.psm1

### DIFF
--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -481,6 +481,7 @@ function Get-LabInternetFile
             try
             {
                 $bytesProcessed = 0
+                [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
                 $request = [System.Net.WebRequest]::Create($Uri)
                 $request.AllowAutoRedirect = $true
                 


### PR DESCRIPTION
OS: Server 2012 R2 with WMF 5.1 installed

Problem while invoking the New-LABSourcesFolder function:

> Write-Error : Ausnahme beim Aufrufen von "GetResponse" mit 0 Argument(en):  "Die Anfrage wurde abgebrochen: Es konnte kein geschützter SSL/TLS-Kanal erstellt 
> werden.."

The problme here is that powershell uses TLS 1.0 per default, i have added
`[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12`
before creating the webrquest at line 484 in AutomatedLabInternals.psm1 - that fixed the issue