### PR TITLE
New TFS agent can use SChannel backend

### DIFF
--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -212,7 +212,7 @@ function Install-LabBuildWorker
 
     $buildWorkerUri = Get-LabConfigurationItem -Name BuildAgentUri
     $buildWorkerPath = Join-Path -Path $labsources -ChildPath Tools\TfsBuildWorker.zip
-    $download = Get-LabInternetFile -Uri $buildWorkerUri -Path $buildWorkerPath -PassThru
+    $download = Get-LabInternetFile -Uri $buildWorkerUri -Path $buildWorkerPath -PassThru -Force
     Copy-LabFileItem -ComputerName $buildWorkers -Path $download.Path
 
     $installationJobs = @()

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -265,11 +265,11 @@ function Install-LabBuildWorker
             $commandLine = if ($useSsl)
             {
 				#sslskipcertvalidation is used as git.exe could not test the certificate chain
-                '--unattended --url https://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --sslskipcertvalidation' -f $machineName, $tfsPort, $env:COMPUTERNAME
+                '--unattended --url https://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --sslskipcertvalidation --gituseschannel' -f $machineName, $tfsPort, $env:COMPUTERNAME
             }
             else
             {
-                '--unattended --url http://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice' -f $machineName, $tfsPort, $env:COMPUTERNAME
+                '--unattended --url http://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --gituseschannel' -f $machineName, $tfsPort, $env:COMPUTERNAME
             }
 
             $configurationProcess = Start-Process -FilePath $configurationTool -ArgumentList $commandLine -Wait -NoNewWindow -PassThru


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

New agent installation option --gituseschannel added. Added Force parameter to download of TFS build agent to always get the latest version and not skip forever. Updated build agent will work on all of our supported TFS versions.

[ x ] - I have tested my changes.  
[ x ] - The PR has a meaningful title.  
[ x ] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->
[  ] Bug fix  
[ x ] New functionality  
[  ] Breaking change

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Ran the DSC workshop lab. According to the documentation [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/certificate?view=azure-devops-2019#git-get-sources-fails-with-ssl-certificate-problem-windows-agent-only) the current TFS agent that can be downloaded contains a version of git that can make use of SChannel on Windows, enabling us to use our Lab CA certificates, self-signed certs and more without any issues.