### PR TITLE
LabBuilder custom role was unable to start unattended

### DIFF
--- a/LabSources/CustomRoles/LabBuilder/HostStart.ps1
+++ b/LabSources/CustomRoles/LabBuilder/HostStart.ps1
@@ -60,6 +60,8 @@ Copy-LabFileItem -Path $global:labSources -ComputerName $ComputerName -Destinati
 
 Invoke-LabCommand -ComputerName $vm -ActivityName EnablePolaris -ScriptBlock {
     [Environment]::SetEnvironmentVariable('AUTOMATEDLAB_TELEMETRY_OPTOUT', $TelemetryOptOut, 'Machine')
+    $env:AUTOMATEDLAB_TELEMETRY_OPTOUT = $TelemetryOptOut
+    Enable-LabHostRemoting -Force -NoDisplay
     Expand-Archive -Path C:\Polaris.zip -DestinationPath C:\
     Rename-Item -Path C:\Polaris-master -NewName C:\Polaris
     Copy-Item -Recurse -Path C:\Polaris 'C:\Program Files\WindowsPowerShell\Modules'


### PR DESCRIPTION
Since we request users to confirm that they want to relax CredSSP settings and so on the LabBuilder role was unable to start properly. So now before the scheduled task is started that hosts the REST API ```Enable-LabRemoting -Force``` is used.