### PR TITLE
Removed Write-ScreenInfo in Get-LabInternetFileInternal

### DIFF
--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -470,7 +470,7 @@ function Get-LabInternetFile
 
         if ((Test-Path -Path $Path) -and -not $Force)
         {
-            Write-ScreenInfo "The file '$Path' does already exist, skipping the download"
+            Write-Verbose -Message "The file '$Path' does already exist, skipping the download"
         }
         else
         {
@@ -519,7 +519,7 @@ function Get-LabInternetFile
                             }
                             else
                             {
-                                Write-ScreenInfo -Message "Could not determine the ContentLength of '$Uri'" -Type Verbose
+                                Write-Verbose -Message "Could not determine the ContentLength of '$Uri'"
                             }
                         
                         } while ($bytesRead -gt 0)


### PR DESCRIPTION
if executed on Azure, cmdlet does not exist. The generated errors due to this are only confusing users.