### PR TITLE
Updated Azure image SKU for Windows Server Datacenter to 1803

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1315,7 +1315,7 @@ function Get-LabAvailableOperatingSystem
 
         $type = Get-Type -GenericType AutomatedLab.ListXmlStore -T AutomatedLab.OperatingSystem
         $osList = New-Object $type
-        $skus = (Get-LabAzureAvailableSku -Location 'West Europe')
+        $skus = (Get-LabAzureAvailableSku -Location $Location)
 
         foreach ($sku in $skus)
         {

--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -25,7 +25,7 @@ namespace AutomatedLab
             {"2012-R2-Datacenter", "Windows Server 2012 R2 Datacenter (Server with a GUI)" },
             {"2016-Datacenter", "Windows Server 2016 Datacenter (Desktop Experience)" },
             {"2016-Datacenter-Server-Core", "Windows Server 2016 Datacenter" },
-            {"Datacenter-Core-1709-smalldisk", "Windows Server Datacenter" },
+            {"Datacenter-Core-1803-with-Containers-smalldisk", "Windows Server Datacenter" },
             {"Win81-Ent-N-x64", "Windows 8.1 Enterprise" },
             {"Windows-10-N-x64", "Windows 10 Enterprise" },
             {"Win7-SP1-Ent-N-x64", "Windows 7 Enterprise" },


### PR DESCRIPTION
Updated the lookup dictionary.

I don't like the current behavior of AutomatedLab in that it treats 1709 and 1803 equally. On-premises that's fine - simple remove the ISO. On Azure this is not possible. I will probably add an azure property like "ImageSku" so that we can at least override this.