### PR TITLE
Increase $Timeout default value at least twice.

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorker.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psm1
@@ -822,7 +822,7 @@ function Wait-LWLabJob
         [ValidateRange(0, 300)]
         [int]$ProgressIndicator = $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData.DefaultProgressIndicator,
 
-        [int]$Timeout = 60,
+        [int]$Timeout = 120,
 
         [switch]$NoNewLine,
 


### PR DESCRIPTION
I suggest you to increase job timeout limit.
I have Core i7 CPU and 32Gb DDR3 memory. All vm files is on SSD disk but when i install Exchange 2016 server on my computer and install job task has a timeout error. Script installs .Net update and library optimization processes are very CPU intensive.
I increased $Timeout twice, clean and restart deploy. My deployment has completed successfully.
I think 60 minutes is too small for standart desktop computer in Exchange deployments
It is pity, that this timeout is hardcoded. Can we set timeout on the fly in script?