### PR TITLE
Updated to Support ADK 1809

### DIFF
--- a/LabSources/CustomRoles/MDT/DownloadAdk.ps1
+++ b/LabSources/CustomRoles/MDT/DownloadAdk.ps1
@@ -3,7 +3,7 @@ param(
     [string]$AdkDownloadPath
 )
 
-$windowsAdkUrl = 'http://download.microsoft.com/download/3/1/E/31EC1AAF-3501-4BB4-B61C-8BD8A07B4E8A/adk/adksetup.exe'
+$windowsAdkUrl = 'https://download.microsoft.com/download/0/1/C/01CC78AA-B53B-4884-B7EA-74F2878AA79F/adk/adksetup.exe'
 $adkSetup = Get-LabInternetFile -Uri $windowsAdkUrl -Path $labSources\SoftwarePackages -PassThru
 
 if (-not (Test-Path -Path $AdkDownloadPath))
@@ -18,5 +18,25 @@ if (-not (Test-Path -Path $AdkDownloadPath))
 }
 else
 {
-    Write-ScreenInfo "ADK folder does already exist, skipping the download. Delete the folder '$AdkDownloadPath' if you want to download again."
+    Write-ScreenInfo "ADK folder already exists, skipping the download. Delete the folder '$AdkDownloadPath' if you want to download again."
 }
+
+$windowsAdkWinPEUrl = 'https://download.microsoft.com/download/D/7/E/D7E22261-D0B3-4ED6-8151-5E002C7F823D/adkwinpeaddons/adkwinpesetup.exe'
+$adkWinPESetup = Get-LabInternetFile -Uri $windowsAdkWinPEUrl -Path $labSources\SoftwarePackages -PassThru
+
+if (-not (Test-Path -Path $AdkWinPEDownloadPath))
+{
+    $p = Start-Process -FilePath $adkWinPESetup.FullName -ArgumentList "/quiet /layout $AdkWinPEDownloadPath" -PassThru
+    Write-ScreenInfo "Waiting for ADK Windows PE Addons to download files" -NoNewLine
+    while (-not $p.HasExited) {
+        Write-ScreenInfo '.' -NoNewLine
+        Start-Sleep -Seconds 10
+    }
+    Write-ScreenInfo 'finished'
+}
+else
+{
+    Write-ScreenInfo "ADK Windows PE Addons folder already exists, skipping the download. Delete the folder '$AdkWinPEDownloadPath' if you want to download again."
+}
+
+

--- a/LabSources/CustomRoles/MDT/HostStart.ps1
+++ b/LabSources/CustomRoles/MDT/HostStart.ps1
@@ -11,7 +11,10 @@ param(
     [Parameter(Mandatory)]
     [string[]]$OperatingSystems,
 
-    [string]$AdkDownloadPath = "$labSources\SoftwarePackages\ADK"
+    [string]$AdkDownloadPath = "$labSources\SoftwarePackages\ADK",
+    
+    [string]$AdkWinPEDownloadPath = "$labSources\SoftwarePackages\ADKWinPEAddons"
+
 )
 
 Import-Lab -Name $data.Name

--- a/LabSources/CustomRoles/MDT/MDTApplications.xml
+++ b/LabSources/CustomRoles/MDT/MDTApplications.xml
@@ -1,278 +1,278 @@
 <Applications>
-  <Application Name="Microsoft Visual C++ 2005 Redistributable (x86)">
-    <DownloadPath>https://download.microsoft.com/download/e/1/c/e1c773de-73ba-494a-a5ba-f24906ecf088/vcredist_x86.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2005 Redistributable (x86)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x86.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2005 Redistributable (x64)">
-    <DownloadPath>https://download.microsoft.com/download/d/4/1/d41aca8a-faa5-49a7-a5f2-ea0aa4587da0/vcredist_x64.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2005 Redistributable (x64)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x64.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2008 Redistributable (x86)">
-    <DownloadPath>https://download.microsoft.com/download/d/d/9/dd9a82d0-52ef-40db-8dab-795376989c03/vcredist_x86.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2008 Redistributable (x86)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x86.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2008 Redistributable (x64)">
-    <DownloadPath>https://download.microsoft.com/download/2/d/6/2d61c766-107b-409d-8fba-c39e61ca08e8/vcredist_x64.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2008 Redistributable (x64)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x64.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2010 Redistributable (x86)">
-    <DownloadPath>https://download.microsoft.com/download/C/6/D/C6D0FD4E-9E53-4897-9B91-836EBA2AACD3/vcredist_x86.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2010 Redistributable (x86)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x86.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2010 Redistributable (x64)">
-    <DownloadPath>https://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2010 Redistributable (x64)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x64.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2012 Redistributable (x86)">
-    <DownloadPath>https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2012 Redistributable (x86)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x86.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2012 Redistributable (x64)">
-    <DownloadPath>https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2012 Redistributable (x64)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x64.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2013 Redistributable (x86)">
-    <DownloadPath>https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2013 Redistributable (x86)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x86.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2013 Redistributable (x64)">
-    <DownloadPath>https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2013 Redistributable (x64)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vcredist_x64.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2015 Redistributable (x86)">
-    <DownloadPath>https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2015 Redistributable (x86)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vc_redist.x86.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Microsoft Visual C++ 2015 Redistributable (x64)">
-    <DownloadPath>https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe</DownloadPath>
-    <AppPath>Frameworks</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Microsoft Visual C++ 2015 Redistributable (x64)</ShortName>
-    <AppVersion></AppVersion>
-    <Publisher>Microsoft</Publisher>
-    <Langauge></Langauge>
-    <CommandLine>vc_redist.x64.exe /Q</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Adobe Acrobat Reader">
-    <DownloadPath>http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/1800920044/AcroRdrDC1800920044_en_US.exe</DownloadPath>
-    <AppPath>Utilities</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Adobe Acrobat Reader</ShortName>
-    <AppVersion>2018.009.20044</AppVersion>
-    <Publisher>Adobe</Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>AcroRdrDC1800920044_en_US.exe /sAll /rs /l /msi /qb- /norestart EULA_ACCEPT=YES</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Mozilla Firefox">
-    <DownloadPath>https://ftp.mozilla.org/pub/firefox/releases/57.0/win64/en-US/Firefox%20Setup%2057.0.exe</DownloadPath>
-    <AppPath>Applications</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Mozilla Firefox</ShortName>
-    <AppVersion>57.0</AppVersion>
-    <Publisher>Mozilla</Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>Firefox%20Setup%2057.0.exe -ms</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Notepad Plus Plus">
-    <DownloadPath>https://notepad-plus-plus.org/repository/7.x/7.5.3/npp.7.5.3.Installer.exe</DownloadPath>
-    <AppPath>Utilities</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Notepad Plus Plus</ShortName>
-    <AppVersion>7.5.3</AppVersion>
-    <Publisher></Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>npp.7.5.3.Installer.exe /S</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="WinPcap">
-    <DownloadPath>https://www.winpcap.org/install/bin/WinPcap_4_1_3.exe</DownloadPath>
-    <AppPath>Utilities</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>WinPcap</ShortName>
-    <AppVersion>4.1.3</AppVersion>
-    <Publisher></Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>WinPcap_4_1_3.exe /S</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Wireshark x64">
-    <DownloadPath>https://1.eu.dl.wireshark.org/win64/Wireshark-win64-2.6.5.exe</DownloadPath>
-    <AppPath>Utilities</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>WireShark x64</ShortName>
-    <AppVersion>2.6.5</AppVersion>
-    <Publisher></Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>Wireshark-win64-2.6.5.exe /S</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Wireshark x86">
-    <DownloadPath>https://1.eu.dl.wireshark.org/win32/Wireshark-win32-2.6.5.exe</DownloadPath>
-    <AppPath>Utilities</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>WireShark x86</ShortName>
-    <AppVersion>2.6.5</AppVersion>
-    <Publisher></Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>Wireshark-win32-2.6.5.exe /S</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Nmap">
-    <DownloadPath>https://nmap.org/dist/nmap-7.60-setup.exe</DownloadPath>
-    <AppPath>Utilities</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Nmap</ShortName>
-    <AppVersion>7.60</AppVersion>
-    <Publisher></Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>nmap-7.60-setup.exe /S</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Palemoon x64">
-    <DownloadPath>http://rm-eu.palemoon.org/release/palemoon-28.2.2.win64.installer.exe</DownloadPath>
-    <AppPath>Applications</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Palemoon x64</ShortName>
-    <AppVersion>28.2.2</AppVersion>
-    <Publisher></Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>palemoon-28.2.2.win64.installer.exe /S</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Waterfox x64">
-    <DownloadPath>https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%2056.0.1%20Setup.exe</DownloadPath>
-    <AppPath>Applications</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Waterfox x64</ShortName>
-    <AppVersion>56.0.1</AppVersion>
-    <Publisher></Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>Waterfox%2056.0.1%20Setup.exe /S</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="TeraCopy">
-    <DownloadPath>https://www.codesector.com/files/teracopy.exe</DownloadPath>
-    <AppPath>Utilities</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>TeraCopy</ShortName>
-    <AppVersion>3.2.1</AppVersion>
-    <Publisher></Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>teracopy.exe /S</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
-  <Application Name="Advanced IP Scanner">
-    <DownloadPath>http://download1.famatech.com/download/files/ipscan25.exe</DownloadPath>
-    <AppPath>Utilities</AppPath>
-    <ImportApp>True</ImportApp>
-    <Enabled>True</Enabled>
-    <ShortName>Advanced IP Scanner</ShortName>
-    <AppVersion>2.5</AppVersion>
-    <Publisher></Publisher>
-    <Langauge>English</Langauge>
-    <CommandLine>ipscan25.exe /S</CommandLine>
-    <WorkingDirectory></WorkingDirectory>
-  </Application>
+    <Application Name="Microsoft Visual C++ 2005 Redistributable (x86)">
+        <DownloadPath>https://download.microsoft.com/download/e/1/c/e1c773de-73ba-494a-a5ba-f24906ecf088/vcredist_x86.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2005 Redistributable (x86)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x86.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2005 Redistributable (x64)">
+        <DownloadPath>https://download.microsoft.com/download/d/4/1/d41aca8a-faa5-49a7-a5f2-ea0aa4587da0/vcredist_x64.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2005 Redistributable (x64)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x64.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2008 Redistributable (x86)">
+        <DownloadPath>https://download.microsoft.com/download/d/d/9/dd9a82d0-52ef-40db-8dab-795376989c03/vcredist_x86.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2008 Redistributable (x86)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x86.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2008 Redistributable (x64)">
+        <DownloadPath>https://download.microsoft.com/download/2/d/6/2d61c766-107b-409d-8fba-c39e61ca08e8/vcredist_x64.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2008 Redistributable (x64)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x64.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2010 Redistributable (x86)">
+        <DownloadPath>https://download.microsoft.com/download/C/6/D/C6D0FD4E-9E53-4897-9B91-836EBA2AACD3/vcredist_x86.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2010 Redistributable (x86)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x86.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2010 Redistributable (x64)">
+        <DownloadPath>https://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2010 Redistributable (x64)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x64.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2012 Redistributable (x86)">
+        <DownloadPath>https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2012 Redistributable (x86)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x86.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2012 Redistributable (x64)">
+        <DownloadPath>https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2012 Redistributable (x64)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x64.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2013 Redistributable (x86)">
+        <DownloadPath>https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2013 Redistributable (x86)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x86.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2013 Redistributable (x64)">
+        <DownloadPath>https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2013 Redistributable (x64)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vcredist_x64.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2015 Redistributable (x86)">
+        <DownloadPath>https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2015 Redistributable (x86)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vc_redist.x86.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Microsoft Visual C++ 2015 Redistributable (x64)">
+        <DownloadPath>https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe</DownloadPath>
+        <AppPath>Frameworks</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Microsoft Visual C++ 2015 Redistributable (x64)</ShortName>
+        <AppVersion></AppVersion>
+        <Publisher>Microsoft</Publisher>
+        <Langauge></Langauge>
+        <CommandLine>vc_redist.x64.exe /Q</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Adobe Acrobat Reader">
+        <DownloadPath>http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/1800920044/AcroRdrDC1800920044_en_US.exe</DownloadPath>
+        <AppPath>Utilities</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Adobe Acrobat Reader</ShortName>
+        <AppVersion>2018.009.20044</AppVersion>
+        <Publisher>Adobe</Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>AcroRdrDC1800920044_en_US.exe /sAll /rs /l /msi /qb- /norestart EULA_ACCEPT=YES</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Mozilla Firefox">
+        <DownloadPath>https://download-installer.cdn.mozilla.net/pub/firefox/releases/64.0/win64/en-US/Firefox%20Setup%2064.0.exe</DownloadPath>
+        <AppPath>Applications</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Mozilla Firefox</ShortName>
+        <AppVersion>64.0</AppVersion>
+        <Publisher>Mozilla</Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>Firefox%20Setup%2064.0.exe -ms</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Notepad Plus Plus">
+        <DownloadPath>https://notepad-plus-plus.org/repository/7.x/7.6.1/npp.7.6.1.Installer.x64.exe</DownloadPath>
+        <AppPath>Utilities</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Notepad Plus Plus</ShortName>
+        <AppVersion>7.6.1</AppVersion>
+        <Publisher></Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>npp.7.6.1.Installer.x64.exe /S</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="WinPcap">
+        <DownloadPath>https://www.winpcap.org/install/bin/WinPcap_4_1_3.exe</DownloadPath>
+        <AppPath>Utilities</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>WinPcap</ShortName>
+        <AppVersion>4.1.3</AppVersion>
+        <Publisher></Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>WinPcap_4_1_3.exe /S</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Wireshark x64">
+        <DownloadPath>https://1.as.dl.wireshark.org/win64/Wireshark-win64-2.6.5.exe</DownloadPath>
+        <AppPath>Utilities</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>WireShark x64</ShortName>
+        <AppVersion>2.6.5</AppVersion>
+        <Publisher></Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>Wireshark-win64-2.6.5.exe /S</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Wireshark x86">
+        <DownloadPath>https://1.as.dl.wireshark.org/win32/Wireshark-win32-2.6.5.exe</DownloadPath>
+        <AppPath>Utilities</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>WireShark x86</ShortName>
+        <AppVersion>2.6.5</AppVersion>
+        <Publisher></Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>Wireshark-win32-2.6.5.exe /S</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Nmap">
+        <DownloadPath>https://nmap.org/dist/nmap-7.60-setup.exe</DownloadPath>
+        <AppPath>Utilities</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Nmap</ShortName>
+        <AppVersion>7.60</AppVersion>
+        <Publisher></Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>nmap-7.60-setup.exe /S</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Palemoon x64">
+        <DownloadPath>http://rm-eu.palemoon.org/release/palemoon-28.2.2.win64.installer.exe</DownloadPath>
+        <AppPath>Applications</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Palemoon x64</ShortName>
+        <AppVersion>28.2.2</AppVersion>
+        <Publisher></Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>palemoon-28.2.2.win64.installer.exe /S</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application> 
+    <Application Name="Waterfox x64">
+        <DownloadPath>https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%2056.0.1%20Setup.exe</DownloadPath>
+        <AppPath>Applications</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Waterfox x64</ShortName>
+        <AppVersion>56.0.1</AppVersion>
+        <Publisher></Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>Waterfox%2056.0.1%20Setup.exe /S</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application> 
+    <Application Name="TeraCopy">
+        <DownloadPath>https://www.codesector.com/files/teracopy.exe</DownloadPath>
+        <AppPath>Utilities</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>TeraCopy</ShortName>
+        <AppVersion>3.2.1</AppVersion>
+        <Publisher></Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>teracopy.exe /S</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application>
+    <Application Name="Advanced IP Scanner">
+        <DownloadPath>https://www.advanced-ip-scanner.com/download/Advanced_IP_Scanner_2.5.3646.exe</DownloadPath>
+        <AppPath>Utilities</AppPath>
+        <ImportApp>True</ImportApp>
+        <Enabled>True</Enabled>
+        <ShortName>Advanced IP Scanner</ShortName>
+        <AppVersion>2.5.3646</AppVersion>
+        <Publisher></Publisher>
+        <Langauge>English</Langauge>
+        <CommandLine>Advanced_IP_Scanner_2.5.3646.exe /S</CommandLine>
+        <WorkingDirectory></WorkingDirectory>
+    </Application> 
 </Applications>


### PR DESCRIPTION
As per issue #545, have updated MDT custom role files to support new ADK 1809 with split ADK and Windows PE installation executables.

Updated identified files with out of date URL's in Applications.XML file

Removed some unnecessary comments from InstallMDT.ps1 Script

Tested updated code with both scripts present in the LabSources\SampleScripts\Scenarios folder