### PR TITLE
Added a configurable timeout for Test-Port.

### DIFF
--- a/AutomatedLab.sln
+++ b/AutomatedLab.sln
@@ -93,6 +93,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AutomatedLab", "AutomatedLa
 		AutomatedLab\AutomatedLabTfs.psm1 = AutomatedLab\AutomatedLabTfs.psm1
 		AutomatedLab\AutomatedLabVirtualMachines.psm1 = AutomatedLab\AutomatedLabVirtualMachines.psm1
 		AutomatedLab\AutomatedLabVMWare.psm1 = AutomatedLab\AutomatedLabVMWare.psm1
+		AutomatedLab\settings.psd1 = AutomatedLab\settings.psd1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISOs", "ISOs", "{02DDCCD0-7EAA-450B-AE8A-67D54E8EF30C}"

--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -237,8 +237,4 @@
         'AutomatedLabVirtualMachines.psm1',
         'AutomatedLabVMWare.psm1'
     )
-    
-    PrivateData            = @{
-        
-    }
 }

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -2656,6 +2656,7 @@ function New-LabPSSession
 
         #Due to a problem in Windows 10 not being able to reach VMs from the host
         netsh.exe interface ip delete arpcache | Out-Null
+        $testPortTimeout = (Get-LabConfigurationItem -Name Timeout_TestPortInSeconds) * 1000
     }
 
     process
@@ -2803,7 +2804,7 @@ function New-LabPSSession
                 netsh.exe interface ip delete arpcache | Out-Null
 
                 Write-Verbose "Testing port $($param.Port) on computer '$($param.ComputerName)'"
-                $portTest = Test-Port -ComputerName $param.ComputerName -Port $param.Port -TCP
+                $portTest = Test-Port -ComputerName $param.ComputerName -Port $param.Port -TCP -TcpTimeout $testPortTimeout
                 if ($portTest.Open)
                 {
                     Write-Verbose 'Port was open, trying to create the session'

--- a/AutomatedLab/settings.psd1
+++ b/AutomatedLab/settings.psd1
@@ -185,6 +185,7 @@
         Timeout_StartLabMachine_Online         = 60
         Timeout_RestartLabMachine_Shutdown     = 30
         Timeout_StopLabMachine_Shutdown        = 30
+        Timeout_TestPortInSeconds              = 2
         
         Timeout_InstallLabCAInstallation       = 40
         

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psd1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psd1
@@ -63,6 +63,4 @@
         'Set-LabLocalVirtualMachineDiskAuto'
         'Test-LabDefinition'
     )
-
-    PrivateData = @{ }
 }


### PR DESCRIPTION
- The 'Test-Port' timeout in 'New-LabPSSession' is now configurable in the 'settings.psd1'. The default is 2 seconds.
- Some cleanup and adding the settings.psd1 file to the VS solution.