### PR TITLE
Replace CimInstance in Remote Commands

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1976,7 +1976,7 @@ function Install-VisualStudio2013
                 Write-Verbose 'Installing Visual Studio 2013'
 
                 Push-Location
-                Set-Location -Path (Get-CimInstance -Class Win32_CDRomDrive).Drive
+                Set-Location -Path (Get-WmiObject -Class Win32_CDRomDrive).Drive
                 $exe = Get-ChildItem -Filter *.exe
                 if ($exe.Count -gt 1)
                 {
@@ -2095,7 +2095,7 @@ function Install-VisualStudio2015
                 Write-Verbose 'Installing Visual Studio 2015'
 
                 Push-Location
-                Set-Location -Path (Get-CimInstance -Class Win32_CDRomDrive).Drive
+                Set-Location -Path (Get-WmiObject -Class Win32_CDRomDrive).Drive
                 $exe = Get-ChildItem -Filter *.exe
                 if ($exe.Count -gt 1)
                 {
@@ -2528,7 +2528,7 @@ function Install-LabSoftwarePackage
         {
             Add-Type -Path '/ALLibraries/core/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
         }
-        else
+        elseif ([System.Environment]::OSVersion.Version -gt '6.3')
         {
             Add-Type -Path '/ALLibraries/full/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
         }

--- a/AutomatedLab/AutomatedLabADCS.psm1
+++ b/AutomatedLab/AutomatedLabADCS.psm1
@@ -2383,7 +2383,7 @@ function Install-LabCAMachine
             $DatabaseDirectoryDrive = ($param.DatabaseDirectory.split(':')[0]) + ':'
 
             $disk = Invoke-LabCommand -ComputerName $Machine -ScriptBlock {
-                Get-CimInstance -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$DatabaseDirectoryDrive"""
+                Get-WmiObject -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$DatabaseDirectoryDrive"""
             } -Variable (Get-Variable -Name DatabaseDirectoryDrive) -PassThru
 
             if (-not $disk -or -not $disk.DriveType -eq 3)
@@ -2397,7 +2397,7 @@ function Install-LabCAMachine
         {
             $LogDirectoryDrive = ($param.LogDirectory.split(':')[0]) + ':'
             $disk = Invoke-LabCommand -ComputerName $Machine -ScriptBlock {
-                Get-CimInstance -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$LogDirectoryDrive"""
+                Get-WmiObject -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$LogDirectoryDrive"""
             } -Variable (Get-Variable -Name LogDirectoryDrive) -PassThru
             if (-not $disk -or -not $disk.DriveType -eq 3)
             {
@@ -3009,7 +3009,7 @@ function Publish-LabCAInstallCertificates
             {
                 Write-Verbose -Message "Install certificate ($((Get-PfxCertificate $certfile.FullName).Subject)) on machine $(hostname)"
                 #If workgroup, publish to local store
-                if ((Get-CimInstance -Namespace root\cimv2 -Class Win32_ComputerSystem).DomainRole -eq 2)
+                if ((Get-WmiObject -Namespace root\cimv2 -Class Win32_ComputerSystem).DomainRole -eq 2)
                 {
                     Write-Verbose -Message '  Machine is not domain joined. Publishing certificate to local store'
 

--- a/AutomatedLab/AutomatedLabADDS.psm1
+++ b/AutomatedLab/AutomatedLabADDS.psm1
@@ -1753,7 +1753,7 @@ function Reset-DNSConfiguration
             (
                 $DnsServers
             )
-            $AdapterNames = (Get-CimInstance -Namespace Root\CIMv2 -Class Win32_NetworkAdapter | Where-Object {$_.PhysicalAdapter}).NetConnectionID
+            $AdapterNames = (Get-WmiObject -Namespace Root\CIMv2 -Class Win32_NetworkAdapter | Where-Object {$_.PhysicalAdapter}).NetConnectionID
             foreach ($AdapterName in $AdapterNames)
             {
                 netsh.exe interface ipv4 set dnsservers "$AdapterName" static $DnsServers primary

--- a/AutomatedLab/AutomatedLabFailover.psm1
+++ b/AutomatedLab/AutomatedLabFailover.psm1
@@ -76,7 +76,7 @@ function Install-LabFailoverCluster
                     if ($line -match 'Disk (?<DiskNumber>\d) \s+(Offline)\s+(?<Size>\d+) GB\s+(?<Free>\d+) GB')
                     {
                         $nextDriveLetter = [char[]](67..90) |
-                            Where-Object { (Get-CimInstance -Class Win32_LogicalDisk |
+                            Where-Object { (Get-WmiObject -Class Win32_LogicalDisk |
                                     Select-Object -ExpandProperty DeviceID) -notcontains "$($_):"} |
                             Select-Object -First 1
 
@@ -206,7 +206,7 @@ function Install-LabFailoverStorage
         $initiatorIds = Invoke-LabCommand -ActivityName 'Retrieving IQNs' -ComputerName $machines -ScriptBlock {
             Set-Service -Name MSiSCSI -StartupType Automatic
             Start-Service -Name MSiSCSI
-            "IQN:$((Get-CimInstance -Namespace root\wmi -Class MSiSCSIInitiator_MethodClass).iSCSINodeName)"
+            "IQN:$((Get-WmiObject -Namespace root\wmi -Class MSiSCSIInitiator_MethodClass).iSCSINodeName)"
         } -PassThru -ErrorAction Stop
 
         $clusters[$clusterName] = $initiatorIds

--- a/AutomatedLab/AutomatedLabHybrid.psm1
+++ b/AutomatedLab/AutomatedLabHybrid.psm1
@@ -515,7 +515,7 @@ function Connect-OnPremisesWithAzure
             $MacAddress
         )
 
-        $externalAdapter = Get-CimInstance -Class Win32_NetworkAdapter -Filter ('MACAddress = "{0}"' -f $MacAddress) |
+        $externalAdapter = Get-WmiObject -Class Win32_NetworkAdapter -Filter ('MACAddress = "{0}"' -f $MacAddress) |
             Select-Object -ExpandProperty NetConnectionID
 
         Set-Service -Name RemoteAccess -StartupType Automatic

--- a/AutomatedLab/AutomatedLabOffice.psm1
+++ b/AutomatedLab/AutomatedLabOffice.psm1
@@ -112,7 +112,7 @@ function Install-LabOffice2013
                 $start = Get-Date
 
                 Push-Location
-                Set-Location -Path (Get-CimInstance -Class Win32_CDRomDrive).Drive
+                Set-Location -Path (Get-WmiObject -Class Win32_CDRomDrive).Drive
                 Write-Verbose 'Calling "$($PWD.Path)setup.exe /config C:\Office2013Config.xml"'
                 .\setup.exe /config C:\Office2013Config.xml
                 Pop-Location

--- a/AutomatedLab/AutomatedLabRouting.psm1
+++ b/AutomatedLab/AutomatedLabRouting.psm1
@@ -78,7 +78,7 @@ function Install-LabRouting
 
                 Write-Verbose 'Setting up NAT...'
 
-                $externalAdapter = Get-CimInstance -Class Win32_NetworkAdapter -Filter ('MACAddress = "{0}"' -f $args[0]) |
+                $externalAdapter = Get-WmiObject -Class Win32_NetworkAdapter -Filter ('MACAddress = "{0}"' -f $args[0]) |
                     Select-Object -ExpandProperty NetConnectionID
 
                 netsh.exe routing ip nat install
@@ -141,7 +141,7 @@ function Set-LabADDNSServerForwarder
         {
             Invoke-LabCommand -ActivityName 'Get default gateway' -ComputerName $dc -ScriptBlock {
 
-                Get-CimInstance -Class Win32_NetworkAdapterConfiguration | Where-Object { $_.DefaultIPGateway } | Select-Object -ExpandProperty DefaultIPGateway | Select-Object -First 1
+                Get-WmiObject -Class Win32_NetworkAdapterConfiguration | Where-Object { $_.DefaultIPGateway } | Select-Object -ExpandProperty DefaultIPGateway | Select-Object -First 1
 
             } -PassThru -NoDisplay
         }

--- a/AutomatedLab/AutomatedLabSQL.psm1
+++ b/AutomatedLab/AutomatedLabSQL.psm1
@@ -243,7 +243,7 @@ GO
                     while (-not $dvdDrive -and (($startTime).AddSeconds(120) -gt (Get-Date)))
                     {
                         Start-Sleep -Seconds 2
-                        $dvdDrive = (Get-CimInstance -Class Win32_CDRomDrive | Where-Object MediaLoaded).Drive
+                        $dvdDrive = (Get-WmiObject -Class Win32_CDRomDrive | Where-Object MediaLoaded).Drive
                     }
 
                     if ($dvdDrive)

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -65,7 +65,7 @@ function Install-LabTeamFoundationEnvironment
             while (-not $dvdDrive -and (($startTime).AddSeconds(120) -gt (Get-Date)))
             {
                 Start-Sleep -Seconds 2
-                $dvdDrive = (Get-CimInstance -Class Win32_CDRomDrive | Where-Object MediaLoaded).Drive
+                $dvdDrive = (Get-WmiObject -Class Win32_CDRomDrive | Where-Object MediaLoaded).Drive
             }
 
             if ($dvdDrive)

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -590,7 +590,7 @@ function Initialize-LWAzureVM
                 if ($line -match 'Disk (?<DiskNumber>\d) \s+(Online|Offline)\s+(?<Size>\d+) GB\s+(?<Free>\d+) (B|GB)')
                 {
                     $nextDriveLetter = [char[]](67..90) |
-                        Where-Object { (Get-CimInstance -Class Win32_LogicalDisk |
+                        Where-Object { (Get-WmiObject -Class Win32_LogicalDisk |
                                 Select-Object -ExpandProperty DeviceID) -notcontains "$($_):"} |
                         Select-Object -First 1
 

--- a/AutomatedLabWorker/AutomatedLabWorker.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psm1
@@ -529,12 +529,12 @@ function Install-LWHypervWindowsFeature
         {
             if ($m.OperatingSystem.Installation -eq 'Client')
             {
-                $cmd = [scriptblock]::Create("Enable-WindowsOptionalFeature -Online -FeatureName $($FeatureName -join ', ') -Source ""`$(@(Get-CimInstance -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -All:`$$IncludeAllSubFeature -NoRestart -WarningAction SilentlyContinue")
+                $cmd = [scriptblock]::Create("Enable-WindowsOptionalFeature -Online -FeatureName $($FeatureName -join ', ') -Source ""`$(@(Get-WmiObject -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -All:`$$IncludeAllSubFeature -NoRestart -WarningAction SilentlyContinue")
                 $result += Invoke-LabCommand -ComputerName $m -ActivityName $activityName -NoDisplay -ScriptBlock $cmd -UseLocalCredential:$UseLocalCredential -AsJob:$AsJob -PassThru:$PassThru
             }
             else
             {
-                $cmd = [scriptblock]::Create("Install-WindowsFeature $($FeatureName -join ', ') -Source ""`$(@(Get-CimInstance -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -IncludeAllSubFeature:`$$IncludeAllSubFeature -IncludeManagementTools:`$$IncludeManagementTools -WarningAction SilentlyContinue")
+                $cmd = [scriptblock]::Create("Install-WindowsFeature $($FeatureName -join ', ') -Source ""`$(@(Get-WmiObject -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -IncludeAllSubFeature:`$$IncludeAllSubFeature -IncludeManagementTools:`$$IncludeManagementTools -WarningAction SilentlyContinue")
                 $result += Invoke-LabCommand -ComputerName $m -ActivityName $activityName -NoDisplay -ScriptBlock $cmd -UseLocalCredential:$UseLocalCredential -AsJob:$AsJob -PassThru:$PassThru
             }
         }
@@ -608,12 +608,12 @@ function Install-LWAzureWindowsFeature
         {
             if ($m.OperatingSystem.Installation -eq 'Client')
             {
-                $cmd = [scriptblock]::Create("Enable-WindowsOptionalFeature -Online -FeatureName $($FeatureName -join ', ') -Source ""`$(@(Get-CimInstance -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -All:`$$IncludeAllSubFeature -NoRestart -WarningAction SilentlyContinue")
+                $cmd = [scriptblock]::Create("Enable-WindowsOptionalFeature -Online -FeatureName $($FeatureName -join ', ') -Source ""`$(@(Get-WmiObject -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -All:`$$IncludeAllSubFeature -NoRestart -WarningAction SilentlyContinue")
                 $result += Invoke-LabCommand -ComputerName $m -ActivityName $activityName -NoDisplay -ScriptBlock $cmd -UseLocalCredential:$UseLocalCredential -AsJob:$AsJob -PassThru:$PassThru
             }
             else
             {
-                $cmd = [scriptblock]::Create("Install-WindowsFeature $($FeatureName -join ', ') -Source ""`$(@(Get-CimInstance -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -IncludeAllSubFeature:`$$IncludeAllSubFeature -IncludeManagementTools:`$$IncludeManagementTools -WarningAction SilentlyContinue")
+                $cmd = [scriptblock]::Create("Install-WindowsFeature $($FeatureName -join ', ') -Source ""`$(@(Get-WmiObject -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -IncludeAllSubFeature:`$$IncludeAllSubFeature -IncludeManagementTools:`$$IncludeManagementTools -WarningAction SilentlyContinue")
                 $result += Invoke-LabCommand -ComputerName $m -ActivityName $activityName -NoDisplay -ScriptBlock $cmd -UseLocalCredential:$UseLocalCredential -AsJob:$AsJob -PassThru:$PassThru
             }
         }

--- a/AutomatedLabWorker/AutomatedLabWorkerADCS.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerADCS.psm1
@@ -226,7 +226,7 @@ function Install-LWLabCAServers
 
 
         #region - Install CA
-        $hostOSVersion = [system.version](Get-CimInstance -Class Win32_OperatingSystem).Version
+        $hostOSVersion = [system.version](Get-WmiObject -Class Win32_OperatingSystem).Version
         if ($hostOSVersion -ge [system.version]'6.2')
         {
             $InstallFeatures = 'Import-Module -Name ServerManager; Add-WindowsFeature -IncludeManagementTools -Name ADCS-Cert-Authority'
@@ -707,7 +707,7 @@ function Install-LWLabCAServers2008
 
 
         #region - Install CA
-        $hostOSVersion = [system.version](Get-CimInstance -Class Win32_OperatingSystem).Version
+        $hostOSVersion = [system.version](Get-WmiObject -Class Win32_OperatingSystem).Version
         if ($hostOSVersion -ge [system.version]'6.2')
         {
             $InstallFeatures = 'Import-Module -Name ServerManager; Add-WindowsFeature -IncludeManagementTools -Name ADCS-Cert-Authority'

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -616,7 +616,7 @@ $disks = $diskpartCmd | diskpart.exe
         }	
     }	
 }	
- foreach ($volume in (Get-CimInstance -Class Win32_Volume))	
+ foreach ($volume in (Get-WmiObject -Class Win32_Volume))	
 {	
     if ($volume.Label -notmatch '(?<Label>[\w\d]+)_AL_(?<DriveLetter>[A-Z])')	
     {	
@@ -1457,7 +1457,7 @@ function Mount-LWIsoImage
         $delayIndex = 0
 
         $dvdDrivesBefore = Invoke-LabCommand -ComputerName $machine -ScriptBlock {
-            Get-CimInstance -Class Win32_LogicalDisk -Filter 'DriveType = 5 AND FileSystem LIKE "%"' | Select-Object -ExpandProperty DeviceID
+            Get-WmiObject -Class Win32_LogicalDisk -Filter 'DriveType = 5 AND FileSystem LIKE "%"' | Select-Object -ExpandProperty DeviceID
         } -PassThru -NoDisplay
 
         #this is required as Compare-Object cannot work with a null object
@@ -1500,7 +1500,7 @@ function Mount-LWIsoImage
         }
         
         $dvdDrivesAfter = Invoke-LabCommand -ComputerName $machine -ScriptBlock {
-            Get-CimInstance -Class Win32_LogicalDisk -Filter 'DriveType = 5 AND FileSystem LIKE "%"' | Select-Object -ExpandProperty DeviceID
+            Get-WmiObject -Class Win32_LogicalDisk -Filter 'DriveType = 5 AND FileSystem LIKE "%"' | Select-Object -ExpandProperty DeviceID
         } -PassThru -NoDisplay
 
         $driveLetter = (Compare-Object -ReferenceObject $dvdDrivesBefore -DifferenceObject $dvdDrivesAfter).InputObject

--- a/LabSources/CustomRoles/MDT/InstallMDT.ps1
+++ b/LabSources/CustomRoles/MDT/InstallMDT.ps1
@@ -105,7 +105,7 @@ function Install-MDTDhcp {
         Start-Sleep -Seconds 10
         Set-DhcpServerv4Binding -BindingState $True -InterfaceAlias "Ethernet" | Out-Null
 
-        If ((Get-CimInstance -Class Win32_ComputerSystem).PartOfDomain) {
+        If ((Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain) {
             Add-DHCPServerinDC
         }
                


### PR DESCRIPTION
## Description

Replace CimInstance in Remote Commands to ensure that even very old lab VM operating systems can execute the script blocks that were passed to Invoke-LabCommand.

To further ensure compatibility, Install-LabSoftwarePackage does not import type on old OS any longer.


- [x] - I have tested my changes.  
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
DSC Workshop lab with 2008R2 servers for DSCWeb01-03 and DSCFile01-03. Ran the lab on both PS Core as well as Windows PowerShell with the recent modification to ALCommon outlined in https://github.com/AutomatedLab/AutomatedLab.Common/pull/76
Basic functionality of AL works fine. The later scripts for customization of course show errors, but these are to be expected.