### PR TITLE
 rename Windows 10 Enterprise for Remote Sessions SKU to Windows 10 Enterprise for Virtual Desktops

### DIFF
--- a/LabSources/CustomRoles/Exchange2016/HostStart.ps1
+++ b/LabSources/CustomRoles/Exchange2016/HostStart.ps1
@@ -271,7 +271,7 @@ function Start-ExchangeInstallation
 }
 
 $ucmaDownloadLink = 'http://download.microsoft.com/download/2/C/4/2C47A5C1-A1F3-4843-B9FE-84C0032C61EC/UcmaRuntimeSetup.exe'
-$exchangeDownloadLink = 'https://download.microsoft.com/download/5/8/C/58CA2823-6764-4355-B9DE-EB196E43BC81/ExchangeServer2016-x64-cu9.iso'
+$exchangeDownloadLink = 'http://download.microsoft.com/download/B/C/9/BC9C77DA-97D9-43D8-A3F8-50D8AF89E3FA/ExchangeServer2016-x64-cu10.iso'
 $dotnetDownloadLink = (Get-Module -Name AutomatedLab -ListAvailable)[0].PrivateData.dotnet471DownloadLink
 
 #----------------------------------------------------------------------------------------------------------------------------------------------------

--- a/LabSources/CustomRoles/Exchange2016/HostStart.ps1
+++ b/LabSources/CustomRoles/Exchange2016/HostStart.ps1
@@ -271,7 +271,7 @@ function Start-ExchangeInstallation
 }
 
 $ucmaDownloadLink = 'http://download.microsoft.com/download/2/C/4/2C47A5C1-A1F3-4843-B9FE-84C0032C61EC/UcmaRuntimeSetup.exe'
-$exchangeDownloadLink = 'http://download.microsoft.com/download/B/C/9/BC9C77DA-97D9-43D8-A3F8-50D8AF89E3FA/ExchangeServer2016-x64-cu10.iso'
+$exchangeDownloadLink = 'https://download.microsoft.com/download/5/8/C/58CA2823-6764-4355-B9DE-EB196E43BC81/ExchangeServer2016-x64-cu9.iso'
 $dotnetDownloadLink = (Get-Module -Name AutomatedLab -ListAvailable)[0].PrivateData.dotnet471DownloadLink
 
 #----------------------------------------------------------------------------------------------------------------------------------------------------

--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -266,7 +266,7 @@ namespace AutomatedLab
                         return "WNMTR-4C88C-JK8YV-HQ7T2-76DF9";
                     case "Windows 10 Enterprise 2016 LTSB":
                         return "DCPHK-NFMTC-H88MJ-PFHPY-QJ4BJ";
-                    case "Windows 10 Enterprise for Remote Sessions":
+                    case "Windows 10 Enterprise for Virtual Desktops":
                         return "CPWHC-NT2C7-VYW78-DHDB2-PG3GK";
 
                     //Windows Server 2016 new names


### PR DESCRIPTION
Microsoft has renamed the SKU for the final RTM release of the product