### PR TITLE
Adding support for TLS 1.2

### DIFF
--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -726,7 +726,17 @@ function Update-LabSysinternalsTools
 {
     #Update SysInternals suite if needed
     $type = Get-Type -GenericType AutomatedLab.DictionaryXmlStore -T String, DateTime
-    
+
+    try {
+        #https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netcore-2.0#System_Net_SecurityProtocolType_SystemDefault
+        if ($PSVersionTable.PSVersion.Major -lt 6 -and [Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12') {
+            Write-Verbose -Message 'Adding support for TLS 1.2'
+            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+        }
+    }
+    catch {
+        Write-Warning -Message 'Adding TLS 1.2 to supported security protocols was unsuccessful.'
+    }
     try
     {
         Write-Verbose -Message 'Get last check time of SysInternals suite'


### PR DESCRIPTION
Adding TLS 1.2 support to `Update-LabSysinternalsTools` Rest API calls, which is the only supported protocol by Sysinternals site ([Source](https://support.microsoft.com/en-us/help/4057306/preparing-for-tls-1-2-in-office-365)). For older PowerShell versions, TLS 1.0 is the default protocol.

This update also fixes [#401](https://github.com/AutomatedLab/AutomatedLab/issues/401).