### PR TITLE
Fixed issue with domain join that fails on Azure

### DIFF
--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -1312,6 +1312,18 @@ function Join-LabVMDomain
             [bool]$AlwaysReboot = $false
         )
 
+        try 
+        {
+            if ([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Name -eq $DomainName)
+            {
+                return $true
+            }
+        }
+        catch
+        {
+            # Empty catch. If we are a workgroup member, it is domain join time.
+        }
+        
         try
         {
             Add-Computer -DomainName $DomainName -Credential $Credential -ErrorAction Stop -WarningAction SilentlyContinue


### PR DESCRIPTION
On the first try, if the machine is rebooted before the session is properly exited, it will be in a failure state:
```
Processing data for a remote command failed with the following error message: The I/O operation has been aborted because of either a thread exit or an application 
request.
```

Which means that those machines will NEVER join the domain, since the second call to Add-Computer will inadvertently fail with "Computer already a member".

This PR amends that issue by trying to determine the machine's domain first.