### PR TITLE
Offline env should not throw (Fixes #641)

### DIFF
--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -1031,7 +1031,7 @@ function Test-LabPathIsOnLabAzureLabSourcesStorage
         [string]$Path
     )
     
-    Test-LabHostConnected -Throw -Quiet
+    if (-not (Test-LabHostConnected -Quiet)) { return $false }
 
     try
     {

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
@@ -446,8 +446,6 @@ function Get-LabAzureLoadBalancedPort
         $ComputerName
     )
 
-    Test-LabHostConnected -Throw -Quiet
-
     $lab = Get-Lab -ErrorAction SilentlyContinue
 
     if (-not $lab)


### PR DESCRIPTION
## Description

Test-LabPathIsOnLabAzureLabSourceStorage used Test-LabHostConnected -Throw when it should have been just quiet. Cmdlet now returns false if the host is not connected when testing if a path is on Azure.

- [x] - I have tested my changes.  
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Unplugged network, deployed Hyper-V lab. Without change, deployment immediately failed, with change, deployment worked as intended.