### PR TITLE
ALNotifications. Added voice notification

### DIFF
--- a/AutomatedLabNotifications/AutomatedLabNotifications.psd1
+++ b/AutomatedLabNotifications/AutomatedLabNotifications.psd1
@@ -52,6 +52,12 @@
             Provider = 'AutomatedLab'
         }
 
+        Voice = @{
+            Culture = 'en-us' # While this can be set to any installed voice culture, the text will still be english.
+            Gender  = 'female'
+            Age     = 'Senior' # Any age from NotSet,Child,Teen,Adult,Senior
+        }
+
     } # End of PrivateData hashtable
 
     # HelpInfo URI of this module

--- a/AutomatedLabNotifications/Private/Send-ALVoiceNotification.ps1
+++ b/AutomatedLabNotifications/Private/Send-ALVoiceNotification.ps1
@@ -1,0 +1,48 @@
+function Send-ALVoiceNotification
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Activity,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Message
+    )
+
+    $lab = Get-Lab
+    $voiceInfo = (Get-Module AutomatedLabNotifications).PrivateData.Voice
+
+    try
+    {
+        Add-Type -AssemblyName System.Speech -ErrorAction Stop
+    }
+    catch
+    {
+        return
+    }
+
+    $synth = New-Object System.Speech.Synthesis.SpeechSynthesizer
+    try
+    {
+        $synth.SelectVoiceByHints($voiceInfo.Gender, $voiceInfo.Age, $null, $voiceInfo.Culture)
+    }
+    catch {return}
+
+    if (-not $synth.Voice)
+    {
+        Write-Warning -Message ('No voice installed for culture {0} and gender {1}' -f $voiceInfo.Culture, $voiceInfo.Gender)
+        return;
+    }
+    $synth.SetOutputToDefaultAudioDevice()
+
+    $text = "
+        Hi {4}!
+        AutomatedLab has a new message for you!
+        Deployment of {0} on {1} entered status {2}. Message {3}.
+        Live long and prosper.
+        " -f $lab.Name, $lab.DefaultVirtualizationEngine, $Activity, $Message, $env:USERNAME
+    $synth.Speak($Text)
+    $synth.Dispose()    
+}


### PR DESCRIPTION
Because why not.

This feature requires at least one voice to be installed. If none are present it silently fails. Windows 10 should include these by default.