### PR TITLE
OS Type detection fix

### DIFF
--- a/Assets/ProductKeys.xml
+++ b/Assets/ProductKeys.xml
@@ -80,6 +80,7 @@
   <ProductKey OperatingSystemName="Windows Server 2019 Datacenter (Desktop Experience)" Key="WMDGN-G9PQG-XVVXX-R3X43-63DFG" Version="10.0.17763.107" />
   <ProductKey OperatingSystemName="Windows Server 2019 Datacenter Evaluation" Key="WMDGN-G9PQG-XVVXX-R3X43-63DFG" Version="10.0.17763.107" />
   <ProductKey OperatingSystemName="Windows Server 2019 Datacenter Evaluation (Desktop Experience)" Key="WMDGN-G9PQG-XVVXX-R3X43-63DFG" Version="10.0.17763.107" />
+  <ProductKey OperatingSystemName="Hyper-V Server" Key="WMDGN-G9PQG-XVVXX-R3X43-63DFG" Version="10.0.17763.557" />
 
   <ProductKey OperatingSystemName="Windows Server 2019 SERVERSTANDARDCORE" Key="N69G4-B89J2-4G8F4-WWYCC-J464C" Version="10.0.17763.107" />
   <ProductKey OperatingSystemName="Windows Server 2019 SERVERSTANDARD" Key="N69G4-B89J2-4G8F4-WWYCC-J464C" Version="10.0.17763.107" />

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -7,8 +7,6 @@ function Enable-LabHostRemoting
         [switch]$NoDisplay
     )
 
-    
-
     Write-LogFunctionEntry
 
     if (-not (Test-IsAdministrator))
@@ -700,6 +698,7 @@ function Install-Lab
         [switch]$AzureServices,
         [switch]$TeamFoundation,
         [switch]$FailoverCluster,
+        [switch]$HyperV,
         [switch]$StartRemainingMachines,
         [switch]$CreateCheckPoints,
         [int]$DelayBetweenComputers,

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2237,7 +2237,14 @@ function Add-LabMachineDefinition
 
         if (-not $OperatingSystem.Version)
         {
-            throw "Could not identify the version of operating system '$($OperatingSystem.OperatingSystemName)' assigned to machine '$Name'. The version is required to continue."
+            if ($OperatingSystemVersion)
+            {
+                $OperatingSystem.Version = $OperatingSystemVersion
+            }
+            else
+            {
+                throw "Could not identify the version of operating system '$($OperatingSystem.OperatingSystemName)' assigned to machine '$Name'. The version is required to continue."
+            }
         }
 
         switch ($OperatingSystem.Version.ToString(2))

--- a/LabXml/Machines/Machine.cs
+++ b/LabXml/Machines/Machine.cs
@@ -81,7 +81,7 @@ namespace AutomatedLab
         {
             get
             {
-                return ((bool)(operatingSystem?.OperatingSystemName.Contains("Windows"))) ? OperatingSystemType.Windows : OperatingSystemType.Linux;
+                return operatingSystem.OperatingSystemType;
             }
         }
 

--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -342,7 +342,18 @@ namespace AutomatedLab
         {
             get
             {
-                return OperatingSystemName.Contains("Windows") ? OperatingSystemType.Windows : OperatingSystemType.Linux;
+                if (OperatingSystemName.Contains("Windows"))
+                {
+                    return OperatingSystemType.Windows;
+                }
+                else if (OperatingSystemName.Contains("Hyper-V"))
+                {
+                    return OperatingSystemType.Windows;
+                }
+                else
+                {
+                    return OperatingSystemType.Linux;
+                }
             }
         }
         public string OperatingSystemImageName


### PR DESCRIPTION
## Description

- OS Type detection fix
- Adds support for deploying Hyper-V Server 2019 (this one does not support AutomatedLab)

- [x] - I have tested my changes.  
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Some lab deployment