### PR TITLE
CentOS: Allow passwords with special characters (Fixes #453)

### DIFF
--- a/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartAdministratorName.ps1
+++ b/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartAdministratorName.ps1
@@ -5,5 +5,5 @@ function Set-UnattendedKickstartAdministratorName
         $Name
     )
 
-    $script:un.Add("user --name=$Name --groups=wheel --password=%PASSWORD%")
+    $script:un.Add("user --name=$Name --groups=wheel --password='%PASSWORD%'")
 }

--- a/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartAdministratorPassword.ps1
+++ b/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartAdministratorPassword.ps1
@@ -5,6 +5,6 @@ function Set-UnattendedKickstartAdministratorPassword
 		[string]$Password
     )
 		
-		$Script:un.Add("rootpw $Password")
+		$Script:un.Add("rootpw '$Password'")
 		$Script:un = [System.Collections.Generic.List[string]]($Script:un.Replace('%PASSWORD%', $Password))
 }

--- a/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartAdministratorPassword.ps1
+++ b/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartAdministratorPassword.ps1
@@ -6,5 +6,5 @@ function Set-UnattendedKickstartAdministratorPassword
     )
 		
 		$Script:un.Add("rootpw $Password")
-		$Script:un = [System.Collections.Generic.List[string]]($Script:un -replace '%PASSWORD%', $Password)
+		$Script:un = [System.Collections.Generic.List[string]]($Script:un.Replace('%PASSWORD%', $Password))
 }

--- a/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartDomain.ps1
+++ b/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartDomain.ps1
@@ -11,5 +11,5 @@ function Set-UnattendedKickstartDomain
 		[string]$Password
     )
 	
-	$script:un.Add(('realm join --one-time-password={0} {1}' -f $Password, $DomainName))
+	$script:un.Add(("realm join --one-time-password='{0}' {1}" -f $Password, $DomainName))
 }


### PR DESCRIPTION
Due to the usage of the -replace operator, passwords with $ in them were incorrectly set. Using the String.Replace() method instead properly sets the password in the kickstart configuration. In order to escape all kinds of characters all passwords in the kickstart file will now be enclosed in single quotes.