### PR TITLE
Fixing random XML Serialization corruptions by removing the old file first

### DIFF
--- a/LabXml/Stores/DictionaryXmlStore.cs
+++ b/LabXml/Stores/DictionaryXmlStore.cs
@@ -22,10 +22,12 @@ namespace AutomatedLab
 
         public void Export(string path)
         {
+            File.Delete(path);
+
             var serializer = new XmlSerializer(GetType());
             var xmlNamespace = new XmlSerializerNamespaces();
             xmlNamespace.Add(string.Empty, string.Empty);
-            FileStream fileStream = new FileStream(path, FileMode.OpenOrCreate);
+            FileStream fileStream = new FileStream(path, FileMode.CreateNew);
 
             serializer.Serialize(fileStream, this, xmlNamespace);
 

--- a/LabXml/Stores/ListXmlStore.cs
+++ b/LabXml/Stores/ListXmlStore.cs
@@ -25,8 +25,10 @@ namespace AutomatedLab
 
         public void Export(string path)
         {
+            File.Delete(path);
+
             var serializer = new XmlSerializer(typeof(ListXmlStore<T>));
-            var fileStream = new FileStream(path, FileMode.OpenOrCreate);
+            var fileStream = new FileStream(path, FileMode.CreateNew);
             var xmlNamespace = new XmlSerializerNamespaces();
             xmlNamespace.Add(string.Empty, string.Empty);
 

--- a/LabXml/Stores/XmlStore.cs
+++ b/LabXml/Stores/XmlStore.cs
@@ -42,10 +42,12 @@ namespace AutomatedLab
 
         public void Export(string path)
         {
+            File.Delete(path);
+
             var serializer = new XmlSerializer(typeof(T));
             var xmlNamespace = new XmlSerializerNamespaces();
             xmlNamespace.Add(string.Empty, string.Empty);
-            var fileStream = new FileStream(path, FileMode.OpenOrCreate);
+            var fileStream = new FileStream(path, FileMode.CreateNew);
 
             serializer.Serialize(fileStream, this, xmlNamespace);
 


### PR DESCRIPTION
## Description

We have seen the curruptions since day 1 of AL. Somehow, in some cases, the .net serialization used content in the existing file and merged it with the new data creating malformed XML. This did no longer happen after removing the old XML file first.

- [X] - I have tested my changes.  
- [X] - The PR has a meaningful title.  
- [X] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [X] Bug fix  
- [ ] New functionality  
- [ ] Breaking change

## How was the change tested?
A bunch of test lab setups.
