### PR TITLE
Fix the chaos from merging master into develop

### DIFF
--- a/AutomatedLab/AutomatedLabADDS.psm1
+++ b/AutomatedLab/AutomatedLabADDS.psm1
@@ -827,27 +827,27 @@ function Install-LabRootDcs
                 $domainFunctionalLevel = $dcRole.Properties.DomainFunctionalLevel
             }
 
-            $netBiosDomainName = if ($rootDcRole.Properties.ContainsKey('NetBiosDomainName'))
+            $netBiosDomainName = if ($dcRole.Properties.ContainsKey('NetBiosDomainName'))
             {
-                $rootDcRole.Properties.NetBiosDomainName
+                $dcRole.Properties.NetBiosDomainName
             }
             else
             {
                 $machine.DomainName.Substring(0, $machine.DomainName.IndexOf('.'))
             }
 
-            $databasePath = if ($rootDcRole.Properties.ContainsKey('DatabasePath'))
+            $databasePath = if ($dcRole.Properties.ContainsKey('DatabasePath'))
             {
-                $rootDcRole.Properties.DatabasePath
+                $dcRole.Properties.DatabasePath
             }
             else
             {
                 'C:\Windows\NTDS'
             }
 
-            $logPath = if ($rootDcRole.Properties.ContainsKey('LogPath'))
+            $logPath = if ($dcRole.Properties.ContainsKey('LogPath'))
             {
-                $rootDcRole.Properties.LogPath
+                $dcRole.Properties.LogPath
             }
             else
             {

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -59,7 +59,7 @@ function New-LWHypervVM
     Import-UnattendedContent -Content $Machine.UnattendedXmlContent
     
     #region network adapter settings
-    $macAddressPrefix = (Get-Module -Name AutomatedLab)[0].PrivateData.MacAddressPrefix
+    $macAddressPrefix = Get-LabConfigurationItem -Name MacAddressPrefix
     $macAddressesInUse = @(Get-VM | Get-VMNetworkAdapter | Select-Object -ExpandProperty MacAddress)
     $macAddressesInUse += (Get-LabVm -IncludeLinux).NetworkAdapters.MacAddress
 
@@ -198,13 +198,13 @@ function New-LWHypervVM
         Set-UnattendedAutoLogon -DomainName $Machine.Name -Username $Machine.InstallationUser.Username -Password $Machine.InstallationUser.Password
     }
 
-    $disableWindowsDefender = (Get-Module -Name AutomatedLab)[0].PrivateData.DisableWindowsDefender
+    $disableWindowsDefender = Get-LabConfigurationItem -Name DisableWindowsDefender
     if (-not $disableWindowsDefender)
     {
         Set-UnattendedAntiMalware -Enabled $false
     }
 
-    $setLocalIntranetSites = (Get-Module -Name AutomatedLab)[0].PrivateData.SetLocalIntranetSites
+    $setLocalIntranetSites = Get-LabConfigurationItem -Name SetLocalIntranetSites
     if ($setLocalIntranetSites -ne 'None' -or $setLocalIntranetSites -ne $null)
     {
         if ($setLocalIntranetSites -eq 'All')
@@ -267,7 +267,7 @@ function New-LWHypervVM
     #set the Generation for the VM depending on SupportGen2VMs, host OS version and VM OS version
     $hostOsVersion = [System.Version](Get-CimInstance -ClassName Win32_OperatingSystem).Version
 
-    $generation = if ($PSCmdlet.MyInvocation.MyCommand.Module.PrivateData.SupportGen2VMs)
+    $generation = if (Get-LabConfigurationItem -Name SupportGen2VMs)
     {
         if ($hostOsVersion -ge [System.Version]6.3 -and $Machine.Gen2VmSupported)
         {


### PR DESCRIPTION
Master and develop had diverged due to a community PR targeting master instead of develop.
Merging master into develop to get the development branch up to date undid some of the work done.
Reapplied:
- Some instances of Get-LabConfigurationItem missing
- Variable rename in AutomatedLabADDS.psm1 reapplied