### PR TITLE
[CentOS] Added GUI environment if desktop is added as package group

### DIFF
--- a/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartPackage.ps1
+++ b/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartPackage.ps1
@@ -11,7 +11,7 @@ function Set-UnattendedKickstartPackage
     }
     elseif ($Package -like '*KDE*')
     {
-        Write-Warning -Message 'Adding KDE UI to RHEL/CentOS via kickstart file is not supported.'
+        Write-Warning -Message 'Adding KDE UI to RHEL/CentOS via kickstart file is not supported. Please configure your UI manually.'
     }
 
     $script:un.Add('%packages --ignoremissing')
@@ -22,6 +22,8 @@ function Set-UnattendedKickstartPackage
         if ($p -eq 'core') { continue }
 
         $script:un.Add(('@{0}' -f $p))
+
+        if ($p -like '*gnome*') { $script:un.Add('@^graphical-server-environment')}
     }
 
     $script:un.Add('oddjob')


### PR DESCRIPTION
In order to reliably install the UI I have added the graphical server environment. This should install all necessary packages and worked in my test environment with the CentOS 7.4 DVD version.

I am still figuring out why X was properly configured for the non-domain joined system whereas I had to startx on the domain-joined one. But calling startx reliably started te UI.

Depends on #416 to be merged first, sorry.