### PR TITLE
Implemented custom role WindowsAdminCenter

### DIFF
--- a/LabSources/CustomRoles/WindowsAdminCenter/HostStart.ps1
+++ b/LabSources/CustomRoles/WindowsAdminCenter/HostStart.ps1
@@ -1,0 +1,96 @@
+param
+(
+    [Parameter(Mandatory)]
+    [string]
+    $ComputerName,
+
+    [Parameter(Mandatory)]
+    [string]
+    $WacDownloadLink,
+
+    [Parameter()]
+    [uint16]
+    $Port = 443
+)
+
+$lab = Import-Lab -Name $data.Name -NoValidation -NoDisplay -PassThru
+
+if (-not $lab)
+{
+    Write-Error -Message 'Please deploy a lab first.'
+    return
+}
+
+$labMachine = Get-LabVm -ComputerName $ComputerName
+$wacDownload = Get-LabInternetFile -Uri $WacDownloadLink -Path "$(Get-LabSourcesLocationInternal -Local)\SoftwarePackages\WAC.msi" -PassThru -NoDisplay
+
+if ($labMachine.IsDomainJoined -and (Get-LabIssuingCA -DomainName $labMachine.DomainName -ErrorAction SilentlyContinue) )
+{
+    $cert = Request-LabCertificate -Subject "CN=$($machine.FQDN)" -SAN $labMachine.Name -TemplateName WebServer -ComputerName $labMachine -PassThru -ErrorAction Stop
+}
+
+$arguments = @(
+    '/qn'
+    '/L*v C:\wacLoc.txt'
+    "SME_PORT=$Port"
+)
+if ($cert.Thumbprint)
+{
+    $arguments += "SME_THUMBPRINT=$($cert.Thumbprint)"
+    $arguments += "SSL_CERTIFICATE_OPTION=installed"
+}
+else
+{
+    $arguments += "SSL_CERTIFICATE_OPTION=generate"
+}
+
+Write-ScreenInfo -Type Verbose -Message "Starting installation of Windows Admin Center on $labMachine"
+$installation = Install-LabSoftwarePackage -Path $wacDownload.Path -CommandLine $($arguments -join ' ') -ComputerName $labMachine -ExpectedReturnCodes 0, 3010 -AsJob -PassThru -NoDisplay
+
+Write-ScreenInfo -Message "Waiting for the installation of Windows Admin Center to finish on $labMachine"
+Wait-LWLabJob -Job $installation -ProgressIndicator 5 -NoNewLine -NoDisplay
+
+if ($installation.State -eq 'Failed')
+{
+    Get-Job -Id $($installation.Id) | Receive-Job -Keep -ErrorAction SilentlyContinue -ErrorVariable err
+    if ($err[0].Exception -is [System.Management.Automation.Remoting.PSRemotingTransportException])
+    {
+        Write-ScreenInfo -Type Verbose -Message "WAC setup has restarted WinRM. The setup of WAC should be completed"
+        Invoke-LabCommand -ActivityName 'Waiting for WAC setup to really complete' -ComputerName $labMachine -ScriptBlock {
+            while ((Get-Process -Name msiexec).Count -gt 1)
+            {
+                Start-Sleep -Milliseconds 250
+            }
+        } -NoDisplay
+    }
+    else
+    {
+        Write-ScreenInfo -Type Error -Message "Installing Windows Admin Center on $labMachine failed. Review the errors with Get-Job -Id $($installation.Id) | Receive-Job -Keep"
+        return
+    }
+}
+
+Write-ScreenInfo -Message "Installation of Windows Admin Center done. You can access it here: https://$($labMachine.FQDN):$Port"
+
+# Add hosts through REST API
+Write-ScreenInfo -Message "Adding $((Get-LabVm | Where-Object -Property Name -ne $ComputerName).Count) hosts to the admin center for user $($labMachine.GetCredential($lab).UserName)"
+$apiEndpoint = "https://$($labmachine.FQDN):$Port/api/connections"
+
+$bodyHash = foreach ($machine in (Get-LabVm | Where-Object -Property Name -ne $ComputerName))
+{
+    @{
+        id   = "msft.sme.connection-type.server!$($machine.FQDN)"
+        name = $machine.FQDN
+        type = "msft.sme.connection-type.server"
+    }
+}
+
+try
+{
+    $response = Invoke-RestMethod -Method PUT -Uri $apiEndpoint -Credential $labMachine.GetCredential($lab) -Body $($bodyHash | ConvertTo-Json) -ContentType application/json -ErrorAction Stop
+    Write-ScreenInfo -Message "Successfully added all lab machines as connections for $($labMachine.GetCredential($lab).UserName)"
+}
+catch
+{
+    Write-ScreenInfo -type Error -Message "Could not add server connections. Invoke-RestMethod says: $($_.Exception.Message)"
+}

--- a/LabSources/SampleScripts/Scenarios/WindowsAdminCenter.ps1
+++ b/LabSources/SampleScripts/Scenarios/WindowsAdminCenter.ps1
@@ -1,0 +1,38 @@
+﻿$labName = 'WACLab'
+$domainName = 'contoso.com'
+
+New-LabDefinition -Name $labname -DefaultVirtualizationEngine HyperV
+
+Add-LabDomainDefinition -Name $domainName -AdminUser Install -AdminPassword Somepass1
+Set-LabInstallationCredential -Username Install -Password Somepass1
+
+$PSDefaultParameterValues = @{
+    'Add-LabMachineDefinition:ToolsPath'= "$labSources\Tools"
+    'Add-LabMachineDefinition:DomainName' = 'contoso.com'
+    'Add-LabMachineDefinition:OperatingSystem' = 'Windows Server 2016 Datacenter'
+}
+
+# Domain
+$postInstallActivity = @()
+$postInstallActivity += Get-LabPostInstallationActivity -ScriptFileName 'New-ADLabAccounts 2.0.ps1' -DependencyFolder $labSources\PostInstallationActivities\PrepareFirstChildDomain
+$postInstallActivity += Get-LabPostInstallationActivity -ScriptFileName PrepareRootDomain.ps1 -DependencyFolder $labSources\PostInstallationActivities\PrepareRootDomain
+Add-LabMachineDefinition -Name WACDC1 -Memory 1GB -Roles RootDC -PostInstallationActivity $postInstallActivity
+
+# CA
+Add-LabMachineDefinition -Name WACCA1 -Memory 1GB -Roles CARoot
+
+# WAC Server
+$role = Get-LabPostInstallationActivity -CustomRole WindowsAdminCenter -Properties @{
+    WacDownloadLink = 'http://aka.ms/WACDownload'
+}
+Add-LabMachineDefinition -Name WACWAC1 -Memory 1GB -Roles WebServer -PostInstallationActivity $role
+
+# Some managed hosts
+foreach ($i in 1..4)
+{
+    Add-LabMachineDefinition -Name WACHO$i -Memory 1GB
+}
+
+Install-Lab
+
+Show-LabDeploymentSummary


### PR DESCRIPTION
Added Windows Admin Center (formerly known as Project Honolulu) as a little custom role. The role installs WAC and uses either the lab PKI if accessible or a self-signed certificate during deployment.

All lab machines will automatically be added to the lab domain administrator's dashboard. Since dashboards are per-user, the machines have to be added manually for additional users.

The sample lab installs a domain/PKI environment with one host dedicated as the WAC host and a couple of managed systems.