### PR TITLE
Fix/non english windows

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1123,7 +1123,7 @@ function Get-LabAvailableOperatingSystem
         $standardImagePath = "$letter`:\Sources\Install.wim"    
         if (Test-Path -Path $standardImagePath)
         {
-            $dismOutput = Dism.exe /Get-WimInfo /WimFile:$standardImagePath
+            $dismOutput = Dism.exe /English /Get-WimInfo /WimFile:$standardImagePath
             $dismOutput = $dismOutput -join "`n"
             $dismMatches = $dismOutput | Select-String -Pattern $dismPattern -AllMatches
             Write-Verbose "The Windows Image list contains $($dismMatches.Matches.Count) items"

--- a/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
@@ -120,7 +120,7 @@ exit
     
         $wimPath = "$isoDrive\Sources\install.wim"
         $job = Start-Job -ScriptBlock { 
-            $output = Dism.exe /English /apply-Image /ImageFile:$using:wimPath /index:$using:imageIndex /ApplyDir:$using:vhdWindowsVolume\ /english
+            $output = Dism.exe /English /apply-Image /ImageFile:$using:wimPath /index:$using:imageIndex /ApplyDir:$using:vhdWindowsVolume\
             New-Object PSObject -Property @{
                 Outout = $output
                 LastExitCode = $LASTEXITCODE

--- a/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
@@ -120,7 +120,7 @@ exit
     
         $wimPath = "$isoDrive\Sources\install.wim"
         $job = Start-Job -ScriptBlock { 
-            $output = Dism.exe /apply-Image /ImageFile:$using:wimPath /index:$using:imageIndex /ApplyDir:$using:vhdWindowsVolume\
+            $output = Dism.exe /English /apply-Image /ImageFile:$using:wimPath /index:$using:imageIndex /ApplyDir:$using:vhdWindowsVolume\ /english
             New-Object PSObject -Property @{
                 Outout = $output
                 LastExitCode = $LASTEXITCODE


### PR DESCRIPTION
Added _/English_ parameter when Calling _dism.exe_ when using non-English Windows Edition. This was causing issue with _Get-LabAvailableOperatingSystem_ which uses a regex based on the English Output