### PR TITLE
Workflows replaced

### DIFF
--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -401,25 +401,15 @@ function Save-LabVM
             Write-ScreenInfo 'There is no machine to start' -Type Warning
             return
         }
-        
-        foreach ($vm in $vms)
+
+        Write-Verbose -Message "Saving VMs '$($vms -join ',')"
+        switch ($lab.DefaultVirtualizationEngine)
         {
-            Write-Verbose "Saving VMs '$vm'"
-            
-            if ($vm.HostType -eq 'HyperV')
-            {
-                Save-LWHypervVM -ComputerName $vm
-            }
-            elseif ($vm.HostType -eq 'Azure')
-            {
-                Write-Error 'Azure does not support saving machines'
-            }
-            elseif ($vm.HostType -eq 'VMWare')
-            {
-                Save-LWVMWareVM -ComputerName $vm
-            }
+            'HyperV' { Save-LWHypervVM -ComputerName $vms}
+            'VMWare' { Save-LWVMWareVM -ComputerName $vms}
+            'Azure'  { Write-Warning -Message "Skipping Azure VMs '$($vms -join ',')' as suspending the VMs is not supported on Azure."}
         }
-        
+                
         Write-LogFunctionExit
     }
 }

--- a/AutomatedLabWorker/AutomatedLabWorker.psd1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psd1
@@ -22,7 +22,11 @@
     RequiredModules = @(
         'AutomatedLabUnattended',
         'PSLog',
-        'PSFileTransfer'
+        'PSFileTransfer',
+        @{
+            ModuleName = "AutomatedLab.Common"; 
+            ModuleVersion = "1.1.87"; 
+        }
     )
     
     NestedModules = @(


### PR DESCRIPTION
Replaced all workflows with functions making use of the new RunspaceJobs in AutomatedLab.Common. To fully make use of this, Save-LabVm has been modified to not save each individual machine one by one but to pass them in bulk to the appropriate function.

While we cannot achieve PowerShell Core compatibility we at least got rid of the workflows. I did not compare the speed of the new RunspaceJobs - they felt a bit faster but I might be mistaken. 

My test consisted of the following:
```powershell
Save-LabVM -All -Verbose
Start-Labvm -all
Save-Labvm -Name poshfs1
Start-Labvm -ComputerName poshfs1

# All running
Start-LabVm -All
Checkpoint-LabVm -All -SnapshotName new1 -Verbose
Restore-LabVMSnapshot -All -SnapshotName new1 -Verbose
Remove-LabVMSnapshot -AllMachines -SnapshotName new1 -Verbose

# Some running
Stop-LabVm -ComputerName poshfs1
Checkpoint-LabVm -All -SnapshotName new2 -Verbose
Restore-LabVMSnapshot -All -SnapshotName new2 -Verbose
Remove-LabVMSnapshot -AllMachines -SnapshotName new2 -Verbose

# All stopped
Stop-Labvm -All
Checkpoint-LabVm -All -SnapshotName new1 -Verbose
Restore-LabVMSnapshot -All -SnapshotName new1 -Verbose
Remove-LabVMSnapshot -AllMachines -SnapshotName new1 -Verbose
```