### PR TITLE
Add BitLocker write protection check

### DIFF
--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -44,6 +44,11 @@ function New-LabVM
 
     foreach ($machine in $machines)
     {
+        $FDVDenyWriteAccess = (Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FVE -Name FDVDenyWriteAccess).FDVDenyWriteAccess
+        if ($FDVDenyWriteAccess) {
+            Set-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FVE -Name FDVDenyWriteAccess -Value 0
+        }
+        
         Write-ScreenInfo -Message "Creating $($machine.HostType) machine '$machine'" -TaskStart -NoNewLine
 
         if ($machine.HostType -eq 'HyperV')
@@ -83,6 +88,9 @@ function New-LabVM
             $jobs += New-LWAzureVM -Machine $machine
 
             Write-ScreenInfo -Message 'Done' -TaskEnd
+        }
+        if ($FDVDenyWriteAccess) {
+            Set-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FVE -Name FDVDenyWriteAccess -Value $FDVDenyWriteAccess
         }
     }
 


### PR DESCRIPTION
Add BitLocker write protection check

There is a group policy setting for BitLocker enabled devices which, if enabled, causes all fixed drives to be read-only until they have been BitLocker encrypted as described here https://getadmx.com/?Category=Windows_10_2016&Policy=Microsoft.Policies.VolumeEncryption::FDVDenyWriteAccess_Name 

This causes issues with creating base images and creating VHDXs. You get the following pop up box
![image](https://user-images.githubusercontent.com/20758758/48297349-93795180-e49d-11e8-9756-f9370a46e0ee.png)

The pop up is very shortly followed by the below error in the console in the case of the base image
![image](https://user-images.githubusercontent.com/20758758/48297358-c28fc300-e49d-11e8-8cf3-9811a9cfb716.png)


This PR fixes the issue by temporarily disabling this setting in the registry to allow the virtual disks to be written to before restoring the original value during clean up afterwards.