### PR TITLE
Fix missing2019 (Fixes #622)

### DIFF
--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -26,7 +26,7 @@ namespace AutomatedLab
             {"2016-Datacenter", "Windows Server 2016 Datacenter (Desktop Experience)" },
             {"2016-Datacenter-Server-Core", "Windows Server 2016 Datacenter" },
             {"2019-Datacenter", "Windows Server 2019 Datacenter (Desktop Experience)" },
-            {"2019-Datacenter-Server-Core", "Windows Server 2019 Datacenter" },
+            {"2019-Datacenter-Core", "Windows Server 2019 Datacenter" },
             {"Datacenter-Core-1803-with-Containers-smalldisk", "Windows Server Datacenter" },
             {"Win81-Ent-N-x64", "Windows 8.1 Enterprise" },
             {"Windows-10-N-x64", "Windows 10 Enterprise" },

--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -25,6 +25,8 @@ namespace AutomatedLab
             {"2012-R2-Datacenter", "Windows Server 2012 R2 Datacenter (Server with a GUI)" },
             {"2016-Datacenter", "Windows Server 2016 Datacenter (Desktop Experience)" },
             {"2016-Datacenter-Server-Core", "Windows Server 2016 Datacenter" },
+            {"2019-Datacenter", "Windows Server 2019 Datacenter (Desktop Experience)" },
+            {"2019-Datacenter-Server-Core", "Windows Server 2019 Datacenter" },
             {"Datacenter-Core-1803-with-Containers-smalldisk", "Windows Server Datacenter" },
             {"Win81-Ent-N-x64", "Windows 8.1 Enterprise" },
             {"Windows-10-N-x64", "Windows 10 Enterprise" },


### PR DESCRIPTION
## Description

Added two additional hashtable keys to map Azure image SKU to AutomatedLab OS name.

- [x] - I have tested my changes.  
- [X] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [X] Bug fix  
- [ ] New functionality  
- [ ] Breaking change

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Small lab with one Server 2019 Core and one Server 2019 GUI.