### PR TITLE
Test-LabHostConnected throws where it should not

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -4127,9 +4127,9 @@ function Test-LabHostConnected
         $Quiet
     )
 
-    [bool]$connected = if (Get-Command Get-NetConnectionProfile -ErrorAction SilentlyContinue)
+    $connected = if (Get-Command Get-NetConnectionProfile -ErrorAction SilentlyContinue)
     {
-        (Get-NetConnectionProfile | Where {$_.IPv4Connectivity -eq 'Internet' -or $_.IPv6Connectivity -eq 'Internet'})
+        (Get-NetConnectionProfile | Where-Object {$_.IPv4Connectivity -eq 'Internet' -or $_.IPv6Connectivity -eq 'Internet'})
     }
 
     if ($null -eq $connected)


### PR DESCRIPTION
Quick fix, somehow this did not come up before