### PR TITLE
New way to handle product keys

### DIFF
--- a/Assets/ProductKeys.xml
+++ b/Assets/ProductKeys.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<ListXmlStoreOfProductKey>
+
+  <ProductKey OperatingSystemName="Windows 7 Professional" Key="FJ82H-XT6CR-J8D7P-XQJJ2-GPDD4" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows 7 Enterprise" Key="33PXH-7Y6KF-2VJC9-XBBR8-HVTHH" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows 8 Pro" Key="NG4HW-VH26C-733KW-K6F98-J8CK4" Version="6.2.9200.16384" />
+  <ProductKey OperatingSystemName="Windows 8 Enterprise" Key="32JNW-9KQ84-P47T8-D8GGY-CWCK7" Version="6.2.9200.16384" />
+  <ProductKey OperatingSystemName="Windows 8.1 Pro" Key="GCRJD-8NW9H-F2CDX-CCM8D-9D6T9" Version="6.3.9600.16408" />
+  <ProductKey OperatingSystemName="Windows 8.1 Enterprise" Key="MHF9N-XY6XB-WVXMC-BTDCT-MKKG7" Version="6.3.9600.16408" />
+
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 Standard (Full Installation)" Key="YC6KT-GKW9T-YTKYR-T4X34-R7VHC" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 Standard (Server Core Installation)" Key="YC6KT-GKW9T-YTKYR-T4X34-R7VHC" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 Enterprise (Full Installation)" Key="489J6-VHDMP-X63PK-3K798-CPX3Y" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 Enterprise (Server Core Installation)" Key="489J6-VHDMP-X63PK-3K798-CPX3Y" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 Datacenter (Full Installation)" Key="74YFP-3QFB3-KQT8W-PMXWJ-7M648" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 Datacenter (Server Core Installation)" Key="74YFP-3QFB3-KQT8W-PMXWJ-7M648" Version="6.1.7601.17514" />
+
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 SERVERSTANDARD" Key="YC6KT-GKW9T-YTKYR-T4X34-R7VHC" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 SERVERSTANDARDCORE" Key="YC6KT-GKW9T-YTKYR-T4X34-R7VHC" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 SERVERENTERPRISE" Key="489J6-VHDMP-X63PK-3K798-CPX3Y" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 SERVERENTERPRISECORE" Key="489J6-VHDMP-X63PK-3K798-CPX3Y" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 SERVERDATACENTER" Key="74YFP-3QFB3-KQT8W-PMXWJ-7M648" Version="6.1.7601.17514" />
+  <ProductKey OperatingSystemName="Windows Server 2008 R2 SERVERDATACENTERCORE" Key="74YFP-3QFB3-KQT8W-PMXWJ-7M648" Version="6.1.7601.17514" />
+
+  <ProductKey OperatingSystemName="Windows Server 2012 Standard (Server Core Installation)" Key="XC9B7-NBPP2-83J2H-RHMBY-92BT4" Version="6.2.9200.16384" />
+  <ProductKey OperatingSystemName="Windows Server 2012 Standard (Server with a GUI)" Key="XC9B7-NBPP2-83J2H-RHMBY-92BT4" Version="6.2.9200.16384" />
+  <ProductKey OperatingSystemName="Windows Server 2012 Datacenter (Server Core Installation)" Key="48HP8-DN98B-MYWDG-T2DCC-8W83P" Version="6.2.9200.16384" />
+  <ProductKey OperatingSystemName="Windows Server 2012 Datacenter (Server with a GUI)" Key="48HP8-DN98B-MYWDG-T2DCC-8W83P" Version="6.2.9200.16384" />
+
+  <ProductKey OperatingSystemName="Windows Server 2012 SERVERSTANDARD" Key="XC9B7-NBPP2-83J2H-RHMBY-92BT4" Version="6.2.9200.16384" />
+  <ProductKey OperatingSystemName="Windows Server 2012 SERVERSTANDARDCORE" Key="XC9B7-NBPP2-83J2H-RHMBY-92BT4" Version="6.2.9200.16384" />
+  <ProductKey OperatingSystemName="Windows Server 2012 SERVERDATACENTER" Key="48HP8-DN98B-MYWDG-T2DCC-8W83P" Version="6.2.9200.16384" />
+  <ProductKey OperatingSystemName="Windows Server 2012 SERVERDATACENTERCORE" Key="48HP8-DN98B-MYWDG-T2DCC-8W83P" Version="6.2.9200.16384" />
+
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 Standard Evaluation (Server with a GUI)" Key="D2N9P-3P6X9-2R39C-7RTCD-MDVJX" Version="6.3.9600.17031" />
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 Standard (Server with a GUI)" Key="D2N9P-3P6X9-2R39C-7RTCD-MDVJX" Version="6.3.9600.17031" />
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 Standard (Server Core Installation)" Key="D2N9P-3P6X9-2R39C-7RTCD-MDVJX" Version="6.3.9600.17031" />
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 Standard Evaluation (Server Core Installation)" Key="D2N9P-3P6X9-2R39C-7RTCD-MDVJX" Version="6.3.9600.17031" />
+
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 Datacenter Evaluation (Server with a GUI)" Key="W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9" Version="6.3.9600.17031" />
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 Datacenter (Server with a GUI)" Key="W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9" Version="6.3.9600.17031" />
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 Datacenter Evaluation (Server Core Installation)" Key="W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9" Version="6.3.9600.17031" />
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 Datacenter (Server Core Installation)" Key="W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9" Version="6.3.9600.17031" />
+
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 SERVERSTANDARDCORE" Key="D2N9P-3P6X9-2R39C-7RTCD-MDVJX" Version="6.3.9600.17031" />
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 SERVERSTANDARD" Key="D2N9P-3P6X9-2R39C-7RTCD-MDVJX" Version="6.3.9600.17031" />
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 SERVERDATACENTERCORE" Key="W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9" Version="6.3.9600.17031" />
+  <ProductKey OperatingSystemName="Windows Server 2012 R2 SERVERDATACENTER" Key="W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9" Version="6.3.9600.17031" />
+
+  <ProductKey OperatingSystemName="Windows 10 Pro" Key="W269N-WFGWX-YVC9B-4J6C9-T83GX" Version="10.0.17134.1" />
+  <ProductKey OperatingSystemName="Windows 10 Pro for Workstations" Key="NRG8B-VKK3Q-CXVCJ-9G2XF-6Q84J" Version="10.0.17134.1" />
+  <ProductKey OperatingSystemName="Windows 10 Enterprise" Key="NPPR9-FWDCX-D2C8J-H872K-2YT43" Version="10.0.17134.1" />
+  <ProductKey OperatingSystemName="Windows 10 Enterprise Insider Preview" Key="NPPR9-FWDCX-D2C8J-H872K-2YT43" Version="10.0.17134.1" />
+  <ProductKey OperatingSystemName="Windows 10 Enterprise Evaluation" Key="NPPR9-FWDCX-D2C8J-H872K-2YT43" Version="10.0.17134.1" />
+  <ProductKey OperatingSystemName="Windows 10 Enterprise for Virtual Desktops" Key="CPWHC-NT2C7-VYW78-DHDB2-PG3GK" Version="10.0.17134.1" />
+
+  <ProductKey OperatingSystemName="Windows 10 Enterprise 2015 LTSB" Key="WNMTR-4C88C-JK8YV-HQ7T2-76DF9" Version="1.0.0.0" />
+  <ProductKey OperatingSystemName="Windows 10 Enterprise 2016 LTSB" Key="DCPHK-NFMTC-H88MJ-PFHPY-QJ4BJ" Version="1.0.0.0" />
+  <ProductKey OperatingSystemName="Windows 10 Enterprise LTSC" Key="M7XTQ-FN8P6-TTKYV-9D4CC-J462D" Version="1.0.0.0" />
+
+  <ProductKey OperatingSystemName="Windows Server 2016 Standard" Key="WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY" Version="10.0.14393.0"/>
+  <ProductKey OperatingSystemName="Windows Server 2016 Standard (Desktop Experience)" Key="WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY" Version="10.0.14393.0" />
+  <ProductKey OperatingSystemName="Windows Server 2016 Standard Evaluation" Key="WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY" Version="10.0.14393.0" />
+  <ProductKey OperatingSystemName="Windows Server 2016 Standard Evaluation (Desktop Experience)" Key="WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY" Version="10.0.14393.0" />
+  <ProductKey OperatingSystemName="Windows Server 2016 Datacenter" Key="CB7KF-BWN84-R7R2Y-793K2-8XDDG" Version="10.0.14393.0" />
+  <ProductKey OperatingSystemName="Windows Server 2016 Datacenter (Desktop Experience)" Key="CB7KF-BWN84-R7R2Y-793K2-8XDDG" Version="10.0.14393.0" />
+  <ProductKey OperatingSystemName="Windows Server 2016 Datacenter Evaluation" Key="CB7KF-BWN84-R7R2Y-793K2-8XDDG" Version="10.0.14393.0" />
+  <ProductKey OperatingSystemName="Windows Server 2016 Datacenter Evaluation (Desktop Experience)" Key="CB7KF-BWN84-R7R2Y-793K2-8XDDG" Version="10.0.14393.0" />
+
+  <ProductKey OperatingSystemName="Windows Server 2016 SERVERSTANDARD" Key="WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY" Version="10.0.14393.0" />
+  <ProductKey OperatingSystemName="Windows Server 2016 SERVERSTANDARDCORE" Key="WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY" Version="10.0.14393.0" />
+  <ProductKey OperatingSystemName="Windows Server 2016 SERVERDATACENTER" Key="CB7KF-BWN84-R7R2Y-793K2-8XDDG" Version="10.0.14393.0" />
+  <ProductKey OperatingSystemName="Windows Server 2016 SERVERDATACENTERCORE" Key="CB7KF-BWN84-R7R2Y-793K2-8XDDG" Version="10.0.14393.0" />
+
+  <ProductKey OperatingSystemName="Windows Server 2019 Standard" Key="N69G4-B89J2-4G8F4-WWYCC-J464C" Version="10.0.17763.107" />
+  <ProductKey OperatingSystemName="Windows Server 2019 Standard (Desktop Experience)" Key="N69G4-B89J2-4G8F4-WWYCC-J464C" Version="10.0.17763.107" />
+  <ProductKey OperatingSystemName="Windows Server 2019 Datacenter" Key="WMDGN-G9PQG-XVVXX-R3X43-63DFG" Version="10.0.17763.107" />
+  <ProductKey OperatingSystemName="Windows Server 2019 Datacenter (Desktop Experience)" Key="WMDGN-G9PQG-XVVXX-R3X43-63DFG" Version="10.0.17763.107" />
+
+  <ProductKey OperatingSystemName="Windows Server 2019 SERVERSTANDARDCORE" Key="N69G4-B89J2-4G8F4-WWYCC-J464C" Version="10.0.17763.107" />
+  <ProductKey OperatingSystemName="Windows Server 2019 SERVERSTANDARD" Key="N69G4-B89J2-4G8F4-WWYCC-J464C" Version="10.0.17763.107" />
+  <ProductKey OperatingSystemName="Windows Server 2019 SERVERDATACENTER" Key="WMDGN-G9PQG-XVVXX-R3X43-63DFG" Version="10.0.17763.107" />
+  <ProductKey OperatingSystemName="Windows Server 2019 SERVERDATACENTERCORE" Key="WMDGN-G9PQG-XVVXX-R3X43-63DFG" Version="10.0.17763.107" />
+
+  <!--1709-->
+  <ProductKey OperatingSystemName="Windows Server Standard" Key="DPCNP-XQFKJ-BJF7R-FRC8D-GF6G4" Version="10.0.16299.15" /> 
+  <ProductKey OperatingSystemName="Windows Server Datacenter" Key="6Y6KB-N82V8-D8CQV-23MJW-BWTG6" Version="10.0.16299.15" />
+  <ProductKey OperatingSystemName="Windows Server 2016 SERVERSTANDARDACORE" Key="DPCNP-XQFKJ-BJF7R-FRC8D-GF6G4" Version="10.0.16299.15" />
+  <ProductKey OperatingSystemName="Windows Server 2016 SERVERDATACENTERACORE" Key="6Y6KB-N82V8-D8CQV-23MJW-BWTG6" Version="10.0.16299.15" />
+  
+  <!--1803-->
+  <ProductKey OperatingSystemName="Windows Server Standard" Key="PTXN8-JFHJM-4WC78-MPCBR-9W4KR" Version="10.0.17134.1" />
+  <ProductKey OperatingSystemName="Windows Server Datacenter" Key="2HXDN-KRXHB-GPYC7-YCKFJ-7FVDG" Version="10.0.17134.1" />
+  <ProductKey OperatingSystemName="Windows Server 2016 SERVERSTANDARDACORE" Key="PTXN8-JFHJM-4WC78-MPCBR-9W4KR" Version="10.0.17134.1" />
+  <ProductKey OperatingSystemName="Windows Server 2016 SERVERDATACENTERACORE" Key="2HXDN-KRXHB-GPYC7-YCKFJ-7FVDG" Version="10.0.17134.1" />
+
+  <!--1809-->
+  <ProductKey OperatingSystemName="Windows Server Standard" Key="N2KJX-J94YW-TQVFB-DG9YT-724CC" Version="10.0.17763.107" /> 
+  <ProductKey OperatingSystemName="Windows Server Datacenter" Key="6NMRW-2C8FM-D24W7-TQWMY-CWH2D" Version="10.0.17763.107" />
+  <ProductKey OperatingSystemName="Windows Server SERVERSTANDARDACORE" Key="N2KJX-J94YW-TQVFB-DG9YT-724CC" Version="10.0.17763.107" />
+  <ProductKey OperatingSystemName="Windows Server SERVERDATACENTERACORE" Key="6NMRW-2C8FM-D24W7-TQWMY-CWH2D" Version="10.0.17763.107" />
+
+
+</ListXmlStoreOfProductKey>

--- a/AutomatedLab.sln
+++ b/AutomatedLab.sln
@@ -464,6 +464,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Assets", "Assets", "{17D0AC
 		Assets\Automated-Lab_icon256.png = Assets\Automated-Lab_icon256.png
 		Assets\Automated-Lab_icon512.png = Assets\Automated-Lab_icon512.png
 		Assets\Automated-Lab_icon64.png = Assets\Automated-Lab_icon64.png
+		Assets\ProductKeys.xml = Assets\ProductKeys.xml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WebSiteDefaultContent", "WebSiteDefaultContent", "{F8AE4BA3-E199-4E0A-A236-75EF8AB9F3CE}"

--- a/AutomatedLab/settings.psd1
+++ b/AutomatedLab/settings.psd1
@@ -52,6 +52,9 @@
         "DiskFileName"                         = "Disks.xml"
         "LabFileName"                          = "Lab.xml"        
         DefaultAddressSpace                    = '192.168.10.0/24'
+        ProductKeyFileName                     = 'ProductKeys.xml'
+        ProductKeyCustomFileName               = 'ProductKeysCustom.xml'
+        ProductKeyFileLink                     = 'https://raw.githubusercontent.com/AutomatedLab/AutomatedLab/feature/NewProductKeyHandling/Assets/ProductKeys.xml'
         "ValidationSettings"                   = @{
             "ValidRoleProperties"     = @{
                 "Orchestrator2012" = @(

--- a/AutomatedLab/settings.psd1
+++ b/AutomatedLab/settings.psd1
@@ -54,7 +54,7 @@
         DefaultAddressSpace                    = '192.168.10.0/24'
         ProductKeyFileName                     = 'ProductKeys.xml'
         ProductKeyCustomFileName               = 'ProductKeysCustom.xml'
-        ProductKeyFileLink                     = 'https://raw.githubusercontent.com/AutomatedLab/AutomatedLab/feature/NewProductKeyHandling/Assets/ProductKeys.xml'
+        ProductKeyFileLink                     = 'https://raw.githubusercontent.com/AutomatedLab/AutomatedLab/master/Assets/ProductKeys.xml'
         "ValidationSettings"                   = @{
             "ValidRoleProperties"     = @{
                 "Orchestrator2012" = @(

--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -24,9 +24,9 @@
              Value ="&quot;[POWERSHELLEXE]&quot; -NoProfile -NonInteractive -InputFormat None -ExecutionPolicy Bypass -Command &quot;&amp; Install-PackageProvider -Name nuget -Force -ea SilentlyContinue -Verbose;Install-Module Newtonsoft.Json,powershell-yaml,Datum -Force -AllowClobber -ea SilentlyContinue -ErrorVariable err -Verbose;Write-Host $$err.Exception.Message; exit 0&quot;" />
     <CustomAction Id="RunPowerShellScript" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="yes" />
     <InstallExecuteSequence>
-            <Custom Action="RunPowerShellScript" Before="InstallFinalize"><![CDATA[NOT Installed]]></Custom>
+      <Custom Action="RunPowerShellScript" Before="InstallFinalize"><![CDATA[NOT Installed]]></Custom>
     </InstallExecuteSequence>
-    
+
     <MajorUpgrade MigrateFeatures='yes' AllowSameVersionUpgrades='yes' DowngradeErrorMessage='A newer version of [ProductName] is already installed. If you are sure you want to downgrade, remove the existing installation via Programs and Features.'/>
     <Media Id='1' CompressionLevel='high' Cabinet='AutomatedLab.cab' EmbedCab='yes' />
     <Directory Id='TARGETDIR' Name='SourceDir'>
@@ -445,6 +445,17 @@
           </Directory>
         </Directory>
       </Directory>
+      <Directory Id="InstallFolder_ProgramData" Name="ProgramData">
+        <Directory Id="InstallFolder_ProgramDataAutomatedLab" Name="AutomatedLab">
+          <Directory Id="InstallFolder_ProgramDataAssets" Name="Assets">
+            <Component Id="AutomatedLabAssets" Guid="d3d29a38-766a-4a81-9a11-285d8764d89d">
+              <RegistryValue Root="HKLM" Key="Software\[Manufacturer]\[ProductName]" Type="string" Value="ALAssets"/>
+              <File Source="$(var.SolutionDir)Assets\ProductKeys.xml" />
+              <RemoveFolder Id="RemoveFolderAssets" Directory="InstallFolder_ProgramDataAssets" On="both"/>
+            </Component>
+          </Directory>
+        </Directory>
+      </Directory>
       <Directory Id="LABSOURCESVOLUME">
         <Directory Id="LABSOURCESDIR" Name="LabSources">
           <Directory Id="SAMPLESDIR" Name="Sample Scripts">
@@ -551,6 +562,7 @@
       </Directory>
     </Directory>
     <SetDirectory Id="LABSOURCESVOLUME" Value="C:\" />
+    <SetDirectory Id="InstallFolder_ProgramData" Value="[WindowsVolume]ProgramData" />
     <Feature Id='Complete' Title='AutomatedLab' Description='The complete package.' Display='expand' Level='1'>
       <Feature Id='Modules' Title='Modules' Description='AutomatedLab PowerShell Modules' Level='1'>
         <ComponentRef Id='PSFileTransferComponent'/>
@@ -581,6 +593,7 @@
         <ComponentRef Id='AutomatedLabUnattendedComponentPublic' />
         <ComponentRef Id='AutomatedLabToolsComponent'/>
         <ComponentRef Id='AutomatedLabHypervToolsComponent'/>
+        <ComponentRef Id='AutomatedLabAssets'/>
       </Feature>
       <Feature Id='LabSources' Title='Lab Sources' Description='Creates a folder structure that all samples scripts are based on and provides some lab preparation scripts.' Level='1' ConfigurableDirectory='LABSOURCESDIR'>
         <ComponentGroupRef Id='LabSourcesComponentGroup'/>

--- a/LabXml/LabXml.csproj
+++ b/LabXml/LabXml.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Machines\NetworkAdapter.cs" />
     <Compile Include="Machines\OperatingSystem.cs" />
     <Compile Include="Machines\PostInstallationActivity.cs" />
+    <Compile Include="Machines\ProductKey.cs" />
     <Compile Include="Machines\Role.cs" />
     <Compile Include="Machines\SoftwarePackage.cs" />
     <Compile Include="Machines\User.cs" />

--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -33,6 +33,15 @@ namespace AutomatedLab
             };
         private Dictionary<string, string> isoNameToAzureSku;
 
+        private static ListXmlStore<ProductKey> productKeys = null;
+        private static ListXmlStore<ProductKey> productKeysCustom = null;
+        private static string productKeysXmlFilePath = string.Format(@"{0}\{1}",
+                        System.Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                        @"AutomatedLab\Assets\ProductKeys.xml");
+        private static string productKeysCusomXmlFilePath = string.Format(@"{0}\{1}",
+                System.Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                @"AutomatedLab\Assets\ProductKeysCustom.xml");
+
         public string OperatingSystemName
         {
             get { return operatingSystemName; }
@@ -158,185 +167,19 @@ namespace AutomatedLab
         {
             get
             {
-                switch (operatingSystemName)
+                var keys = productKeys.Where(pk => pk.OperatingSystemName == operatingSystemImageName).OrderByDescending(pk => (Version)pk.Version);
+                if (keys.Count() == 0)
                 {
-                    //Windows 7
-                    case "Windows 7 Professional":
-                        return "FJ82H-XT6CR-J8D7P-XQJJ2-GPDD4";
-                    case "Windows 7 Enterprise":
-                        return "33PXH-7Y6KF-2VJC9-XBBR8-HVTHH";
-
-                    //Windows 8
-                    case "Windows 8 Pro":
-                        return "NG4HW-VH26C-733KW-K6F98-J8CK4";
-                    case "Windows 8 Enterprise":
-                        return "32JNW-9KQ84-P47T8-D8GGY-CWCK7";
-
-                    //Windows 8.1
-                    case "Windows 8.1 Pro":
-                        return "GCRJD-8NW9H-F2CDX-CCM8D-9D6T9";
-                    case "Windows 8.1 Enterprise":
-                        return "MHF9N-XY6XB-WVXMC-BTDCT-MKKG7";
-
-                    //Windows 2008 new names
-                    case "Windows Server 2008 R2 Standard (Full Installation)":
-                        return "YC6KT-GKW9T-YTKYR-T4X34-R7VHC";
-                    case "Windows Server 2008 R2 Standard (Server Core Installation)":
-                        return "YC6KT-GKW9T-YTKYR-T4X34-R7VHC";
-                    case "Windows Server 2008 R2 Enterprise (Full Installation)":
-                        return "489J6-VHDMP-X63PK-3K798-CPX3Y";
-                    case "Windows Server 2008 R2 Enterprise (Server Core Installation)":
-                        return "489J6-VHDMP-X63PK-3K798-CPX3Y";
-                    case "Windows Server 2008 R2 Datacenter (Full Installation)":
-                        return "74YFP-3QFB3-KQT8W-PMXWJ-7M648";
-                    case "Windows Server 2008 R2 Datacenter (Server Core Installation)":
-                        return "74YFP-3QFB3-KQT8W-PMXWJ-7M648";
-
-                    //Windows 2008 old names
-                    case "Windows Server 2008 R2 SERVERSTANDARD":
-                        return "YC6KT-GKW9T-YTKYR-T4X34-R7VHC";
-                    case "Windows Server 2008 R2 SERVERSTANDARDCORE":
-                        return "YC6KT-GKW9T-YTKYR-T4X34-R7VHC";
-                    case "Windows Server 2008 R2 SERVERENTERPRISE":
-                        return "489J6-VHDMP-X63PK-3K798-CPX3Y";
-                    case "Windows Server 2008 R2 SERVERENTERPRISECORE":
-                        return "489J6-VHDMP-X63PK-3K798-CPX3Y";
-                    case "Windows Server 2008 R2 SERVERDATACENTER":
-                        return "74YFP-3QFB3-KQT8W-PMXWJ-7M648";
-                    case "Windows Server 2008 R2 SERVERDATACENTERCORE":
-                        return "74YFP-3QFB3-KQT8W-PMXWJ-7M648";
-
-                    //Windows Server 2012 new names
-                    case "Windows Server 2012 Standard (Server Core Installation)":
-                        return "XC9B7-NBPP2-83J2H-RHMBY-92BT4";
-                    case "Windows Server 2012 Standard (Server with a GUI)":
-                        return "XC9B7-NBPP2-83J2H-RHMBY-92BT4";
-                    case "Windows Server 2012 Datacenter (Server Core Installation)":
-                        return "48HP8-DN98B-MYWDG-T2DCC-8W83P";
-                    case "Windows Server 2012 Datacenter (Server with a GUI)":
-                        return "48HP8-DN98B-MYWDG-T2DCC-8W83P";
-
-                    //Windows Server 2012 new names
-                    case "Windows Server 2012 SERVERSTANDARDCORE":
-                        return "XC9B7-NBPP2-83J2H-RHMBY-92BT4";
-                    case "Windows Server 2012 SERVERSTANDARD":
-                        return "XC9B7-NBPP2-83J2H-RHMBY-92BT4";
-                    case "Windows Server 2012 SERVERDATACENTERCORE":
-                        return "48HP8-DN98B-MYWDG-T2DCC-8W83P";
-                    case "Windows Server 2012 SERVERDATACENTER":
-                        return "48HP8-DN98B-MYWDG-T2DCC-8W83P";
-
-                    //Windows Server 2012 R2 new names
-                    case "Windows Server 2012 R2 Standard (Server Core Installation)":
-                        return "D2N9P-3P6X9-2R39C-7RTCD-MDVJX";
-                    case "Windows Server 2012 R2 Standard Evaluation (Server Core Installation)":
-                        return "D2N9P-3P6X9-2R39C-7RTCD-MDVJX";
-
-                    case "Windows Server 2012 R2 Standard (Server with a GUI)":
-                        return "D2N9P-3P6X9-2R39C-7RTCD-MDVJX";
-                    case "Windows Server 2012 R2 Standard Evaluation (Server with a GUI)":
-                        return "D2N9P-3P6X9-2R39C-7RTCD-MDVJX";
-
-                    case "Windows Server 2012 R2 Datacenter (Server Core Installation)":
-                        return "W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9";
-                    case "Windows Server 2012 R2 Datacenter Evaluation (Server Core Installation)":
-                        return "W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9";
-
-                    case "Windows Server 2012 R2 Datacenter (Server with a GUI)":
-                        return "W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9";
-                    case "Windows Server 2012 R2 Datacenter Evaluation (Server with a GUI)":
-                        return "W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9";
-
-                    //Windows Server 2012 R2 old names
-                    case "Windows Server 2012 R2 SERVERSTANDARDCORE":
-                        return "D2N9P-3P6X9-2R39C-7RTCD-MDVJX";
-                    case "Windows Server 2012 R2 SERVERSTANDARD":
-                        return "D2N9P-3P6X9-2R39C-7RTCD-MDVJX";
-                    case "Windows Server 2012 R2 SERVERDATACENTERCORE":
-                        return "W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9";
-                    case "Windows Server 2012 R2 SERVERDATACENTER":
-                        return "W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9";
-
-                    //Windows 10
-                    case "Windows 10 Pro":
-                        return "W269N-WFGWX-YVC9B-4J6C9-T83GX";
-                    case "Windows 10 Pro for Workstations":
-                        return "W269N-WFGWX-YVC9B-4J6C9-T83GX";
-                    case "Windows 10 Enterprise":
-                        return "NPPR9-FWDCX-D2C8J-H872K-2YT43";
-                    case "Windows 10 Enterprise Evaluation":
-                        return "NPPR9-FWDCX-D2C8J-H872K-2YT43";
-                    case "Windows 10 Enterprise Insider Preview":
-                        return "NPPR9-FWDCX-D2C8J-H872K-2YT43";
-                    case "Windows 10 Pro Insider Preview":
-                        return "W269N-WFGWX-YVC9B-4J6C9-T83GX";
-                    case "Windows 10 Enterprise 2015 LTSB":
-                        return "WNMTR-4C88C-JK8YV-HQ7T2-76DF9";
-                    case "Windows 10 Enterprise 2016 LTSB":
-                        return "DCPHK-NFMTC-H88MJ-PFHPY-QJ4BJ";
-                    case "Windows 10 Enterprise for Virtual Desktops":
-                        return "CPWHC-NT2C7-VYW78-DHDB2-PG3GK";
-
-                    //Windows Server 2016 new names
-                    case "Windows Server 2016 Standard":
-                        return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
-                    case "Windows Server 2016 Standard (Desktop Experience)":
-                        return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
-
-                    case "Windows Server 2016 Datacenter":
-                        return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
-                    case "Windows Server 2016 Datacenter (Desktop Experience)":
-                        return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
-
-                    case "Windows Server 2016 Standard Evaluation":
-                        return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
-                    case "Windows Server 2016 Standard Evaluation (Desktop Experience)":
-                        return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
-
-                    case "Windows Server 2016 Datacenter Evaluation":
-                        return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
-                    case "Windows Server 2016 Datacenter Evaluation (Desktop Experience)":
-                        return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
-
-                    //Windows Server 2016 old names
-                    case "Windows Server 2016 SERVERSTANDARDCORE":
-                        return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
-                    case "Windows Server 2016 SERVERSTANDARD":
-                        return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
-                    case "Windows Server 2016 SERVERDATACENTERCORE":
-                        return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
-                    case "Windows Server 2016 SERVERDATACENTER":
-                        return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
-
-                    // Windows Server 1709+ new names
-                    case "Windows Server Standard":
-                        return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
-                    case "Windows Server Standard (Desktop Experience)":
-                        return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
-
-                    case "Windows Server Datacenter":
-                        return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
-                    case "Windows Server Datacenter (Desktop Experience)":
-                        return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
-
-                    // Windows Server 1709+ old names
-                    case "Windows Server 2016 SERVERSTANDARDACORE":
-                        return "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY";
-                    case "Windows Server 2016 SERVERDATACENTERACORE":
-                        return "CB7KF-BWN84-R7R2Y-793K2-8XDDG";
-
-                    // Windows Server 2019 new names
-                    case "Windows Server 2019 Standard (Desktop Experience)":
-                        return "N69G4-B89J2-4G8F4-WWYCC-J464C";
-                    case "Windows Server 2019 Datacenter (Desktop Experience)":
-                        return "WMDGN-G9PQG-XVVXX-R3X43-63DFG";
-                    case "Windows Server 2019 Standard":
-                        return "N69G4-B89J2-4G8F4-WWYCC-J464C";
-                    case "Windows Server 2019 Datacenter":
-                        return "WMDGN-G9PQG-XVVXX-R3X43-63DFG";
-
-                    default:
-                        return string.Empty;
+                    return "";
+                }
+                else if (keys.Count() == 1)
+                {
+                    return keys.FirstOrDefault().Key;
+                }
+                else
+                {
+                    keys = keys.Where(pk => pk.Version >= version).OrderByDescending(pk => (Version)pk.Version);
+                    return keys.Last().Key;
                 }
             }
         }
@@ -381,6 +224,50 @@ namespace AutomatedLab
             catch (KeyNotFoundException)
             {
                 // OS not in dictionary - can happen
+            }
+        }
+
+        static OperatingSystem()
+        {
+            try
+            {
+                productKeys = ListXmlStore<ProductKey>.Import(productKeysXmlFilePath);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(string.Format("Could not read 'ProductKeys.xml' file. Make sure the file exist in path '{0}': {1}", productKeysXmlFilePath, ex.Message));
+            }
+
+            try
+            {
+                productKeysCustom = ListXmlStore<ProductKey>.Import(productKeysCusomXmlFilePath);
+            }
+            catch (Exception)
+            {
+                //don't throw, the file is not mandatory
+            }
+
+            //merge keys from custom file
+            foreach (var key in productKeysCustom)
+            {
+                var existingKey = productKeys.Where(pk => pk.OperatingSystemName == key.OperatingSystemName && pk.Version == key.Version);
+                if (existingKey.Count() == 0)
+                {
+                    productKeys.Add(new ProductKey()
+                    {
+                        OperatingSystemName = key.OperatingSystemName,
+                        Version = key.Version,
+                        Key = key.Key
+                    });
+                }
+                else if (existingKey.Count() == 1)
+                {
+                    existingKey.First().Key = key.Key;
+                }
+                else
+                {
+
+                }
             }
         }
 
@@ -446,7 +333,7 @@ namespace AutomatedLab
         {
             get
             {
-                return ((bool)(OperatingSystemName.Contains("Windows"))) ? OperatingSystemType.Windows : OperatingSystemType.Linux;
+                return OperatingSystemName.Contains("Windows") ? OperatingSystemType.Windows : OperatingSystemType.Linux;
             }
         }
         public string OperatingSystemImageName

--- a/LabXml/Machines/ProductKey.cs
+++ b/LabXml/Machines/ProductKey.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace AutomatedLab
+{
+    [Serializable]
+    public class ProductKey
+    {
+        [XmlAttribute]
+        public string OperatingSystemName { get; set; }
+
+        [XmlAttribute]
+        public string Key { get; set; }
+
+        [XmlAttribute]
+        public string Version { get; set; }
+
+        public override string ToString()
+        {
+            return Key;
+        }
+    }
+}


### PR DESCRIPTION
It was quite uncomfortable to manage the product keys in the C# code. Product Keys are not in ProgramData\AutomatedLab\Assets\ProductKey.xml. The is also the file ProductKeyCustom.xml to give users a better way to add custom product keys to the solution.