### PR TITLE
Write-PSFMessage is not available in remote scope

### DIFF
--- a/PSFileTransfer/PSFileTransfer.psm1
+++ b/PSFileTransfer/PSFileTransfer.psm1
@@ -71,7 +71,7 @@ function Send-File
 
     $firstChunk = $true
 
-    Write-PSFMessage -Message "PSFileTransfer: Sending file $SourceFilePath to $DestinationFolderPath on $($Session.ComputerName) ($([Math]::Round($chunkSize / 1MB, 2)) MB chunks)"
+    Write-Verbose -Message "PSFileTransfer: Sending file $SourceFilePath to $DestinationFolderPath on $($Session.ComputerName) ($([Math]::Round($chunkSize / 1MB, 2)) MB chunks)"
 
     $sourcePath = (Resolve-Path $SourceFilePath -ErrorAction SilentlyContinue).Path
     if (-not $sourcePath)
@@ -114,7 +114,7 @@ function Send-File
 
     $sourceFileStream.Close()
 
-    Write-PSFMessage -Message "PSFileTransfer: Finished sending file $SourceFilePath"
+    Write-Verbose -Message "PSFileTransfer: Finished sending file $SourceFilePath"
 }
 #endregion Send-File
 


### PR DESCRIPTION
## Description

Send-File is also invoked remotely where Write-PSFMessage is not available. Changing this to Write-Verbose.

- [x] - I have tested my changes.  
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change

## How was the change tested?
PowerShell Workshop Lab