### PR TITLE
implement support for Windows 10 Enterprise for Remote Sessions

### DIFF
--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -266,6 +266,8 @@ namespace AutomatedLab
                         return "WNMTR-4C88C-JK8YV-HQ7T2-76DF9";
                     case "Windows 10 Enterprise 2016 LTSB":
                         return "DCPHK-NFMTC-H88MJ-PFHPY-QJ4BJ";
+                    case "Windows 10 Enterprise for Remote Sessions":
+                        return "CPWHC-NT2C7-VYW78-DHDB2-PG3GK";
 
                     //Windows Server 2016 new names
                     case "Windows Server 2016 Standard":


### PR DESCRIPTION
The latest Windows 10 release previews contain the new SKU Windows 10 Enterprise for Remote Sessions; that SKU is interesting for all those working with Remote Desktop Services, as it implements Remote Desktop Services on Windows 10, basically making a Windows 10 VDI multi-user capable.

From what I could gather the included product key can be used to set it up for KMS volume licensing.