### PR TITLE
Modified git repo path to be lab-specific

### DIFF
--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -349,11 +349,12 @@ function New-LabReleasePipeline
 
         Write-ScreenInfo -Type Verbose -Message "Generated repo url $repoUrl"
 
-        $repoparent = Join-Path -Path $locallabsources -ChildPath GitRepositories
+        $repoparent = Join-Path -Path (Join-Path -Path $locallabsources -ChildPath GitRepositories) -ChildPath (Get-Lab).Name
+
         if (-not (Test-Path $repoparent))
         {
             Write-ScreenInfo -Type Verbose -Message "Creating $repoparent to contain your cloned repos"
-            [void] (New-Item -ItemType Directory -Path $repoparent)
+            [void] (New-Item -ItemType Directory -Path $repoparent -Force)
         }
 
         $repositoryPath = Join-Path -Path $repoparent -ChildPath (Split-Path -Path $SourceRepository -Leaf)


### PR DESCRIPTION
This should remove any issues when New-LabReleasePipeline was called with the same git repository but a different TFS machine as the remote called "tfs"