### PR TITLE
Azure: TFS Build Worker is not installed

### DIFF
--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -459,9 +459,9 @@ function Get-LabInternetFile
             
             [string]$FileName,
 
-            [switch]$NoDisplay,
+            [bool]$NoDisplay,
 
-            [switch]$Force
+            [bool]$Force
         )
 
         if (Test-Path -Path $Path -PathType Container)
@@ -587,7 +587,12 @@ function Get-LabInternetFile
         $machine = Get-LabVM -IsRunning | Select-Object -First 1
         Write-Verbose "Target path is on AzureLabSources, invoking the copy job on the first available Azure machine."
 
-        $result = Invoke-LabCommand -ComputerName $machine -ScriptBlock (Get-Command -Name Get-LabInternetFileInternal).ScriptBlock -ArgumentList $Uri, $Path, $FileName -PassThru
+        $argumentList = $Uri, $Path, $FileName
+
+        $argumentList += if ($NoDisplay) {$true} else {$false}
+        $argumentList += if ($Force) {$true} else {$false}
+        
+        $result = Invoke-LabCommand -ComputerName $machine -ScriptBlock (Get-Command -Name Get-LabInternetFileInternal).ScriptBlock -ArgumentList $argumentList -PassThru
     }
     else
     {

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -251,6 +251,7 @@ function Install-LabBuildWorker
                 Write-Error -Message 'There has been an error setting the Azure port during TFS installation. Cannot continue installing build worker.'
                 return
             }
+
             $machineName = $tfsServer.AzureConnectionInfo.DnsName
         }
 
@@ -275,9 +276,9 @@ function Install-LabBuildWorker
 
             $configurationProcess = Start-Process -FilePath $configurationTool -ArgumentList $commandLine -Wait -NoNewWindow -PassThru
 
-            if ($configurationProcess.ExitCode -ne 0)
+            if ($configurationProcess.ExitCode -notin 0, 3010)
             {
-                Write-ScreenInfo -Message "Build worker $env:COMPUTERNAME failed to install. Exit code was $($configurationProcess.ExitCode)" -Type Warning
+                Write-Warning -Message "Build worker $env:COMPUTERNAME failed to install. Exit code was $($configurationProcess.ExitCode)"
             }
         } -AsJob -Variable (Get-Variable machineName, tfsPort, useSsl) -ActivityName "Setting up build agent $machine" -PassThru -NoDisplay
     }

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -267,11 +267,11 @@ function Install-LabBuildWorker
             $commandLine = if ($useSsl)
             {
                 #sslskipcertvalidation is used as git.exe could not test the certificate chain
-                '--unattended --url https://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --sslskipcertvalidation --gituseschannel' -f $machineName, $tfsPort.DestinationPort, $env:COMPUTERNAME
+                '--unattended --url https://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --sslskipcertvalidation --gituseschannel' -f $machineName, $tfsPort.Port, $env:COMPUTERNAME
             }
             else
             {
-                '--unattended --url http://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --gituseschannel' -f $machineName, $tfsPort.DestinationPort, $env:COMPUTERNAME
+                '--unattended --url http://{0}:{1} --auth Integrated --pool default --agent {2} --runasservice --gituseschannel' -f $machineName, $tfsPort.Port, $env:COMPUTERNAME
             }
 
             $configurationProcess = Start-Process -FilePath $configurationTool -ArgumentList $commandLine -Wait -NoNewWindow -PassThru


### PR DESCRIPTION
## Description

Due to an issue with Get-LabInternetFile an old TFS agent could have been installed instead of the most recent one. Depending on the agent version contained in $LabSources, this would mean an error during the agent installation.

- [x] - I have tested my changes.  
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Tested with DSC Workshop Lab on Azure