### PR TITLE
Change regex in CIMInstance parsing. Fixes #751

### DIFF
--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -1960,7 +1960,7 @@ function Test-LabAutoLogon
 	                        ForEach-Object {
                             # For deprecated OS versions...
                             # Output is convoluted vs the CimInstance variant: \\.\root\cimv2:Win32_Account.Domain="contoso",Name="Install"
-                            $null = $_ -match 'Domain="(?<Domain>\w+)",Name="(?<Name>\w+)"'
+                            $null = $_ -match 'Domain="(?<Domain>.+)",Name="(?<Name>.+)"'
                             -join ($Matches.Domain, '\', $Matches.Name)
                         } | Select-Object -Unique
 


### PR DESCRIPTION

<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Change regex in CIMInstance parsing to match any character type in domain and username of currently logged on user.

- [X] - I have tested my changes.  
- [X] - The PR has a meaningful title.  
- [X] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [X] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

Re-run the Install-Lab after the change was made and all VMs were successfully configured for auto-logon.  My lab domain had a dash "-" in the name and the enabling autologon was looping prior to the change.