### PR TITLE
Invoke-LabCommand did not work with scripts on Azure LabSources

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -3334,7 +3334,7 @@ function Invoke-LabCommand
             $scriptContent = if ($isLabPathIsOnLabAzureLabSourcesStorage)
             {
                 #if the script is on an Azure file storage, the host machine cannot access it. The read operation is done on the first Azure machine.
-                Invoke-LabCommand -ComputerName $machines[0] -ScriptBlock { Get-Content -Path $FilePath -Raw } -Variable (Get-Variable -Name FilePath) -NoDisplay -PassThru
+                Invoke-LabCommand -ComputerName ($machines | Where-Object HostType -eq 'Azure')[0] -ScriptBlock { Get-Content -Path $FilePath -Raw } -Variable (Get-Variable -Name FilePath) -NoDisplay -PassThru
             }
             else
             {

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -3140,10 +3140,11 @@ function Invoke-LabCommand
         Write-LogFunctionExitWithError -Message 'No machine definitions imported, so there is nothing to do. Please use Import-Lab first'
         return
     }
-
+    
     if ($FilePath)
     {
-        if (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $FilePath)
+        $isLabPathIsOnLabAzureLabSourcesStorage = Test-LabPathIsOnLabAzureLabSourcesStorage -Path $FilePath
+        if ($isLabPathIsOnLabAzureLabSourcesStorage)
         {
             Write-Verbose "$FilePath is on Azure. Skipping test."
         }
@@ -3330,7 +3331,15 @@ function Invoke-LabCommand
 
         if ($FilePath)
         {
-            $scriptContent = Get-Content -Path $FilePath -Raw
+            $scriptContent = if ($isLabPathIsOnLabAzureLabSourcesStorage)
+            {
+                #if the script is on an Azure file storage, the host machine cannot access it. The read operation is done on the first Azure machine.
+                Invoke-LabCommand -ComputerName $machines[0] -ScriptBlock { Get-Content -Path $FilePath -Raw } -Variable (Get-Variable -Name FilePath) -NoDisplay -PassThru
+            }
+            else
+            {
+                 Get-Content -Path $FilePath -Raw
+            }
             $ScriptBlock = [scriptblock]::Create($scriptContent)
         }
 
@@ -4248,6 +4257,3 @@ Register-ArgumentCompleter -CommandName Add-LabMachineDefinition -ParameterName 
         [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
     }
 }
-
-#Import available operating systms from cache (if available)
-#Get-LabAvailableOperatingSystem -Path $labSources\ISOs -NoDisplay | Out-Null


### PR DESCRIPTION
## Description

A given file path on Azure could not be resolved from the host machine. The file content needs to read on one of the Azure machines that have access to Azure LabSources

- [x] - I have tested my changes.  
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change

## How was the change tested?
DscWorkshop deployment