### PR TITLE
Fixes #491

### DIFF
--- a/AutomatedLabNotifications/Private/Send-ALToastNotification.ps1
+++ b/AutomatedLabNotifications/Private/Send-ALToastNotification.ps1
@@ -49,13 +49,19 @@ function Send-ALToastNotification
     $template = "<?xml version=`"1.0`" encoding=`"utf-8`"?><toast><visual><binding template=`"ToastGeneric`"><text>{2}</text><text>Deployment of {0} on {1}, current status '{2}'. Message {3}.</text><image src=`"{4}`" placement=`"appLogoOverride`" hint-crop=`"circle`" /></binding></visual></toast>" -f `
         $lab.Name, $lab.DefaultVirtualizationEngine, $Activity, $Message, $imageFilePath
 
+    try
+    {
+        [void]([Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime])
+        [void]([Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime])
+        [void]([Windows.UI.Notifications.ToastNotification, Windows.UI.Notifications, ContentType = WindowsRuntime])
+        $xml = New-Object Windows.Data.Xml.Dom.XmlDocument
 
-    [void]([Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime])
-    [void]([Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime])
-    [void]([Windows.UI.Notifications.ToastNotification, Windows.UI.Notifications, ContentType = WindowsRuntime])
-    $xml = New-Object Windows.Data.Xml.Dom.XmlDocument
-
-    $xml.LoadXml($template)
-    $toast = New-Object Windows.UI.Notifications.ToastNotification $xml
-    [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($toastProvider).Show($toast)
+        $xml.LoadXml($template)
+        $toast = New-Object Windows.UI.Notifications.ToastNotification $xml
+        [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($toastProvider).Show($toast)
+    }
+    catch
+    {
+        Write-Verbose "Error sending toast notification: $($_.Exception.Message)"
+    }
 }


### PR DESCRIPTION
'Send-ALToastNotification' throws an error in some rare scenarios. As the toast notification is not critical, it is now wrapped in a try block.