### PR TITLE
Added default parameter to Get-LabConfigurationItem

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -4027,7 +4027,10 @@ function Get-LabConfigurationItem
 
         [Parameter()]
         [string]
-        $UserPath = (Join-Path -Path $home -ChildPath 'AutomatedLab\settings.psd1')
+        $UserPath = (Join-Path -Path $home -ChildPath 'AutomatedLab\settings.psd1'),
+
+        [Parameter()]
+        $Default
     )
 
     if (-not (Test-Path -Path $userPath))
@@ -4062,6 +4065,11 @@ DatumStructure:
     # Return
     if ($Name)
     {
+        if ($null -eq $settings[$Name] -and $null -ne $Default)
+        {
+            return $Default
+        }
+
         return $settings[$Name]
     }
 


### PR DESCRIPTION
When no configuration item is present for some reason and we still want a default.

Usage:
```Get-LabConfigurationItem -Name doesnotexist -Default 500``` will return 500 if no element can be found and the actual value if an element exists.