### PR TITLE
Fixing validator 'MandatoryRoleProperties' and 'UnknownRoleProperties

### DIFF
--- a/LabXml/Validator/Roles/MandatoryRoleProperties.cs
+++ b/LabXml/Validator/Roles/MandatoryRoleProperties.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Management.Automation;
 
 namespace AutomatedLab
 {
@@ -24,12 +25,14 @@ namespace AutomatedLab
                 foreach (var role in machine.Roles.Where(r => mandatoryRoleProperties.ContainsKey(r.Name.ToString())))
                 {
                     var mandatoryKeys = new List<string>();
-                    var keysFromModule = mandatoryRoleProperties[role.Name.ToString()];
+                    //var keysFromModule = mandatoryRoleProperties[role.Name.ToString()];
+                    var keysFromModule = ((object[])((PSObject)mandatoryRoleProperties[role.Name.ToString()]).BaseObject).Cast<string>().ToArray();
+
 
                     if (keysFromModule.GetType().IsArray)
-                        mandatoryKeys.AddRange(((object[])keysFromModule).Cast<string>());
+                        mandatoryKeys.AddRange(keysFromModule);
                     else
-                        mandatoryKeys.Add((string)keysFromModule);
+                        mandatoryKeys.Add(keysFromModule.FirstOrDefault());
 
 
                     foreach (string mandatoryRoleProperty in mandatoryKeys)

--- a/LabXml/Validator/Roles/UnknownRoleProperties.cs
+++ b/LabXml/Validator/Roles/UnknownRoleProperties.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Management.Automation;
 
 namespace AutomatedLab
 {
@@ -24,13 +25,14 @@ namespace AutomatedLab
                 foreach (var role in machine.Roles.Where(r => validRoleProperties.ContainsKey(r.Name.ToString())))
                 {
                     var validKeys = new List<string>();
-                    var keysFromModule = validRoleProperties[role.Name.ToString()];
+                    var keysFromModule = ((object[])((PSObject)validRoleProperties[role.Name.ToString()]).BaseObject).Cast<string>().ToArray();
 
                     if (keysFromModule.GetType().IsArray)
-                        validKeys.AddRange(((object[])keysFromModule).Cast<string>());
+                        validKeys.AddRange(keysFromModule);
                     else
-                        validKeys.Add((string)keysFromModule);
-
+                    {
+                        validKeys.Add(keysFromModule.FirstOrDefault());
+                    }
 
                     var unknownProperties = role.Properties.Keys.Where(k => !validKeys.Contains(k));
 


### PR DESCRIPTION
Validators following validators did not work anymore and have been fixed
- 'MandatoryRoleProperties'
- 'UnknownRoleProperties