### PR TITLE
[Possibly breaking change] Added proper port mapping

### DIFF
--- a/AutomatedLab/AutomatedLabDsc.psm1
+++ b/AutomatedLab/AutomatedLabDsc.psm1
@@ -193,7 +193,9 @@ function Install-LabDscPullServer
         if ($machine.DefaultVirtualizationEngine -eq 'Azure')
         {
             Write-Verbose -Message ('Adding external port 8080 to Azure load balancer')
-            Add-LWAzureLoadBalancedPort -Port 8080 -ComputerName $machine -ErrorAction SilentlyContinue
+            (Get-Lab).AzureSettings.LoadBalancerPortCounter++
+            $remotePort = (Get-Lab).AzureSettings.LoadBalancerPortCounter
+            Add-LWAzureLoadBalancedPort -Port $remotePort -DestinationPort 8080 -ComputerName $machine -ErrorAction SilentlyContinue
         }
 
         Request-LabCertificate -Subject "CN=$machine" -TemplateName DscMofEncryption -ComputerName $machine -PassThru | Out-Null

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -266,11 +266,11 @@ function Install-LabBuildWorker
             $commandLine = if ($useSsl)
             {
                 #sslskipcertvalidation is used as git.exe could not test the certificate chain
-                '--unattended --url https://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --sslskipcertvalidation --gituseschannel' -f $machineName, $tfsPort.Value, $env:COMPUTERNAME
+                '--unattended --url https://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --sslskipcertvalidation --gituseschannel' -f $machineName, $tfsPort.DestinationPort, $env:COMPUTERNAME
             }
             else
             {
-                '--unattended --url http://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --gituseschannel' -f $machineName, $tfsPort.Value, $env:COMPUTERNAME
+                '--unattended --url http://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --gituseschannel' -f $machineName, $tfsPort.DestinationPort, $env:COMPUTERNAME
             }
 
             $configurationProcess = Start-Process -FilePath $configurationTool -ArgumentList $commandLine -Wait -NoNewWindow -PassThru

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
@@ -464,7 +464,7 @@ function Get-LabAzureLoadBalancedPort
         return
     }
 
-    if ($DestinationPort -and $Port)
+    $ports = if ($DestinationPort -and $Port)
     {
         $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -eq "AdditionalPort-$Port-$DestinationPort"
     }
@@ -479,5 +479,13 @@ function Get-LabAzureLoadBalancedPort
     else
     {
         $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -like 'AdditionalPort*'
+    }
+
+    $ports | Foreach-Object {
+        [pscustomobject]@{
+            Port = ($_.Key -split '-')[1]
+            DestinationPort = ($_.Key -split '-')[2]
+            ComputerName = $machine.Name
+        }
     }
 }

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
@@ -322,9 +322,13 @@ function Add-LWAzureLoadBalancedPort
 {
     param
     (
-        [Parameter()]
-        [int]
+        [Parameter(Mandatory)]
+        [uint16]
         $Port,
+
+        [Parameter(Mandatory)]
+        [uint16]
+        $DestinationPort,
 
         [Parameter(Mandatory)]
         [string]
@@ -335,14 +339,13 @@ function Add-LWAzureLoadBalancedPort
 
     if (Get-LabAzureLoadBalancedPort @PSBoundParameters)
     {
-        Write-Verbose -Message ('Port {0} already configured for {1}' -f $Port, $ComputerName)
+        Write-Verbose -Message ('Port {0} -> {1} already configured for {2}' -f $Port, $DestinationPort, $ComputerName)
         return
     }
 
     $lab = Get-Lab
-    $resourceGroup = $lab.Name
+    $resourceGroup = (Get-LabAzureDefaultResourceGroup).ResourceGroupName
     $machine = Get-LabVm -ComputerName $ComputerName
-
 
     $lb = Get-AzLoadBalancer -ResourceGroupName $resourceGroup -WarningAction SilentlyContinue
     if (-not $lb)
@@ -353,14 +356,7 @@ function Add-LWAzureLoadBalancedPort
 
     $frontendConfig = $lb | Get-AzLoadBalancerFrontendIpConfig
 
-    $lab.AzureSettings.LoadBalancerPortCounter++
-    $remotePort = $lab.AzureSettings.LoadBalancerPortCounter
-
-    if (-not $Port)
-    {
-        $Port = $remotePort
-    }
-    $lb = Add-AzLoadBalancerInboundNatRuleConfig -LoadBalancer $lb -Name "$($machine.Name.ToLower())$Port" -FrontendIpConfiguration $frontendConfig -Protocol Tcp -FrontendPort $remotePort -BackendPort $Port
+    $lb = Add-AzLoadBalancerInboundNatRuleConfig -LoadBalancer $lb -Name "$($machine.Name.ToLower())-$Port-$DestinationPort" -FrontendIpConfiguration $frontendConfig -Protocol Tcp -FrontendPort $Port -BackendPort $DestinationPort
     $lb = $lb | Set-AzLoadBalancer
 
     $vm = Get-AzVM -ResourceGroupName $resourceGroup -Name $ComputerName
@@ -369,12 +365,12 @@ function Add-LWAzureLoadBalancedPort
     $nic.IpConfigurations[0].LoadBalancerInboundNatRules = $rules
     [void] ($nic | Set-AzNetworkInterface)
 
-    if (-not $machine.InternalNotes."AdditionalPort$Port")
+    if (-not $machine.InternalNotes."AdditionalPort-$Port-$DestinationPort")
     {
-        $machine.InternalNotes.Add("AdditionalPort$Port", $remotePort)
+        $machine.InternalNotes.Add("AdditionalPort-$Port-$DestinationPort", $DestinationPort)
     }
 
-    $machine.InternalNotes."AdditionalPort$Port" = $remotePort
+    $machine.InternalNotes."AdditionalPort-$Port-$DestinationPort" = $DestinationPort
 
     Export-Lab
 }
@@ -383,9 +379,13 @@ function Get-LWAzureLoadBalancedPort
 {
     param
     (
-
-        [int]
+        [Parameter()]
+        [uint16]
         $Port,
+
+        [Parameter()]
+        [uint16]
+        $DestinationPort,
 
         [Parameter(Mandatory)]
         [string]
@@ -404,30 +404,42 @@ function Get-LWAzureLoadBalancedPort
         return
     }
 
-    $existingConfiguration = if ($Port)
-    {
-        $lb | Get-AzLoadBalancerInboundNatRuleConfig | Where-Object -Property Name -eq "$ComputerName$Port"
-    }
-    else
-    {
-        $lb | Get-AzLoadBalancerInboundNatRuleConfig | Where-Object -Property Name -like "$ComputerName*"
-    }
+    $existingConfiguration = $lb | Get-AzLoadBalancerInboundNatRuleConfig
 
-
+    # Port müssen unique sein, destination port + computername müssen unique sein
     if ($Port)
     {
-        return ($existingConfiguration | Where-Object -Property BackendPort -eq $Port)
+        $filteredRules = $existingConfiguration | Where-Object -Property FrontendPort -eq $Port
+
+        if (($filteredRules | Where-Object Name -notlike "$ComputerName*"))
+        {
+            $err = ($filteredRules | Where-Object Name -notlike "$ComputerName*")[0].Name
+            $existingComputer = $err.Substring(0, $err.IndexOf('-'))
+            Write-Error -Message ("Incoming port {0} is already mapped to {1}!" -f $Port, $existingComputer)
+            return
+        }
+
+        return $filteredRules
+    }
+    
+    if ($DestinationPort)
+    {
+        return ($existingConfiguration | Where-Object {$_.BackendPort -eq $DestinationPort -and $_.Name -like "$ComputerName*"})
     }
 
-    return $existingConfiguration
+    return ($existingConfiguration | Where-Object -Property Name -like "$ComputerName*")
 }
 
 function Get-LabAzureLoadBalancedPort
 {
     param
     (
-        [int]
+        [Parameter()]
+        [uint16]
         $Port,
+
+        [uint16]
+        $DestinationPort,
 
         [Parameter(Mandatory)]
         [string]
@@ -452,12 +464,20 @@ function Get-LabAzureLoadBalancedPort
         return
     }
 
-    if ($Port)
+    if ($DestinationPort -and $Port)
     {
-        $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -eq "AdditionalPort$Port" | Select-Object -ExpandProperty Value
+        $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -eq "AdditionalPort-$Port-$DestinationPort"
+    }
+    elseif ($DestinationPort)
+    {
+        $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -like "AdditionalPort-*-$DestinationPort"
+    }
+    elseif ($Port)
+    {
+        $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -like "AdditionalPort-$Port-*"
     }
     else
     {
-        $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -like 'AdditionalPort*' | Select-Object -ExpandProperty Value
+        $machine.InternalNotes.GetEnumerator() | Where-Object -Property Key -like 'AdditionalPort*'
     }
 }

--- a/LabSources/CustomRoles/ProGet5/HostStart.ps1
+++ b/LabSources/CustomRoles/ProGet5/HostStart.ps1
@@ -33,7 +33,7 @@ else
     Write-ScreenInfo ".net Versions installed on '$proGetServer' are '$($installedDotnetVersion.Version -join ', ')', skipping .net Framework 4.5.2 installation"
 }
 
-if (-not (Test-LabMachineInternetConnectivity -ComputerName (Get-LabVM -Role Routing)))
+if (-not (Test-LabMachineInternetConnectivity -ComputerName $proGetServer))
 {
     Write-Error "The lab is not connected to the internet. Internet connectivity is required to install ProGet. Check the configuration on the machines with the Routing role."
     return
@@ -158,7 +158,7 @@ while (-not $isActivated -and $activationRetries -gt 0)
         iisreset.exe | Out-Null
 
         Start-Sleep -Seconds 30
-        Invoke-WebRequest -Uri http://localhost:80
+        Invoke-WebRequest -Uri http://localhost:80 -UseBasicParsing
         Start-Sleep -Seconds 30
 
     } -NoDisplay


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Custom load-balanced ports are now better controllable with the new Port and DestinationPort parameters. It will be ensured that the port is unique for a load balancer and that the destination port is unique for a VM. The inbound NAT rules will have an updated naming scheme Machine-Port-DestinationPort

- [x] - I have tested my changes.  
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
Possibly a breaking change if people use Add-LWAzureLoadBalancedPort and Get-LWAzureLoadBalancedPort in their own functions.

- [ ] Bug fix  
- [x] New functionality  
- [x] Breaking change

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
```powershell
Describe "tests" {

    Context "New port" {
    It "Should not throw when new port is created" {
            {Add-LWAzureLoadBalancedPort -Port 1234 -DestinationPort 80 -ComputerName POSHWeb1} | Should -Not -Throw
            
        }
    It "Should return proper load balancer rule set" {
        (Get-LWAzureLoadBalancedPort -ComputerName POSHweb1 -port 1234 -DestinationPort 80).Name | Should -Be "POSHWEB1-1234-80"
    }

    It "Should return the load balanced port" {
        (Get-LabAzureLoadBalancedPort -ComputerName poshweb1 -port 1234 -destinationport 80).Key | Should -be "AdditionalPort-1234-80"
    }
    }

    Context "Existing Port" {
        It "Should throw when existing incoming port (bound to another machine) is used" {
            {Add-LWAzureLoadBalancedPort -Port 1234 -DestinationPort 80 -ComputerName POSHFS1 -ErrorAction Stop} | Should -Throw
        }

        It "Should do nothing if incoming and destination port are bound to correct machine" {
            {Add-LWAzureLoadBalancedPort -Port 1234 -DestinationPort 80 -ComputerName POSHWeb1} | Should -Not -Throw
        }
    }
}
```