### PR TITLE
Get-LabAvailableOperatingSystem should return Azure SKUs (fixes #342)

### DIFF
--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -111,6 +111,7 @@
         'Get-LabVMStatus',
         'Get-LabVMUptime',
         'Get-LabWindowsFeature',
+        'Get-LabAvailableAzureSku',
         'Import-Lab',
         'Import-LabAzureCertificate',
         'Install-Lab',

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1067,8 +1067,6 @@ function Get-LabAvailableOperatingSystem
             throw 'Please login to Azure before trying to list Azure image SKUs'
         }
 
-        $type = Get-Type -GenericType AutomatedLab.ListXmlStore -T AutomatedLab.OperatingSystem
-        $osList = New-Object $type
         return (Get-LabAzureAvailableSku -Location $Location)
     }
     

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1067,7 +1067,18 @@ function Get-LabAvailableOperatingSystem
             throw 'Please login to Azure before trying to list Azure image SKUs'
         }
 
-        return (Get-LabAzureAvailableSku -Location $Location)
+        $type = Get-Type -GenericType AutomatedLab.ListXmlStore -T AutomatedLab.OperatingSystem
+        $osList = New-Object $type
+        $skus = (Get-LabAzureAvailableSku -Location 'West Europe')
+
+        foreach ($sku in $skus)
+        {
+            $azureOs = ([AutomatedLab.OperatingSystem]::new($sku.Skus, $true))
+            if (-not $azureOs.OperatingSystemName) { continue }
+
+            $osList.Add($azureOs )
+        }
+        return $osList.ToArray()
     }
     
     $type = Get-Type -GenericType AutomatedLab.ListXmlStore -T AutomatedLab.OperatingSystem

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1035,15 +1035,22 @@ function Remove-Lab
 function Get-LabAvailableOperatingSystem
 {
     # .ExternalHelp AutomatedLab.Help.xml
-    [cmdletBinding()]
+    [cmdletBinding(DefaultParameterSetName='Local')]
     [OutputType([AutomatedLab.OperatingSystem])]
     param
     (
+        [Parameter(ParameterSetName='Local')]
         [string[]]$Path = "$(Get-LabSourcesLocationInternal -Local)\ISOs",
 
         [switch]$UseOnlyCache,
 
-        [switch]$NoDisplay
+        [switch]$NoDisplay,
+
+        [Parameter(ParameterSetName = 'Azure')]
+        [switch]$Azure,
+
+        [Parameter(Mandatory, ParameterSetName = 'Azure')]
+        $Location
     )
 
     Write-LogFunctionEntry
@@ -1051,6 +1058,13 @@ function Get-LabAvailableOperatingSystem
     if (-not (Test-IsAdministrator))
     {
         throw 'This function needs to be called in an elevated PowerShell session.'
+    }
+
+    if ($Azure)
+    {
+        $type = Get-Type -GenericType AutomatedLab.ListXmlStore -T AutomatedLab.OperatingSystem
+        $osList = New-Object $type
+        return (Get-LabAzureAvailableSku -Location $Location)
     }
     
     $type = Get-Type -GenericType AutomatedLab.ListXmlStore -T AutomatedLab.OperatingSystem

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1062,6 +1062,11 @@ function Get-LabAvailableOperatingSystem
 
     if ($Azure)
     {
+        if (-not (Get-AzureRmContext -ErrorAction SilentlyContinue).Subscription)
+        {
+            throw 'Please login to Azure before trying to list Azure image SKUs'
+        }
+
         $type = Get-Type -GenericType AutomatedLab.ListXmlStore -T AutomatedLab.OperatingSystem
         $osList = New-Object $type
         return (Get-LabAzureAvailableSku -Location $Location)

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -319,66 +319,8 @@ function Add-LabAzureSubscription
             Write-Verbose ("Azure OS Cache was older than {0:yyyy-MM-dd HH:mm:ss}. Cache date was {1:yyyy-MM-dd HH:mm:ss}" -f (Get-Date).AddDays(-7) , $global:cacheVmImages.TimeStamp)
         }
         Write-ScreenInfo -Message 'Querying available operating system images' -Type Info
-        
-        # Server
-        $vmImages = Get-AzureRmVMImagePublisher -Location $DefaultLocationName |
-        Where-Object PublisherName -eq 'MicrosoftWindowsServer' |
-        Get-AzureRmVMImageOffer |
-        Get-AzureRmVMImageSku |
-        Get-AzureRmVMImage |
-        Group-Object -Property Skus, Offer |
-        ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
 
-        # Desktop
-        $vmImages += Get-AzureRmVMImagePublisher -Location $DefaultLocationName |
-        Where-Object PublisherName -eq 'MicrosoftWindowsDesktop' |
-        Get-AzureRmVMImageOffer |
-        Get-AzureRmVMImageSku |
-        Get-AzureRmVMImage |
-        Group-Object -Property Skus, Offer |
-        ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
-
-        # SQL
-        $vmImages += Get-AzureRmVMImagePublisher -Location $DefaultLocationName |
-        Where-Object PublisherName -eq 'MicrosoftSQLServer' |
-        Get-AzureRmVMImageOffer |
-        Get-AzureRmVMImageSku |
-        Get-AzureRmVMImage |
-        Where-Object Skus -eq 'Enterprise' |
-        Group-Object -Property Skus, Offer |
-        ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
-        
-        # VisualStudio
-        $vmImages += Get-AzureRmVMImagePublisher -Location $DefaultLocationName |
-        Where-Object PublisherName -eq 'MicrosoftVisualStudio' |
-        Get-AzureRmVMImageOffer |
-        Get-AzureRmVMImageSku |
-        Get-AzureRmVMImage |
-        Where-Object Offer -eq 'VisualStudio' |
-        Group-Object -Property Skus, Offer |
-        ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
-
-        # Client OS
-        $vmImages += Get-AzureRmVMImagePublisher -Location $DefaultLocationName |
-        Where-Object PublisherName -eq 'MicrosoftVisualStudio' |
-        Get-AzureRmVMImageOffer |
-        Get-AzureRmVMImageSku |
-        Get-AzureRmVMImage |
-        Where-Object Offer -eq 'Windows' |
-        Group-Object -Property Skus, Offer |
-        ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
-
-        # Sharepoint 2013 and 2016
-        $vmImages += Get-AzureRmVMImagePublisher -Location $DefaultLocationName |
-        Where-Object PublisherName -eq 'MicrosoftSharePoint' |
-        Get-AzureRmVMImageOffer |
-        Get-AzureRmVMImageSku |
-        Get-AzureRmVMImage |
-        Where-Object Offer -eq 'MicrosoftSharePointServer' |
-        Group-Object -Property Skus, Offer |
-        ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
-
-        $global:cacheVmImages = $vmImages
+        $global:cacheVmImages = Get-LabAzureAvailableSku -Location $DefaultLocationName
     }
     
     $osImageListType = Get-Type -GenericType AutomatedLab.ListXmlStore -T AutomatedLab.Azure.AzureOSImage
@@ -1361,4 +1303,73 @@ function Get-LabAzureAvailableRoleSize
     } | Select-Object -ExpandProperty Name
 
     Get-AzureRmVmSize -Location $Location | Where-Object -Property Name -in $availableRoleSizes
+}
+
+function Get-LabAzureAvailableSku
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [string]
+        $Location
+    )
+
+    # Server
+    Get-AzureRmVMImagePublisher -Location $Location |
+    Where-Object PublisherName -eq 'MicrosoftWindowsServer' |
+    Get-AzureRmVMImageOffer |
+    Get-AzureRmVMImageSku |
+    Get-AzureRmVMImage |
+    Group-Object -Property Skus, Offer |
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
+
+    # Desktop
+    Get-AzureRmVMImagePublisher -Location $Location |
+    Where-Object PublisherName -eq 'MicrosoftWindowsDesktop' |
+    Get-AzureRmVMImageOffer |
+    Get-AzureRmVMImageSku |
+    Get-AzureRmVMImage |
+    Group-Object -Property Skus, Offer |
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
+
+    # SQL
+    Get-AzureRmVMImagePublisher -Location $Location |
+    Where-Object PublisherName -eq 'MicrosoftSQLServer' |
+    Get-AzureRmVMImageOffer |
+    Get-AzureRmVMImageSku |
+    Get-AzureRmVMImage |
+    Where-Object Skus -eq 'Enterprise' |
+    Group-Object -Property Skus, Offer |
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
+    
+    # VisualStudio
+    Get-AzureRmVMImagePublisher -Location $Location |
+    Where-Object PublisherName -eq 'MicrosoftVisualStudio' |
+    Get-AzureRmVMImageOffer |
+    Get-AzureRmVMImageSku |
+    Get-AzureRmVMImage |
+    Where-Object Offer -eq 'VisualStudio' |
+    Group-Object -Property Skus, Offer |
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
+
+    # Client OS
+    Get-AzureRmVMImagePublisher -Location $Location |
+    Where-Object PublisherName -eq 'MicrosoftVisualStudio' |
+    Get-AzureRmVMImageOffer |
+    Get-AzureRmVMImageSku |
+    Get-AzureRmVMImage |
+    Where-Object Offer -eq 'Windows' |
+    Group-Object -Property Skus, Offer |
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
+
+    # Sharepoint 2013 and 2016
+    Get-AzureRmVMImagePublisher -Location $Location |
+    Where-Object PublisherName -eq 'MicrosoftSharePoint' |
+    Get-AzureRmVMImageOffer |
+    Get-AzureRmVMImageSku |
+    Get-AzureRmVMImage |
+    Where-Object Offer -eq 'MicrosoftSharePointServer' |
+    Group-Object -Property Skus, Offer |
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 }
 }

--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Xml.Serialization;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace AutomatedLab
 {
@@ -18,6 +19,18 @@ namespace AutomatedLab
         private string edition;
         private string installation;
         private int imageIndex;
+        private Dictionary<string, string> azureToIsoName = new Dictionary<string, string>(){
+            {"2008-R2-SP1", "Windows Server 2008 R2 Datacenter (Full Installation)" },
+            {"2012-Datacenter", "Windows Server 2012 Datacenter (Server with a GUI)" },
+            {"2012-R2-Datacenter", "Windows Server 2012 R2 Datacenter (Server with a GUI)" },
+            {"2016-Datacenter", "Windows Server 2016 Datacenter (Desktop Experience)" },
+            {"2016-Datacenter-Server-Core", "Windows Server 2016 Datacenter" },
+            {"Datacenter-Core-1709-smalldisk", "Windows Server Datacenter" },
+            {"Win81-Ent-N-x64", "Windows 8.1 Enterprise" },
+            {"Windows-10-N-x64", "Windows 10 Enterprise" },
+            {"Win7-SP1-Ent-N-x64", "Windows 7 Enterprise" }
+            };
+        private Dictionary<string, string> isoNameToAzureSku;
 
         public string OperatingSystemName
         {
@@ -96,44 +109,20 @@ namespace AutomatedLab
         {
             get
             {
-                //updating the list by getting the current list if Azure-VMImages:
-                //Get-AzureVMImage | Where-Object OS -eq Windows | Group-Object -Property Imagefamily | ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 } | Format-Table -Property Imagefamily, PublishedDate
-
-                switch (operatingSystemName)
+                try
                 {
-                    case "Windows Server 2008 R2 Datacenter (Full Installation)":
-                        return "2008-R2-SP1";
-
-                    case "Windows Server 2012 Datacenter (Server with a GUI)":
-                        return "2012-Datacenter";
-
-                    case "Windows Server 2012 R2 Datacenter (Server with a GUI)":
-                        return "2012-R2-Datacenter";
-
-                    case "Windows Server 2016 Datacenter (Desktop Experience)":
-                        return "2016-Datacenter";
-
-                    case "Windows Server 2016 Datacenter":
-                        return "2016-Datacenter-Server-Core";
-
-                    case "Windows Server Datacenter":
-                        return "Datacenter-Core-1709-smalldisk";
-
-                    case "Windows 8.1 Enterprise":
-                        return "Win8.1-Ent-N";
-
-                    case "Windows 10 Pro":
-                        return "Windows-10-N-x64";
-
-                    case "Windows 10 Enterprise":
-                        return "Windows-10-N-x64";
-
-                    case "Windows 7 Enterprise":
-                        return "Win7-SP1-Ent-N";
-
-                    default:
-                        return string.Empty;
+                    return isoNameToAzureSku[OperatingSystemName];
                 }
+                catch (ArgumentNullException)
+                {
+                    // Key is null - can happen
+                }
+                catch (KeyNotFoundException)
+                {
+                    // OS not in dictionary - can happen
+                }
+
+                return string.Empty;
             }
         }
 
@@ -349,10 +338,30 @@ namespace AutomatedLab
         public OperatingSystem()
         {
             LinuxPackageGroup = new List<String>();
+            isoNameToAzureSku = azureToIsoName.ToDictionary(kp => kp.Value, kp => kp.Key);
+        }
+
+        public OperatingSystem(string azureSkuName, bool azure = true)
+        {
+            isoNameToAzureSku = azureToIsoName.ToDictionary(kp => kp.Value, kp => kp.Key);
+
+            try
+            {
+                operatingSystemName = azureToIsoName[azureSkuName];
+            }
+            catch (ArgumentNullException)
+            {
+                // Key is null - can happen
+            }
+            catch (KeyNotFoundException)
+            {
+                // OS not in dictionary - can happen
+            }
         }
 
         public OperatingSystem(string operatingSystemName)
         {
+            isoNameToAzureSku = azureToIsoName.ToDictionary(kp => kp.Value, kp => kp.Key);
             this.operatingSystemName = operatingSystemName;
             LinuxPackageGroup = new List<String>();
             if (operatingSystemName.ToLower().Contains("windows server"))


### PR DESCRIPTION
Updated AutomatedLab.OperatingSystem and Get-LabAvailableOperatingSystem to return valid Azure OS SKUs as AutomatedLab.OperatingSystem objects.

Added switch-parameter to Get-LabAvailableOperatingSystem:
```powershell
Get-LabAvailableOperatingSystem -Azure -Location 'West Europe'
```