### PR TITLE
Added telemetry client to collect telemetry data

### DIFF
--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -205,7 +205,9 @@
         'Wait-LabVMShutdown',
         'Get-LabBuildStep',
         'Get-LabReleaseStep',
-        'New-LabReleasePipeline'
+        'New-LabReleasePipeline',
+        'Enable-LabTelemetry',
+        'Disable-LabTelemetry'
     )
     
     FileList               = @(

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -467,6 +467,10 @@ function Install-Lab
     
     Write-LogFunctionEntry
 
+	$telemetryClient = [AutomatedLab.LabTelemetry]::Instance
+	$telemetryClient.LabXmlPath = (Get-LabDefinition).LabFilePath
+	$telemetryClient.LabStarted((Get-Module AutomatedLab).Version, $PSVersionTable.BuildVersion)
+
     #perform full install if no role specific installation is requested
     $performAll = -not ($PSBoundParameters.Keys | Where-Object { $_ -notin ('NoValidation', 'DelayBetweenComputers' + [System.Management.Automation.Internal.CommonParameters].GetProperties().Name)}).Count
     
@@ -827,6 +831,7 @@ function Install-Lab
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }
     
+	$telemetryClient.LabFinished()
     Send-ALNotification -Activity 'Lab finished' -Message 'Lab deployment successfully finished.' -Provider $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData.NotificationProviders
     
     Write-LogFunctionExit

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -501,6 +501,7 @@ function Install-Lab
     catch
     {
         # Nothing to catch - if an error occurs, we simply do not get telemetry.
+        Write-Verbose -Message ('Error sending telemetry: {0}' -f $_.Exception)
     }
     
     Unblock-LabSources
@@ -843,6 +844,7 @@ function Install-Lab
     catch
     {
         # Nothing to catch - if an error occurs, we simply do not get telemetry.
+        Write-Verbose -Message ('Error sending telemetry: {0}' -f $_.Exception)
     }
     
     Send-ALNotification -Activity 'Lab finished' -Message 'Lab deployment successfully finished.' -Provider $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData.NotificationProviders

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -495,8 +495,7 @@ function Install-Lab
     }
 
 	$telemetryClient = [AutomatedLab.LabTelemetry]::Instance
-	$telemetryClient.LabXmlPath = (Get-LabDefinition).LabFilePath
-	$telemetryClient.LabStarted((Get-Module AutomatedLab).Version, $PSVersionTable.BuildVersion)
+	$telemetryClient.LabStarted((Get-Lab).Export(), (Get-Module AutomatedLab)[-1].Version, $PSVersionTable.BuildVersion, $PSVersionTable.PSVersion)
     
     Unblock-LabSources
 
@@ -831,7 +830,7 @@ function Install-Lab
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }
     
-	$telemetryClient.LabFinished()
+	$telemetryClient.LabFinished((Get-Lab).Export())
     Send-ALNotification -Activity 'Lab finished' -Message 'Lab deployment successfully finished.' -Provider $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData.NotificationProviders
     
     Write-LogFunctionExit

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -886,11 +886,20 @@ function Remove-Lab
     {
         Write-Error 'No definitions imported, so there is nothing to test. Please use Import-Lab against the xml file'
         return
-    }
+    }    
 
     if($pscmdlet.ShouldProcess((Get-Lab).Name, 'Remove the lab completely'))
     {
         Write-ScreenInfo -Message "Removing lab '$($Script:data.Name)'" -Type Warning -TaskStart
+
+        try 
+        {
+            [AutomatedLab.LabTelemetry]::Instance.LabRemoved((Get-Lab).Export())
+        }
+        catch 
+        {
+            Write-Verbose -Message ('Error sending telemetry: {0}' -f $_.Exception)
+        }
     
         Write-ScreenInfo -Message 'Removing lab sessions'
         Remove-LabPSSession -All

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -3755,7 +3755,7 @@ Alternatively you can use Enable-LabTelemetry and Disable-LabTelemetry to accomp
 
 We will not ask you again while `$env:AUTOMATEDLAB_TELEMETRY_OPTOUT exists.
 
-If you want to opt out ( :-( ), you can tell us now!
+If you want to opt out, please select Yes.
 "@
 
 if (-not $env:AUTOMATEDLAB_TELEMETRY_OPTOUT)

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -494,8 +494,14 @@ function Install-Lab
         return
     }
 
-	$telemetryClient = [AutomatedLab.LabTelemetry]::Instance
-	$telemetryClient.LabStarted((Get-Lab).Export(), (Get-Module AutomatedLab)[-1].Version, $PSVersionTable.BuildVersion, $PSVersionTable.PSVersion)
+    try
+    {
+        [AutomatedLab.LabTelemetry]::Instance.LabStarted((Get-Lab).Export(), (Get-Module AutomatedLab)[-1].Version, $PSVersionTable.BuildVersion, $PSVersionTable.PSVersion)
+    }
+    catch
+    {
+        # Nothing to catch - if an error occurs, we simply do not get telemetry.
+    }
     
     Unblock-LabSources
 
@@ -830,7 +836,15 @@ function Install-Lab
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }
     
-	$telemetryClient.LabFinished((Get-Lab).Export())
+	try
+    {
+        [AutomatedLab.LabTelemetry]::Instance.LabFinished((Get-Lab).Export())
+    }
+    catch
+    {
+        # Nothing to catch - if an error occurs, we simply do not get telemetry.
+    }
+    
     Send-ALNotification -Activity 'Lab finished' -Message 'Lab deployment successfully finished.' -Provider $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData.NotificationProviders
     
     Write-LogFunctionExit

--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -369,6 +369,8 @@
                   <File Source="$(var.SolutionDir)\AutomatedLab\AutomatedLabAzureServices.psm1" />
                   <File Source="$(var.SolutionDir)\AutomatedLab\AutomatedLabTfs.psm1" />
                   <File Id="AutomatedLabDll" Source="$(var.LabXml.ProjectDir)\bin\debug\AutomatedLab.dll" />
+                  <File Id="AppInsightsDll" Source="$(var.LabXml.ProjectDir)\bin\debug\Microsoft.ApplicationInsights.dll" />
+                  <File Id="AppInsightsDiagnosticsDll" Source="$(var.LabXml.ProjectDir)\bin\debug\System.Diagnostics.DiagnosticSource.dll" />
                   <RemoveFolder Id="RemoveFolderAutomatedLab" Directory="InstallFolder_AutomatedLab" On="both"/>
                   <RemoveFolder Id="RemoveFolderWindowsPowerShell" Directory="WindowsPowerShell" On="both"/>
                   <RemoveFolder Id="RemoveFolderINSTALLDIR" Directory="INSTALLDIR" On="both"/>

--- a/LabXml/LabXml.csproj
+++ b/LabXml/LabXml.csproj
@@ -164,7 +164,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(TargetPath) $(SolutionDir)AutomatedLab\AutomatedLab.dll /Y</PostBuildEvent>
+    <PostBuildEvent>copy $(TargetPath) $(SolutionDir)AutomatedLab\AutomatedLab.dll /Y
+copy $(TargetPath) $(SolutionDir)AutomatedLab\Microsoft.ApplicationInsights.dll /Y
+copy $(TargetPath) $(SolutionDir)AutomatedLab\System.Diagnostics.DiagnosticSource.dll /Y</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/LabXml/LabXml.csproj
+++ b/LabXml/LabXml.csproj
@@ -35,8 +35,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.2.5.1\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\Windows\assembly\GAC_MSIL\System.Management.Automation\1.0.0.0__31bf3856ad364e35\System.Management.Automation.dll</HintPath>
@@ -104,6 +110,7 @@
     <Compile Include="Stores\SerializableDictionary.cs" />
     <Compile Include="Stores\SerializableList.cs" />
     <Compile Include="Stores\XmlStore.cs" />
+    <Compile Include="Telemetry\LabTelemetry.cs" />
     <Compile Include="Validator\ActiveDirectory\DomainInformation.cs" />
     <Compile Include="Validator\ActiveDirectory\DuplicateDomainRoles.cs" />
     <Compile Include="Validator\ActiveDirectory\EmptyDomains.cs" />
@@ -152,7 +159,9 @@
     <Compile Include="Validator\XmlValidator.cs" />
     <Compile Include="Validator\Xml\PathValidator.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>copy $(TargetPath) $(SolutionDir)AutomatedLab\AutomatedLab.dll /Y</PostBuildEvent>

--- a/LabXml/LabXml.csproj
+++ b/LabXml/LabXml.csproj
@@ -40,8 +40,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -160,6 +160,7 @@
     <Compile Include="Validator\Xml\PathValidator.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/LabXml/Telemetry/LabTelemetry.cs
+++ b/LabXml/Telemetry/LabTelemetry.cs
@@ -17,16 +17,40 @@ namespace AutomatedLab
         private Lab lab;
         private ListXmlStore<Machine> machines = new ListXmlStore<Machine>();
         private DateTime labStarted;
-
+        private const string _telemetryOptoutEnvVar = "AUTOMATEDLAB_TELEMETRY_OPTOUT";
+        public bool TelemetryEnabled { get; private set; }
         public string LabXmlPath { get; set; }
 
         private LabTelemetry()
         {
             TelemetryConfiguration.Active.InstrumentationKey = telemetryKey;
             TelemetryConfiguration.Active.TelemetryChannel.DeveloperMode = false;
-
             telemetryClient = new TelemetryClient();
+            TelemetryEnabled = !GetEnvironmentVariableAsBool(_telemetryOptoutEnvVar, false);
+        }
 
+        // taken from https://github.com/powershell/powershell
+        private static bool GetEnvironmentVariableAsBool(string name, bool defaultValue)
+        {
+            var str = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(str))
+            {
+                return defaultValue;
+            }
+
+            switch (str.ToLowerInvariant())
+            {
+                case "true":
+                case "1":
+                case "yes":
+                    return true;
+                case "false":
+                case "0":
+                case "no":
+                    return false;
+                default:
+                    return defaultValue;
+            }
         }
 
         public static LabTelemetry Instance

--- a/LabXml/Telemetry/LabTelemetry.cs
+++ b/LabXml/Telemetry/LabTelemetry.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+using System.Collections.Generic;
+using System.Xml;
+using System.Linq;
+
+namespace AutomatedLab
+{
+    public class LabTelemetry
+    {
+        private static volatile LabTelemetry instance;
+        private static object syncRoot = new Object();
+        private TelemetryClient telemetryClient = null;
+        private const string telemetryKey = "03367df3-a45f-4ba8-9163-e73999e2c7b6";
+        private List<XmlDocument> docs = new List<XmlDocument>();
+        private Lab lab;
+        private ListXmlStore<Machine> machines = new ListXmlStore<Machine>();
+        private DateTime labStarted;
+
+        public string LabXmlPath { get; set; }
+
+        private LabTelemetry()
+        {
+            TelemetryConfiguration.Active.InstrumentationKey = telemetryKey;
+            TelemetryConfiguration.Active.TelemetryChannel.DeveloperMode = false;
+
+            telemetryClient = new TelemetryClient();
+
+        }
+
+        public static LabTelemetry Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    lock (syncRoot)
+                    {
+                        if (instance == null)
+                            instance = new LabTelemetry();
+                    }
+                }
+
+                return instance;
+            }
+        }
+
+        private void ImportLabData()
+        {
+            if (string.IsNullOrWhiteSpace(LabXmlPath)) return;
+
+            XmlDocument mainDoc = new XmlDocument();
+            mainDoc.Load(LabXmlPath);
+            docs.Add(mainDoc);
+
+            var xmlPaths = mainDoc.SelectNodes("//@Path").OfType<XmlAttribute>().Select(e => e.Value).Where(text => text.EndsWith(".xml"));
+
+            foreach (var path in xmlPaths)
+            {
+                XmlDocument doc = new XmlDocument();
+                doc.Load(path);
+                docs.Add(doc);
+            }
+
+            lab = Lab.Import(LabXmlPath);
+            lab.MachineDefinitionFiles.ForEach(file => machines.AddFromFile(file.Path));
+            machines.ForEach(m => SendUsedRole(m.Roles.Select(r => r.ToString()).ToList()));
+            lab.Machines = machines;
+        }
+
+        public void LabStarted(string version, string osVersion)
+        {
+            if (string.IsNullOrWhiteSpace(LabXmlPath)) return;
+            if (lab == null) ImportLabData();
+
+            var properties = new Dictionary<string, string>
+            {
+                { "version", version},
+                { "hypervisor", lab.DefaultVirtualizationEngine},
+                { "osversion", osVersion}
+            };
+
+            var metrics = new Dictionary<string, double>
+            {
+                {
+                    "machineCount", machines.Count
+                }
+            };
+
+            labStarted = DateTime.Now;
+
+            try
+            {
+                telemetryClient.TrackEvent("LabStarted", properties, metrics);
+                telemetryClient.Flush();
+            }
+            catch
+            {
+                ; //nothing to catch. If it doesn't work, it doesn't work.
+            }
+        }
+
+        public void LabFinished()
+        {
+            if (string.IsNullOrWhiteSpace(LabXmlPath)) return;
+            if (lab == null) ImportLabData();
+
+            var labDuration = DateTime.Now - labStarted;
+
+            var properties = new Dictionary<string, string>
+            {
+                { "dayOfWeek", labStarted.DayOfWeek.ToString() }
+            };
+
+            var metrics = new Dictionary<string, double>
+            {
+                { "timeTakenSeconds", labDuration.TotalSeconds }
+            };
+
+            try
+            {
+                telemetryClient.TrackEvent("LabFinished", null, metrics);
+                telemetryClient.Flush();
+            }
+            catch
+            {
+                ; //nothing to catch. If it doesn't work, it doesn't work.
+            }
+        }
+
+        private void SendUsedRole(List<string> roleName)
+        {
+            if (string.IsNullOrWhiteSpace(LabXmlPath)) return;
+            if (lab == null) ImportLabData();
+
+            roleName.ForEach(name =>
+            {
+                var properties = new Dictionary<string, string>
+                {
+                    { "role", name},
+                };
+
+                try
+                {
+                    telemetryClient.TrackEvent("Role", properties, null);
+                }
+                catch
+                {
+                    ; //nothing to catch. If it doesn't work, it doesn't work.
+                }
+            });
+
+            try
+            {
+
+                telemetryClient.Flush();
+            }
+            catch
+            {
+                ; //nothing to catch. If it doesn't work, it doesn't work.
+            }
+        }
+    }
+}

--- a/LabXml/app.config
+++ b/LabXml/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.1" newVersion="4.0.2.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/LabXml/packages.config
+++ b/LabXml/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.5.1" targetFramework="net45" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net45" />
 </packages>

--- a/LabXml/packages.config
+++ b/LabXml/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.ApplicationInsights" version="2.5.1" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
+</packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ assembly_info:
   assembly_informational_version: "{version}"
 
 before_build:
+  - nuget restore
   - ps: |
         Write-Host "'before_build' block"
 


### PR DESCRIPTION
## New cmdlets
Enable-LabTelemetry
Disable-LabTelemetry

## What is collected
We are collecting the following metrics with Azure Application Insights:
- Lab started - Timestamp
  - Amount of Machines
  - Used roles
  - Your AutomatedLab version
  - Your OS version
  - Your PowerShell version
  - The lab hypervisor type, i.e. Hyper-V, VMWare or Azure
- Lab finished - Timestamp
  - DayOfWeek
  - Time taken in seconds
- Coarse Geolocation (Country you are coming from) - Your IP address is discarded automatically by Application Insights - we never see this data at all.