### PR TITLE
Added  -ErrorAction SilentlyContinue to new FVE thing

### DIFF
--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -44,7 +44,7 @@ function New-LabVM
 
     foreach ($machine in $machines)
     {
-        $FDVDenyWriteAccess = (Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FVE -Name FDVDenyWriteAccess).FDVDenyWriteAccess
+        $FDVDenyWriteAccess = (Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FVE -Name FDVDenyWriteAccess -ErrorAction SilentlyContinue).FDVDenyWriteAccess
         if ($FDVDenyWriteAccess) {
             Set-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FVE -Name FDVDenyWriteAccess -Value 0
         }

--- a/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
@@ -36,7 +36,7 @@ function New-LWReferenceVHDX
 
     try
     {
-        $FDVDenyWriteAccess = (Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FVE -Name FDVDenyWriteAccess).FDVDenyWriteAccess
+        $FDVDenyWriteAccess = (Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FVE -Name FDVDenyWriteAccess -ErrorAction SilentlyContinue).FDVDenyWriteAccess
 
         $imageList = Get-LabAvailableOperatingSystem -Path $IsoOsPath
         Write-Verbose "The Windows Image list contains $($imageList.Count) items"


### PR DESCRIPTION
Last PR broke development code if the key HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FVE does not exist. Added ErrorAction SilentlyContinue to the remaining Get-ItemProperty calls.