### PR TITLE
Propose to remove DNS forwarder on Domain Controller DNS Settings on-premise

### DIFF
--- a/AutomatedLab/AutomatedLabADDS.psm1
+++ b/AutomatedLab/AutomatedLabADDS.psm1
@@ -913,9 +913,9 @@ function Install-LabRootDcs
         Wait-LabVM -ComputerName $machines -DoNotUseCredSsp -TimeoutInMinutes 30 -ProgressIndicator 30 -NoNewLine
         Wait-LabADReady -ComputerName $machines -TimeoutInMinutes $AdwsReadyTimeout -ErrorAction Stop -ProgressIndicator 30 -NoNewLine
 
-        Invoke-LabCommand -ActivityName 'Configuring DNS Forwarders on Azure Root DCs' -ComputerName $machines -ScriptBlock {
-            dnscmd /ResetForwarders 168.63.129.16
-        } -DoNotUseCredSsp -NoDisplay
+#        Invoke-LabCommand -ActivityName 'Configuring DNS Forwarders on Azure Root DCs' -ComputerName $machines -ScriptBlock {
+#            dnscmd /ResetForwarders 168.63.129.16
+#        } -DoNotUseCredSsp -NoDisplay
 
         #Create reverse lookup zone (forest scope)
         foreach ($network in ((Get-LabVirtualNetworkDefinition).AddressSpace.IpAddress.AddressAsString))


### PR DESCRIPTION
There is a "Configuring DNS Forwarders on Azure Root DCs" task with enables Azure DNS ip 168.63.129.16 as a DNS forwarder.
Well. I do not use azure, and on my side this ip address is not available.
Making unavailable dns server as a forwarder makes problems in resolving dns names in on-premise deployments.


dig domain.com @168.63.129.16
; <<>> DiG 9.10.5 <<>> ya.ru @168.63.129.16
;; global options: +cmd
;; connection timed out; no servers could be reached

Well. I did some research about this ip.
https://blogs.msdn.microsoft.com/mast/2015/05/18/what-is-the-ip-address-168-63-129-16/
And i think this dns forwarder ip is not an option in on-premise deployments.