### PR TITLE
Fixed error message with empty disk cache

### DIFF
--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -3213,8 +3213,8 @@ function Set-LabLocalVirtualMachineDiskAuto
         return $false
     }
 
-    #if the current disk config is different from the is in the cache, wait until the running lab deploymet is done.
-    if (Compare-Object -ReferenceObject $drives.DriveLetter -DifferenceObject $cachedDrives.DriveLetter)
+    #if the current disk config is different from the is in the cache, wait until the running lab deployment is done.
+    if ($cachedDrives -and (Compare-Object -ReferenceObject $drives.DriveLetter -DifferenceObject $cachedDrives.DriveLetter))
     {
         $labDiskDeploymentInProgressPath = Get-LabConfigurationItem -Name DiskDeploymentInProgressPath
         if (Test-Path -Path $labDiskDeploymentInProgressPath)


### PR DESCRIPTION
With an empty disk cache an unnecessary (and possibly confusing) error is displayed. By first checking if the disk cache actually exists, we clear this error.