### PR TITLE
Bug fix: PrivateData in case multiple module versions exist

### DIFF
--- a/AutomatedLab/AutomatedLabSQL.psm1
+++ b/AutomatedLab/AutomatedLabSQL.psm1
@@ -322,7 +322,7 @@ GO
             $roleName = ($this.Roles | Where-Object Name -like "SQL*")[0].Name.ToString()
         $roleName.Substring($roleName.Length - 4, 4)} -PassThru -Force | 
         Add-Member -Name 'SsmsUri' -Value {
-            (Get-Module AutomatedLab -ListAvailable).PrivateData["Sql$($this.SQLVersion)ManagementStudio"]
+            (Get-Module AutomatedLab -ListAvailable)[0].PrivateData["Sql$($this.SQLVersion)ManagementStudio"]
         } -MemberType ScriptProperty -PassThru -Force
     
         if ($servers)

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -188,7 +188,7 @@ function Install-LabBuildWorker
 
     $buildWorkers = Get-LabVm -Role TfsBuildWorker
 
-    $buildWorkerUri = (Get-Module AutomatedLab -ListAvailable).PrivateData["BuildAgentUri"]
+    $buildWorkerUri = (Get-Module AutomatedLab -ListAvailable)[0].PrivateData["BuildAgentUri"]
     $buildWorkerPath = Join-Path -Path $labsources -ChildPath Tools\TfsBuildWorker.zip
     $download = Get-LabInternetFile -Uri $buildWorkerUri -Path $buildWorkerPath -PassThru
     Copy-LabFileItem -ComputerName $buildWorkers -Path $download.Path

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -1152,7 +1152,7 @@ function Connect-LabVM
 
                 if ([bool]$download)
                 {
-                    $downloadUri = (Get-Module AutomatedLab).PrivateData['OpenSshUri']
+                    $downloadUri = (Get-Module AutomatedLab)[0].PrivateData['OpenSshUri']
                     $downloadPath = Join-Path ([System.IO.Path]::GetTempPath()) -ChildPath openssh.zip
                     $targetPath = "$labsources\Tools\OpenSSH"
                     Get-LabInternetFile -Uri $downloadUri -Path $downloadPath

--- a/AutomatedLabNotifications/Private/Send-ALToastNotification.ps1
+++ b/AutomatedLabNotifications/Private/Send-ALToastNotification.ps1
@@ -30,8 +30,8 @@ function Send-ALToastNotification
     
     # Hardcoded toaster from PowerShell - no custom Toast providers after 1709
     $toastProvider = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\WindowsPowerShell\v1.0\powershell.exe"
-    $imageLocation = (Get-Module AutomatedLabNotifications).PrivateData.Toast.Image
-    $imagePath = Join-Path (Get-Module AutomatedLabNotifications).ModuleBase -ChildPath Assets
+    $imageLocation = (Get-Module AutomatedLabNotifications)[0].PrivateData.Toast.Image
+    $imagePath = Join-Path (Get-Module AutomatedLabNotifications)[0].ModuleBase -ChildPath Assets
     $imageFilePath = Join-Path $imagePath -ChildPath (Split-Path $imageLocation -Leaf)
 
     if (-not (Test-Path -Path $imagePath))

--- a/AutomatedLabNotifications/Private/Send-ALVoiceNotification.ps1
+++ b/AutomatedLabNotifications/Private/Send-ALVoiceNotification.ps1
@@ -12,7 +12,7 @@ function Send-ALVoiceNotification
     )
 
     $lab = Get-Lab
-    $voiceInfo = (Get-Module AutomatedLabNotifications).PrivateData.Voice
+    $voiceInfo = (Get-Module AutomatedLabNotifications)[0].PrivateData.Voice
 
     try
     {

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1,4 +1,4 @@
-$azureRetryCount = (Get-Module -ListAvailable -Name AutomatedLabWorker).PrivateData.AzureRetryCount
+$azureRetryCount = (Get-Module -ListAvailable -Name AutomatedLabWorker)[0].PrivateData.AzureRetryCount
 
 #region New-LWAzureVM
 function New-LWAzureVM


### PR DESCRIPTION
Not only for the TFS build worker but for other parts as well: In case multiple versions of AutomatedLab are installed, we need to rely on (Get-Module AutomatedLab)[0] instead.