### PR TITLE
Fix azure public ip (fixes #345)

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1039,7 +1039,7 @@ function Get-LabAvailableOperatingSystem
     [OutputType([AutomatedLab.OperatingSystem])]
     param
     (
-        [string[]]$Path = "$labSources\ISOs",
+        [string[]]$Path = "$(Get-LabSourcesLocationInternal -Local)\ISOs",
 
         [switch]$UseOnlyCache,
 

--- a/AutomatedLab/AutomatedLabHybrid.psm1
+++ b/AutomatedLab/AutomatedLabHybrid.psm1
@@ -414,7 +414,7 @@ function Connect-OnPremisesWithAzure
     $publicIpParameters.Add('Name', 's2sip')
     $publicIpParameters.Add('AllocationMethod', 'Dynamic')
     $publicIpParameters.Add('IpAddressVersion', 'IPv4')
-    $publicIpParameters.Add('DomainNameLabel', "$($lab.name)-s2s".ToLower())
+    $publicIpParameters.Add('DomainNameLabel', "$((1..10 | ForEach-Object { [char[]](97..122) | Get-Random }) -join '')".ToLower())
     $publicIpParameters.Add('Force', $true)
     
     $gatewaySubnet = Get-AzureRmVirtualNetworkSubnetConfig -Name GatewaySubnet -VirtualNetwork $vnet -ErrorAction SilentlyContinue
@@ -748,7 +748,7 @@ function Connect-AzureLab
         Name              = 's2sip'
         AllocationMethod  = 'Dynamic'
         IpAddressVersion  = 'IPv4'
-        DomainNameLabel   = "$($SourceLab)-s2s".ToLower()
+        DomainNameLabel   = "$((1..10 | ForEach-Object { [char[]](97..122) | Get-Random }) -join '')"
         Force             = $true
     }
 
@@ -758,7 +758,7 @@ function Connect-AzureLab
         Name              = 's2sip'
         AllocationMethod  = 'Dynamic'
         IpAddressVersion  = 'IPv4'
-        DomainNameLabel   = "$($DestinationLab)-s2s".ToLower()
+        DomainNameLabel   = "$((1..10 | ForEach-Object { [char[]](97..122) | Get-Random }) -join '')"
         Force             = $true
     }   
     

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
@@ -224,7 +224,7 @@ function New-LWAzureLoadBalancer
         {
             $publicIp = New-AzureRmPublicIpAddress -Name "$($resourceGroup)$($vNet.Name)lbfrontendip" -ResourceGroupName $resourceGroup `
                 -Location $location -AllocationMethod Static -IpAddressVersion IPv4 `
-                -DomainNameLabel "$($resourceGroup.ToLower())$($vNet.Name.ToLower())" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+                -DomainNameLabel "$((1..10 | ForEach-Object { [char[]](97..122) | Get-Random }) -join '')" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
         }
 
         $frontendConfig = New-AzureRmLoadBalancerFrontendIpConfig -Name "$($resourceGroup)$($vNet.Name)lbfrontendconfig" -PublicIpAddress $publicIp


### PR DESCRIPTION
Modified all calls to New-AzureRmPublicIp to use 10 random characters as the DNS label. The DNS label is part of the string <dnslabel>.<regional url>, thus it needs to be fairly unique.

Since no functions depend on the label and retrieve it dynamically, this was the only change.