### PR TITLE
AutomatedLab as a Service (fixes #323)

### DIFF
--- a/LabSources/CustomRoles/LabBuilder/HostStart.ps1
+++ b/LabSources/CustomRoles/LabBuilder/HostStart.ps1
@@ -1,11 +1,7 @@
 param(
     [Parameter(Mandatory)]
     [string]
-    $ComputerName,
-
-    [Parameter()]
-    [switch]
-    $CopyLabSources
+    $ComputerName
 )
 
 if (-not (Get-Lab -ErrorAction SilentlyContinue))
@@ -16,25 +12,34 @@ if (-not (Get-Lab -ErrorAction SilentlyContinue))
 $polarisUri = 'https://github.com/PowerShell/Polaris/archive/master.zip'
 
 # Enable Virtualization
-$vm = Get-LabVm -Name $ComputerName
-Stop-LabVm -ComputerName $vm
+$vm = Get-LabVm -ComputerName $ComputerName
+Stop-LabVm -ComputerName $vm -Wait
 $hyperVvm = Get-Vm -Name $vm.Name
 $hyperVvm | Set-VMProcessor -ExposeVirtualizationExtensions $true
 Start-LabVM $vm
 
+Invoke-LabCommand -ComputerName $ComputerName -ScriptBlock {
+    Get-Disk | Where-Object IsOffline | Set-Disk -IsOffline $false
+}
+
 # Download Polaris (as long as it isn't in the Gallery)
 $downloadPath = Join-Path -Path (Get-LabSourcesLocationInternal -Local) -ChildPath SoftwarePackages\Polaris.zip
 $polarisArchive = Get-LabInternetFile -Uri $polarisUri -Path $downloadPath -PassThru
-Copy-LabFileItem -Path $polarisArchive.Fullname -ComputerName $vm
-Copy-LabFileItem -Path .\PolarisLabBuilder.ps1 -ComputerName $vm
+Copy-LabFileItem -Path $polarisArchive.Path -ComputerName $vm
+Copy-LabFileItem -Path $PSScriptRoot\PolarisLabBuilder.ps1 -ComputerName $vm
+
+$driveLetter = if ($vm.Disks.Count -gt 0)
+{
+    'D'
+}
+else
+{
+    'C'
+}
 
 $session = New-LabPSSession -Machine $vm
 Send-ModuleToPSSession -Module (Get-Module AutomatedLab -ListAvailable)[0] -Session $session
-
-if ($CopyLabSources)
-{
-    Copy-LabFileItem -Path $global:labSources -ComputerName $ComputerName -DestinationFolderPath C:\ -Recurse
-}
+Copy-LabFileItem -Path $global:labSources -ComputerName $ComputerName -DestinationFolderPath "$($driveLetter):\" -Recurse
 
 Invoke-LabCommand -ComputerName $vm -ActivityName EnablePolaris -ScriptBlock {
     Expand-Archive -Path C:\Polaris.zip -DestinationPath C:\
@@ -42,6 +47,6 @@ Invoke-LabCommand -ComputerName $vm -ActivityName EnablePolaris -ScriptBlock {
     Copy-Item -Recurse -Path C:\Polaris 'C:\Program Files\WindowsPowerShell\Modules'
 
     $trigger = New-ScheduledTaskTrigger -Daily -At 9:00
-    $action = New-ScheduledTaskAction -Execute "$pshome\powershell.exe" -Argument '-NoProfile -FilePath "C:\PolarisLabBuilder.ps1'
+    $action = New-ScheduledTaskAction -Execute "$pshome\powershell.exe" -Argument '-NoProfile -File "C:\PolarisLabBuilder.ps1'
     Register-ScheduledTask -TaskName AutomatedLabBuilder -Action $action -Trigger $trigger
-}
+} -Variable (Get-Variable driveLetter)

--- a/LabSources/CustomRoles/LabBuilder/HostStart.ps1
+++ b/LabSources/CustomRoles/LabBuilder/HostStart.ps1
@@ -16,10 +16,12 @@ $vm = Get-LabVm -ComputerName $ComputerName
 Stop-LabVm -ComputerName $vm -Wait
 $hyperVvm = Get-Vm -Name $vm.Name
 $hyperVvm | Set-VMProcessor -ExposeVirtualizationExtensions $true
-Start-LabVM $vm
+Start-LabVM $vm -Wait
 
 Invoke-LabCommand -ComputerName $ComputerName -ScriptBlock {
-    Get-Disk | Where-Object IsOffline | Set-Disk -IsOffline $false
+    $disk = Get-Disk | Where-Object IsOffline
+    $disk | Set-Disk -IsOffline $false
+    $disk | Set-Disk -IsReadOnly $false
 }
 
 # Download Polaris (as long as it isn't in the Gallery)

--- a/LabSources/CustomRoles/LabBuilder/HostStart.ps1
+++ b/LabSources/CustomRoles/LabBuilder/HostStart.ps1
@@ -40,7 +40,12 @@ else
 }
 
 $session = New-LabPSSession -Machine $vm
-Send-ModuleToPSSession -Module (Get-Module AutomatedLab -ListAvailable)[0] -Session $session
+
+foreach ($moduleInfo in (Get-Module AutomatedLab*,PSFileTransfer,HostsFile,PSLog -ListAvailable))
+{
+    Send-ModuleToPSSession -Module $moduleInfo -Session $session
+}
+
 Copy-LabFileItem -Path $global:labSources -ComputerName $ComputerName -DestinationFolderPath "$($driveLetter):\" -Recurse
 
 Invoke-LabCommand -ComputerName $vm -ActivityName EnablePolaris -ScriptBlock {
@@ -50,5 +55,5 @@ Invoke-LabCommand -ComputerName $vm -ActivityName EnablePolaris -ScriptBlock {
 
     $trigger = New-ScheduledTaskTrigger -Daily -At 9:00
     $action = New-ScheduledTaskAction -Execute "$pshome\powershell.exe" -Argument '-NoProfile -File "C:\PolarisLabBuilder.ps1'
-    Register-ScheduledTask -TaskName AutomatedLabBuilder -Action $action -Trigger $trigger
+    Register-ScheduledTask -TaskName AutomatedLabBuilder -Action $action -Trigger $trigger | Start-ScheduledTask
 } -Variable (Get-Variable driveLetter)

--- a/LabSources/CustomRoles/LabBuilder/HostStart.ps1
+++ b/LabSources/CustomRoles/LabBuilder/HostStart.ps1
@@ -1,0 +1,34 @@
+param(
+    [Parameter(Mandatory)]
+    [string]$ComputerName
+)
+
+if (-not (Get-Lab))
+{
+    Import-Lab -Name $data.Name
+}
+
+$polarisUri = 'https://github.com/PowerShell/Polaris/archive/master.zip'
+
+# Enable Virtualization
+$vm = Get-LabVm -Role LabBuilder
+Stop-LabVm -ComputerName $vm
+$hyperVvm = Get-Vm -Name $vm.Name
+$hyperVvm | Set-VMProcessor -ExposeVirtualizationExtensions $true
+Start-LabVM $vm
+
+# Download Polaris (as long as it isn't in the Gallery)
+$downloadPath = Join-Path -Path (Get-LabSourcesLocationInternal -Local) -ChildPath SoftwarePackages\Polaris.zip
+$polarisArchive = Get-LabInternetFile -Uri $polarisUri -Path $downloadPath -PassThru
+Copy-LabFileItem -Path $polarisArchive.Fullname -ComputerName $vm
+Copy-LabFileItem -Path .\PolarisLabBuilder.ps1 -ComputerName $vm
+
+Invoke-LabCommand -ComputerName $vm -ActivityName EnablePolaris -ScriptBlock {
+    Expand-Archive -Path C:\Polaris.zip -DestinationPath C:\
+    Rename-Item -Path C:\Polaris-master -NewName C:\Polaris
+    Copy-Item -Recurse -Path C:\Polaris 'C:\Program Files\WindowsPowerShell\Modules'
+
+    $trigger = New-ScheduledTaskTrigger -Daily -At 9:00
+    $action = New-ScheduledTaskAction -Execute "$pshome\powershell.exe" -Argument '-NoProfile -FilePath "C:\PolarisLabBuilder.ps1'
+    Register-ScheduledTask -TaskName AutomatedLabBuilder -Action $action -Trigger $trigger
+}

--- a/LabSources/CustomRoles/LabBuilder/PolarisLabBuilder.ps1
+++ b/LabSources/CustomRoles/LabBuilder/PolarisLabBuilder.ps1
@@ -15,6 +15,12 @@ New-PolarisPostRoute -Path /Lab -ScriptBlock {
     [string]$labScript = $request.Body.LabScript
     $labScriptBlock = [scriptblock]::Create($labScript)
     $labGuid = (New-Guid).Guid
+
+    if (-not (Test-Path -Path C:\Polaris\LabJobs))
+    {
+        [void] (New-Item -Path C:\Polaris\LabJobs -ItemType Directory)
+    }
+    
     New-Item -ItemType File -Path C:\Polaris\LabJobs\$labGuid
     $t = New-JobTrigger -Once -At (Get-Date).AddSeconds(5)
     $job = Register-ScheduledJob -ScriptBlock $labScriptBlock -Name $labGuid -Trigger $t

--- a/LabSources/CustomRoles/LabBuilder/PolarisLabBuilder.ps1
+++ b/LabSources/CustomRoles/LabBuilder/PolarisLabBuilder.ps1
@@ -41,7 +41,7 @@ New-PolarisGetRoute -Force -Verbose -Path /Lab -ScriptBlock {
             $response.Json(($lab | ConvertTo-Json))
         }
     }
-    elseif($request.Query['Id'])
+    elseif ($request.Query['Id'])
     {
         $jobGuid = $request.Query['Id']
         $scheduledJob = Get-ScheduledJob -Name $jobGuid -ErrorAction SilentlyContinue
@@ -51,15 +51,15 @@ New-PolarisGetRoute -Force -Verbose -Path /Lab -ScriptBlock {
         {
             $jsonResponse = @{
                 Status = 'Running'
-                Name = $jobGuid
+                Name   = $jobGuid
             } | ConvertTo-Json
             $response.Json($jsonResponse)
         }
-        elseif($scheduledJob -and $job)
+        elseif ($scheduledJob -and $job)
         {
             $jsonResponse = @{
                 Status = $job.State
-                Name = $jobGuid
+                Name   = $jobGuid
             } | ConvertTo-Json
             $response.Json($jsonResponse)
         }
@@ -72,7 +72,21 @@ New-PolarisGetRoute -Force -Verbose -Path /Lab -ScriptBlock {
 }
 
 New-PolarisDeleteRoute -Path /Lab -ScriptBlock {
-    $labName = $request.Body.Name
+    if ($request.Query['Name'])
+    {
+        $labName = $request.Query['Name']
+    }
+    else
+    {
+        $labName = $request.Body.Name
+    }
+
+    if (-not $labName)
+    {
+        $response.SetStatusCode(404)
+        $response.Send("No lab name supplied")
+        return
+    }
     try
     {
         Remove-Lab -Name $labName -Confirm:$false -ErrorAction Stop

--- a/LabSources/CustomRoles/LabBuilder/PolarisLabBuilder.ps1
+++ b/LabSources/CustomRoles/LabBuilder/PolarisLabBuilder.ps1
@@ -1,0 +1,91 @@
+New-PolarisRouteMiddleware -Name JsonBodyParser -ScriptBlock {
+    if ($Request.BodyString -ne $null)
+    {
+        $Request.Body = $Request.BodyString | ConvertFrom-Json
+    }
+}
+
+New-PolarisGetRoute -Path /Labs -ScriptBlock {
+    $labs = Get-Lab -List | ConvertTo-Json
+    $response.Json($labs)
+}
+
+New-PolarisPostRoute -Path /Lab -ScriptBlock {
+
+    [string]$labScript = $request.Body.LabScript
+    $labScriptBlock = [scriptblock]::Create($labScript)
+    $labGuid = (New-Guid).Guid
+    New-Item -ItemType File -Path C:\Polaris\LabJobs\$labGuid
+    $t = New-JobTrigger -Once -At (Get-Date).AddSeconds(5)
+    $job = Register-ScheduledJob -ScriptBlock $labScriptBlock -Name $labGuid -Trigger $t
+    $response.Send($labGuid)
+}
+
+New-PolarisGetRoute -Force -Verbose -Path /Lab -ScriptBlock {
+
+    if ($request.Query['Name'])
+    {
+        $labName = $request.Query['Name']
+
+        if ((Get-Lab -List) -notcontains $labName)
+        {
+            $response.SetStatusCode(404)
+            $response.Send("Lab '$labName' not found")
+            return
+        }
+
+        $lab = Import-Lab -Name $labName -PassThru
+        
+        if ($lab)
+        {
+            $response.Json(($lab | ConvertTo-Json))
+        }
+    }
+    elseif($request.Query['Id'])
+    {
+        $jobGuid = $request.Query['Id']
+        $scheduledJob = Get-ScheduledJob -Name $jobGuid -ErrorAction SilentlyContinue
+        $job = Get-Job -Name $jobGuid -ErrorAction SilentlyContinue
+
+        if ($scheduledJob -and -not $job)
+        {
+            $jsonResponse = @{
+                Status = 'Running'
+                Name = $jobGuid
+            } | ConvertTo-Json
+            $response.Json($jsonResponse)
+        }
+        elseif($scheduledJob -and $job)
+        {
+            $jsonResponse = @{
+                Status = $job.State
+                Name = $jobGuid
+            } | ConvertTo-Json
+            $response.Json($jsonResponse)
+        }
+        else
+        {
+            $response.SetStatusCode(404)
+            $response.Send("Job with ID '$jobGuid' not found")
+        }
+    }
+}
+
+New-PolarisDeleteRoute -Path /Lab -ScriptBlock {
+    $labName = $request.Body.Name
+    try
+    {
+        Remove-Lab -Name $labName -Confirm:$false -ErrorAction Stop
+    }
+    catch
+    {
+        $repsonse.SetStatusCode(500)
+        $response.Send("Error removing $labname")
+        return
+    }
+
+    $response.Send("$labName removed")
+}
+
+Start-Polaris -Port 80
+Read-Host

--- a/LabSources/SampleScripts/Scenarios/Lab in a Box 3 - Build worker.ps1
+++ b/LabSources/SampleScripts/Scenarios/Lab in a Box 3 - Build worker.ps1
@@ -2,8 +2,7 @@
 Build a lab with the help of nested virtualization. Adjust the machine memory if necessary.
 The build worker will use Polaris as a simple REST endpoint that takes your lab data to deploy.
 
-AutomatedLab will be copied to the machine. If specified, the lab sources can be mirrored
-to the VM. If so, an additional disk will be created.
+AutomatedLab will be copied to the machine. Lab sources will be mirrored to the machine as well, so that lab deployments can start immediately
 #>
 param
 (
@@ -24,10 +23,34 @@ $machineParameters = @{
     DiskName                 = 'vmDisk'
 }
 
-
 $estimatedSize = [Math]::Round(((Get-ChildItem $labsources -File -Recurse | Measure-Object -Property Length -Sum).Sum / 1GB + 20), 0)
 $disk = Add-LabDiskDefinition -Name vmDisk -DiskSizeInGb $estimatedSize -PassThru
 
 Add-LabMachineDefinition @machineParameters
 
 Install-Lab
+
+break
+
+# REST-Methods to interact with
+
+# List
+$allLabs = Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Labs
+$specificLab = Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Name=Win10 # throws, does not exist yet
+$labCreationJob = Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Id=5b89babb-7402-4a7a-9c16-86e1d52613fa # A lab installation job, if it exists
+
+# Create lab
+$request = @{
+    LabScript = Get-Content "$labsources\SampleScripts\Introduction\01 Single Win10 Client.ps1" -Raw
+} | ConvertTo-Json
+
+$guid = Invoke-RestMethod -Method Post -Uri http://NestedBuilder/Lab -Body $request -ContentType application\json
+
+# Get Status
+$labCreationJob = Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Id=$guid
+
+# Remove lab
+Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Name=Win10 # Retrieve lab properties
+
+$request = @{Name = 'Win10'} | ConvertTo-Json
+Invoke-RestMethod -Method Delete -Uri http://NestedBuilder/Lab -Body $request -ContentType application\json

--- a/LabSources/SampleScripts/Scenarios/Lab in a Box 3 - Build worker.ps1
+++ b/LabSources/SampleScripts/Scenarios/Lab in a Box 3 - Build worker.ps1
@@ -1,0 +1,33 @@
+<#
+Build a lab with the help of nested virtualization. Adjust the machine memory if necessary.
+The build worker will use Polaris as a simple REST endpoint that takes your lab data to deploy.
+
+AutomatedLab will be copied to the machine. If specified, the lab sources can be mirrored
+to the VM. If so, an additional disk will be created.
+#>
+param
+(
+    [string]
+    $labName = 'LabAsAService'
+)
+
+New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV
+Add-LabVirtualNetworkDefinition -Name $labName -HyperVProperties @{ SwitchType = 'External'; AdapterName = 'Wi-Fi' }
+
+$role = Get-LabPostInstallationActivity -CustomRole LabBuilder
+$machineParameters = @{
+    Name                     = 'NestedBuilder'
+    PostInstallationActivity = $role
+    OperatingSystem          = 'Windows Server 2016 Datacenter (Desktop Experience)'
+    Memory                   = 16GB
+    Network                  = $labName
+    DiskName                 = 'vmDisk'
+}
+
+
+$estimatedSize = [Math]::Round(((Get-ChildItem $labsources -File -Recurse | Measure-Object -Property Length -Sum).Sum / 1GB + 20), 0)
+$disk = Add-LabDiskDefinition -Name vmDisk -DiskSizeInGb $estimatedSize -PassThru
+
+Add-LabMachineDefinition @machineParameters
+
+Install-Lab

--- a/LabSources/SampleScripts/Scenarios/Lab in a Box 3 - Build worker.ps1
+++ b/LabSources/SampleScripts/Scenarios/Lab in a Box 3 - Build worker.ps1
@@ -7,13 +7,17 @@ AutomatedLab will be copied to the machine. Lab sources will be mirrored to the 
 param
 (
     [string]
-    $labName = 'LabAsAService'
+    $LabName = 'LabAsAService',
+
+    [ValidateSet('yes','no')]
+    $TelemetryOptOut = 'no' # Opt out of telemetry for build worker by saying yes here
 )
 
 New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV
-Add-LabVirtualNetworkDefinition -Name $labName -HyperVProperties @{ SwitchType = 'External'; AdapterName = 'Wi-Fi' }
+Add-LabVirtualNetworkDefinition -Name $labName -HyperVProperties @{ SwitchType = 'External'; AdapterName = 'Ethernet' }
 
-$role = Get-LabPostInstallationActivity -CustomRole LabBuilder
+$role = Get-LabPostInstallationActivity -CustomRole LabBuilder -Properties @{TelemetryOptOut = $TelemetryOptOut}
+
 $machineParameters = @{
     Name                     = 'NestedBuilder'
     PostInstallationActivity = $role
@@ -41,10 +45,10 @@ $labCreationJob = Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Id
 
 # Create lab
 $request = @{
-    LabScript = Get-Content "$labsources\SampleScripts\Introduction\01 Single Win10 Client.ps1" -Raw
+    LabScript = Get-Content "$labsources\Sample Scripts\Introduction\01 Single Win10 Client.ps1" -Raw
 } | ConvertTo-Json
 
-$guid = Invoke-RestMethod -Method Post -Uri http://NestedBuilder/Lab -Body $request -ContentType application\json
+$guid = Invoke-RestMethod -Method Post -Uri http://NestedBuilder/Lab -Body $request -ContentType application/json
 
 # Get Status
 $labCreationJob = Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Id=$guid
@@ -53,4 +57,4 @@ $labCreationJob = Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Id
 Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Name=Win10 # Retrieve lab properties
 
 $request = @{Name = 'Win10'} | ConvertTo-Json
-Invoke-RestMethod -Method Delete -Uri http://NestedBuilder/Lab -Body $request -ContentType application\json
+Invoke-RestMethod -Method Delete -Uri http://NestedBuilder/Lab -Body $request -ContentType application/json


### PR DESCRIPTION
Added a new custom role "LabBuilder" with an accompanying scenario "Lab in a box 3 - build worker". The custom role uses Polaris as the framework to provide a simple REST API:

## Create
```powershell
$request = @{
    LabScript = Get-Content "$labsources\Sample Scripts\Introduction\01 Single Win10 Client.ps1" -Raw
} | ConvertTo-Json

# Queue new job, use GUID to request status update with GET method
$guid = Invoke-RestMethod -Method Post -Uri http://NestedBuilder/Lab -Body $request -ContentType application/json
```
## Read
```powershell
# All labs (Get-Lab -List)
Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Labs
# Specific lab
Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Name=Win10
# Lab creation job (monitoring long running jobs)
Invoke-RestMethod -Method Get -Uri http://NestedBuilder/Lab?Id=5b89babb-7402-4a7a-9c16-86e1d52613fa
```
## Delete
```powershell
# As query parameter
Invoke-RestMethod -Method Delete -Uri http://NestedBuilder/Lab?Name=Win10

# Or as JSON body
$request = @{Name = 'Win10'} | ConvertTo-Json
Invoke-RestMethod -Method Delete -Uri http://NestedBuilder/Lab -Body $request -ContentType application/json
```
The response time for all REST methods is a tad longer since each execution will import AutomatedLab again. This is due to the nature of how Polaris was developed. So, each REST call will take 2-5 seconds.