### PR TITLE
Sync lab sources to Azure (Fixes #226)

### DIFF
--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -258,13 +258,13 @@ Have a look at Get-Command -Syntax Sync-LabAzureLabSources for additional inform
 "@
         $choice = Read-Choice -ChoiceList '&Yes','&No, do not ask me again', 'N&o, not this time' -Caption 'Sync lab sources to Azure?' -Message $syncText -Default 0
 
-        if ($choice -eq 'Yes')
+        if ($choice -eq 0)
         {
             Sync-LabAzureLabSources -MaxFileSizeInMb $syncMaxSize
             $timestamps.LabSourcesSynced = Get-Date
             $timestamps.ExportToRegistry('Cache', 'Timestamps')
         }
-        elseif ($choice -eq 'No, never')
+        elseif ($choice -eq 1)
         {
             $timestamps.LabSourcesSynced = [datetime]::MaxValue
             $timestamps.ExportToRegistry('Cache', 'Timestamps')

--- a/AutomatedLab/settings.psd1
+++ b/AutomatedLab/settings.psd1
@@ -242,6 +242,7 @@
         #Azure
         MinimumAzureModuleVersion              = '1.0'
         DefaultAzureRoleSize                   = 'D'
+        LabSourcesMaxFileSizeMb                = 50
 
         #Office
         OfficeDeploymentTool                   = 'https://download.microsoft.com/download/2/7/A/27AF1BE6-DD20-4CB4-B154-EBAB8A7D4A7E/officedeploymenttool_11107-33602.exe'


### PR DESCRIPTION
Added functionality to auto-sync lab sources if never synced before. A new configuration item is introduced to settings.psd1 to control the file size for this auto-sync.

The auto-sync can be disabled completely when asked for the first time, setting the time stamp to [datetime]::MaxValue. If the sync is enabled, it will be attempted every 60 days. If it is disabled once, the user will simply get asked when executing their next lab.