### PR TITLE
Wrapped calls in try/finally

### DIFF
--- a/AutomatedLab.Ships/AutomatedLab.Ships.psd1
+++ b/AutomatedLab.Ships/AutomatedLab.Ships.psd1
@@ -9,7 +9,6 @@
     DotNetFrameworkVersion = '4.0'    
     CLRVersion             = '4.0'
     RequiredModules        = @('SHiPS')
-    RequiredAssemblies     = @('Microsoft.PowerShell.SHiPS')
     ModuleList             = @('AutomatedLab.Ships')
     FileList               = @('AutomatedLab.Ships.psm1', 'AutomatedLab.Ships.psd1')
 }


### PR DESCRIPTION
So that Remove-Item is called even when CTRL-C is sent during lab deployment. On Azure, when a VM deployment fails, this caused issues. It could also happen when a user cancels during e.g. base image creation.