### PR TITLE
SQL Configuration file behavior, Lab Sources auto update

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -4107,7 +4107,11 @@ function New-LabSourcesFolder
         $DriveLetter,
 
         [switch]
-        $Force
+        $Force,
+
+        [ValidateSet('master','develop')]
+        [string]
+        $Branch = 'master'
     )
 
     $path = Get-LabSourcesLocation
@@ -4150,7 +4154,7 @@ function New-LabSourcesFolder
 
         try
         {
-            Get-LabInternetFile -Uri 'https://github.com/AutomatedLab/AutomatedLab/archive/master.zip' -Path $archivePath -ErrorAction Stop
+            Get-LabInternetFile -Uri ('https://github.com/AutomatedLab/AutomatedLab/archive/{0}.zip' -f $Branch) -Path $archivePath -ErrorAction Stop
         }
         catch
         {

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -4144,7 +4144,10 @@ function New-LabSourcesFolder
         return $Path
     }
 
-    Write-ScreenInfo -Message 'Downloading LabSources from GitHub. This only happens once if no LabSources folder can be found.' -Type Warning
+    if (-not $Force.IsPresent)
+    {
+        Write-ScreenInfo -Message 'Downloading LabSources from GitHub. This only happens once if no LabSources folder can be found.' -Type Warning
+    }
 
     if ($PSCmdlet.ShouldProcess('Downloading module and creating new LabSources', $Path))
     {

--- a/AutomatedLab/AutomatedLabADDS.psm1
+++ b/AutomatedLab/AutomatedLabADDS.psm1
@@ -932,12 +932,16 @@ function Install-LabRootDcs
             $machinesToStart += Get-LabVM | Where-Object { -not $_.IsDomainJoined }
         }
 
-        Wait-LabVMRestart -ComputerName $machines.Name -StartMachinesWhileWaiting $machinesToStart -DoNotUseCredSsp -ProgressIndicator 30 -TimeoutInMinutes $DcPromotionRestartTimeout -ErrorAction Stop -MonitorJob $jobs -NoNewLine
-        Write-ScreenInfo -Message done
+        if ($lab.DefaultVirtualizationEngine -ne 'Azure')
+        {
+            Wait-LabVMRestart -ComputerName $machines.Name -StartMachinesWhileWaiting $machinesToStart -DoNotUseCredSsp -ProgressIndicator 30 -TimeoutInMinutes $DcPromotionRestartTimeout -ErrorAction Stop -MonitorJob $jobs -NoNewLine
+            Write-ScreenInfo -Message done
 
-        Write-ScreenInfo -Message 'Root Domain Controllers have now restarted. Waiting for Active Directory to start up' -NoNewLine
+            Write-ScreenInfo -Message 'Root Domain Controllers have now restarted. Waiting for Active Directory to start up' -NoNewLine
 
-        Wait-LabVM -ComputerName $machines -DoNotUseCredSsp -TimeoutInMinutes 30 -ProgressIndicator 30 -NoNewLine
+            Wait-LabVM -ComputerName $machines -DoNotUseCredSsp -TimeoutInMinutes 30 -ProgressIndicator 30 -NoNewLine
+        }
+
         Wait-LabADReady -ComputerName $machines -TimeoutInMinutes $AdwsReadyTimeout -ErrorAction Stop -ProgressIndicator 30 -NoNewLine
 
         #Create reverse lookup zone (forest scope)

--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -857,7 +857,7 @@ function Update-LabSysinternalsTools
                 if ($null -ne $labSources)
                 {
                     $drive = ($labSources -split ':')[0]
-                    New-LabSourcesFolder -DriveLetter $drive -Force -ErrorAction SilentlyContinue
+                    $null = New-LabSourcesFolder -DriveLetter $drive -Force -ErrorAction SilentlyContinue
                 }
 
                 # Download SysInternals suite

--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -849,10 +849,18 @@ function Update-LabSysinternalsTools
 
             if ($versions['SysInternals'] -ne $updateStringFromWebPage)
             {
-                Write-ScreenInfo -Message 'Performing update of SysInternals suite now' -Type Warning -TaskStart
+                Write-ScreenInfo -Message 'Performing update of SysInternals suite and lab sources directory now' -Type Warning -TaskStart
                 Start-Sleep -Seconds 1
+                
+                # Download Lab Sources
+                $labSources = Get-LabSourcesLocation -Local
+                if ($null -ne $labSources)
+                {
+                    $drive = ($labSources -split ':')[0]
+                    New-LabSourcesFolder -DriveLetter $drive -Force -ErrorAction SilentlyContinue
+                }
 
-                #Download SysInternals suite
+                # Download SysInternals suite
 
                 $tempFilePath = [System.IO.Path]::GetTempFileName()
                 $tempFilePath = Rename-Item -Path $tempFilePath -NewName ([System.IO.Path]::ChangeExtension($tempFilePath, '.zip')) -PassThru

--- a/AutomatedLab/AutomatedLabSQL.psm1
+++ b/AutomatedLab/AutomatedLabSQL.psm1
@@ -117,21 +117,23 @@ GO
             Write-ScreenInfo -Message "Starting machines '$($machinesBatch -join ', ')'" -NoNewLine
             Start-LabVM -ComputerName $machinesBatch -Wait
 
-            Write-ScreenInfo -Message "Starting installation of pre-requisite .Net 3.5 Framework on machine '$($machinesBatch -join ', ')'" -Type Verbose
+            Write-ScreenInfo -Message "Starting installation of pre-requisite .Net 3.5 Framework on machine '$($machinesBatch -join ', ')'" -NoNewLine
             $installFrameworkJobs = Install-LabWindowsFeature -ComputerName $machinesBatch -FeatureName Net-Framework-Core -NoDisplay -AsJob -PassThru
-
-            Write-ScreenInfo -Message "Waiting for pre-requisite .Net 3.5 Framework to finish installation on machines '$($machinesBatch -join ', ')'" -NoNewLine
-            Wait-LWLabJob -Job $installFrameworkJobs -Timeout 10 -NoDisplay -ProgressIndicator 15 -NoNewLine
-
-            Write-ScreenInfo -Message "Starting installation of pre-requisite C++ 2015 redist on machine '$($machinesBatch -join ', ')'" -Type Verbose -NoNewLine
-            Install-LabSoftwarePackage -Path $cppredist32_2015.FullName -CommandLine ' /quiet /norestart /log C:\DeployDebug\cpp32_2015.log' -ComputerName $machinesBatch -ExpectedReturnCodes 0,3010 -PassThru -AsScheduledJob
-            Install-LabSoftwarePackage -Path $cppRedist64_2015.FullName -CommandLine ' /quiet /norestart /log C:\DeployDebug\cpp64_2015.log' -ComputerName $machinesBatch -ExpectedReturnCodes 0,3010 -PassThru -AsScheduledJob
-            Restart-LabVM -ComputerName $machinesBatch -Wait -NoDisplay
+            Wait-LWLabJob -Job $installFrameworkJobs -Timeout 10 -NoDisplay -NoNewLine
             Write-ScreenInfo -Message 'done'
 
-            Write-ScreenInfo -Message "Starting installation of pre-requisite C++ 2017 redist on machine '$($machinesBatch -join ', ')'" -Type Verbose -NoNewLine
-            Install-LabSoftwarePackage -Path $cppredist32_2017.FullName -CommandLine ' /quiet /norestart /log C:\DeployDebug\cpp32_2017.log' -ComputerName $machinesBatch -ExpectedReturnCodes 0,3010 -PassThru
-            Install-LabSoftwarePackage -Path $cppRedist64_2017.FullName -CommandLine ' /quiet /norestart /log C:\DeployDebug\cpp64_2017.log' -ComputerName $machinesBatch -ExpectedReturnCodes 0,3010 -PassThru
+            Write-ScreenInfo -Message "Starting installation of pre-requisite C++ 2015 redist on machine '$($machinesBatch -join ', ')'" -NoNewLine
+            Install-LabSoftwarePackage -Path $cppredist32_2015.FullName -CommandLine ' /quiet /norestart /log C:\DeployDebug\cpp32_2015.log' -ComputerName $machinesBatch -ExpectedReturnCodes 0,3010 -AsScheduledJob -NoDisplay
+            Install-LabSoftwarePackage -Path $cppRedist64_2015.FullName -CommandLine ' /quiet /norestart /log C:\DeployDebug\cpp64_2015.log' -ComputerName $machinesBatch -ExpectedReturnCodes 0,3010 -AsScheduledJob -NoDisplay
+            Write-ScreenInfo -Message 'done'
+
+            Write-ScreenInfo -Message "Starting installation of pre-requisite C++ 2017 redist on machine '$($machinesBatch -join ', ')'" -NoNewLine
+            Install-LabSoftwarePackage -Path $cppredist32_2017.FullName -CommandLine ' /quiet /norestart /log C:\DeployDebug\cpp32_2017.log' -ComputerName $machinesBatch -ExpectedReturnCodes 0,3010 -AsScheduledJob -NoDisplay
+            Install-LabSoftwarePackage -Path $cppRedist64_2017.FullName -CommandLine ' /quiet /norestart /log C:\DeployDebug\cpp64_2017.log' -ComputerName $machinesBatch -ExpectedReturnCodes 0,3010 -AsScheduledJob -NoDisplay
+            Write-ScreenInfo -Message 'done'
+
+            Write-ScreenInfo -Message "Restarting '$($machinesBatch -join ', ')'" -NoNewLine
+            Restart-LabVM -ComputerName $machinesBatch -Wait -NoDisplay
             Write-ScreenInfo -Message 'done'
 
             foreach ($machine in $machinesBatch)

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -563,8 +563,8 @@ function Stop-LabVM
 
     $remainingTargets = @()
     if ($hypervErrors) { $remainingTargets += $hypervErrors.TargetObject }
-    if ($azureErrors) { $remainingTargets + $azureErrors.TargetObject }
-    if ($vmwareErrors) { $remainingTargets + $vmwareErrors.TargetObject }
+    if ($azureErrors) { $remainingTargets += $azureErrors.TargetObject }
+    if ($vmwareErrors) { $remainingTargets += $vmwareErrors.TargetObject }
     if ($null -ne $remainingTargets) { Stop-LabVM2 -ComputerName $remainingTargets }
 
     if ($Wait)

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -565,7 +565,7 @@ function Stop-LabVM
     if ($hypervErrors) { $remainingTargets += $hypervErrors.TargetObject }
     if ($azureErrors) { $remainingTargets += $azureErrors.TargetObject }
     if ($vmwareErrors) { $remainingTargets += $vmwareErrors.TargetObject }
-    if ($null -ne $remainingTargets) { Stop-LabVM2 -ComputerName $remainingTargets }
+    if ($remainingTargets.Count -gt 0) { Stop-LabVM2 -ComputerName $remainingTargets }
 
     if ($Wait)
     {

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -565,7 +565,7 @@ function Stop-LabVM
     if ($hypervErrors) { $remainingTargets += $hypervErrors.TargetObject }
     if ($azureErrors) { $remainingTargets + $azureErrors.TargetObject }
     if ($vmwareErrors) { $remainingTargets + $vmwareErrors.TargetObject }
-    if ($remainingTargets) { Stop-LabVM2 -ComputerName $remainingTargets }
+    if ($null -ne $remainingTargets) { Stop-LabVM2 -ComputerName $remainingTargets }
 
     if ($Wait)
     {

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2022,7 +2022,17 @@ function Add-LabMachineDefinition
 
         if (-not $OperatingSystem)
         {
-            throw "No operating system was defined for machine '$Name' and no default operating system defined. Please define either of these and retry. Call 'Get-LabAvailableOperatingSystem' to get a list of operating systems added to the lab."
+            $os = Get-LabAvailableOperatingSystem -UseOnlyCache -NoDisplay | Where-Object -Property OperatingSystemType -eq 'Windows' | Sort-Object Version | Select-Object -Last 1
+
+            if ($null -ne $os)
+            {
+                Write-ScreenInfo -Message "No operating system specified. Assuming you want $os ($(Split-Path -Leaf -Path $os.IsoPath))."
+                $OperatingSystem = $os
+            }
+            else
+            {
+                throw "No operating system was defined for machine '$Name' and no default operating system defined. Please define either of these and retry. Call 'Get-LabAvailableOperatingSystem' to get a list of operating systems added to the lab."
+            }
         }
 
         if ($AzureProperties)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - SQL setup now does not override custom configuration file any longer when no other parameters are specified
 - Add-LabMachineDefinition now assumes the most recent OS as a default if no system is specified
 - Added System Center Configuration Manager 1902 custom role - Thank you @codaamok !
+- Lab Sources folder is automatically updated now, too
+  - Will reduce issues with missing dependencies on post install activities that get renamed without an info...
 
 ### Bug Fixes
 - Fixes hardcode reference to a SQL configuration file with the path supplied in SQL role's properties `ConfigurationFile` - Thank you @codaamok !

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
-- Fixes hardcode reference to a SQL configuration file with the path supplied in SQL role's properties `ConfigurationFile`
-
 ### Enhancements
+- SQL setup now does not override custom configuration file any longer when no other parameters are specified
+- Add-LabMachineDefinition now assumes the most recent OS as a default if no system is specified
+- Added System Center Configuration Manager 1902 custom role - Thank you @codaamok !
 
 ### Bug Fixes
+- Fixes hardcode reference to a SQL configuration file with the path supplied in SQL role's properties `ConfigurationFile` - Thank you @codaamok !
 
 ## 5.17.0 - 2020-01-08
 

--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -1197,6 +1197,16 @@
       <Component Id="cmp5C2AC57928537B9972701349942A3FFA" Directory="dirE3A2F6A6AFF66E7DBE85D5202BCC2B39" Guid="b201d944-e2ac-4186-a6da-0582fcbd97df">
         <File Id="fil1B630379D59BAF3FB3D75978CD293A6B" KeyPath="yes" Source="$(var.SolutionDir)\LabSources\CustomRoles\README.md" />
       </Component>
+      <Component Id="cmp37d49212390jei0d1d4dca1274" Directory="dirD49C097A9asd9813oen50AC9C2" Guid="b3952a83-4f30-4709-8236-e107e5071d36">
+        <File Id="fil68d33fed4c7f4f8b83f5fc86d924600e" KeyPath="yes" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\ConfigurationFile-SQL.ini" />
+        <File Id="fil18ace1a31c3d4837877053c2cb91a694" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\HostStart.ps1" />
+        <File Id="fil5d8467bd9d3c4ca69b64092c4d6b1948" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-CustomiseCM.ps1" />
+        <File Id="fil760c2c67fe0b4206acf78daa3b8f3879" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-DownloadADK.xml" />
+        <File Id="fil3e9ca7e859044c879b62d400366f630e" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-DownloadCM.ps1" />
+        <File Id="fila209b4ed5af743b196c755331f316841" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-DownloadMisc.ps1" />
+        <File Id="fil3ad4c4c495024d66ae7101748c8ddfe4" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-InstallCM.ps1" />
+        <File Id="fil3ad4c4c495024d66ae7101748c8ddfe5" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-UpdateCM.ps1" />
+      </Component>
       <Component Id="cmp37d492e149754ae5a9ec1f7d4dca1274" Directory="dirD49C097A947F489194CAACFE550AC9C2" Guid="b206fa90-412b-4d5d-9cdf-e7265d07fb7c">
         <File Id="fil14812A370302467D999A50F69F73486E" KeyPath="yes" Source="$(var.SolutionDir)\LabSources\CustomRoles\MDT\DownloadAdk.ps1" />
         <File Id="fil90167B87796A44B0B67E03659AD053BD" Source="$(var.SolutionDir)\LabSources\CustomRoles\MDT\HostStart.ps1" />

--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -46,7 +46,7 @@
       </Directory>
       <Directory Id="LABSOURCESVOLUME">
         <Directory Id="LABSOURCESDIR" Name="LabSources">
-          <Directory Id="SAMPLESDIR" Name="Sample Scripts">
+          <Directory Id="SAMPLESDIR" Name="SampleScripts">
             <Component Id='SamplesComponent' Guid='bd0eb8dc-b958-4b43-b767-53010f4aa713'>
               <RegistryValue Root="HKLM" Key="Software\[Manufacturer]\[ProductName]" Type="string" Value="SamplesComponent" />
               <RemoveFolder Id="RemoveFolderSamplesDir" Directory="SAMPLESDIR" On="both"/>
@@ -165,7 +165,7 @@
         <Component Id="LabSourcesFolderRegistry" Directory='LABSOURCESDIR'>
           <RegistryValue Root='HKLM' Key='SOFTWARE\[Manufacturer]\[ProductName]' Name='LabSourcesFolder' Value='[LABSOURCESDIR]' Type='string' KeyPath="yes" />
         </Component>
-        <Feature Id='Samples' Title='Sample Scripts' Description='A list of sample scripts.' Level='1' ConfigurableDirectory='SAMPLESDIR'>
+        <Feature Id='Samples' Title='SampleScripts' Description='A list of sample scripts.' Level='1' ConfigurableDirectory='SAMPLESDIR'>
           <ComponentRef Id='SamplesComponent' />
           <ComponentRef Id='SamplesHypervComponent' />
           <ComponentRef Id='SamplesAzureComponent' />

--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -1201,7 +1201,7 @@
         <File Id="fil68d33fed4c7f4f8b83f5fc86d924600e" KeyPath="yes" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\ConfigurationFile-SQL.ini" />
         <File Id="fil18ace1a31c3d4837877053c2cb91a694" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\HostStart.ps1" />
         <File Id="fil5d8467bd9d3c4ca69b64092c4d6b1948" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-CustomiseCM.ps1" />
-        <File Id="fil760c2c67fe0b4206acf78daa3b8f3879" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-DownloadADK.xml" />
+        <File Id="fil760c2c67fe0b4206acf78daa3b8f3879" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-DownloadADK.ps1" />
         <File Id="fil3e9ca7e859044c879b62d400366f630e" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-DownloadCM.ps1" />
         <File Id="fila209b4ed5af743b196c755331f316841" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-DownloadMisc.ps1" />
         <File Id="fil3ad4c4c495024d66ae7101748c8ddfe4" Source="$(var.SolutionDir)\LabSources\CustomRoles\CM-1902\Invoke-InstallCM.ps1" />

--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -1400,6 +1400,11 @@
   </Fragment>
   <Fragment>
     <DirectoryRef Id="dirE3A2F6A6AFF66E7DBE85D5202BCC2B39">
+      <Directory Id="dirD49C097A9asd9813oen50AC9C2" Name="CM-1902" />
+    </DirectoryRef>
+  </Fragment>
+  <Fragment>
+    <DirectoryRef Id="dirE3A2F6A6AFF66E7DBE85D5202BCC2B39">
       <Directory Id="dirD49C097A947F489194CAACFE550AC9C2" Name="MDT" />
     </DirectoryRef>
   </Fragment>

--- a/LabSources/PostInstallationActivities/SqlServer/SetupSqlServerReportingServices.ps1
+++ b/LabSources/PostInstallationActivities/SqlServer/SetupSqlServerReportingServices.ps1
@@ -6,7 +6,7 @@ function Get-ConfigSet
     if ($class.__NAMESPACE -match '\\v(?<version>\d\d)\\*.')
     {
         $version = $Matches.version
-        Write-Host "Installed SSRS version is $version"
+        Write-Verbose "Installed SSRS version is $version"
     }
 }
 

--- a/PSLog/PSLog.psm1
+++ b/PSLog/PSLog.psm1
@@ -71,7 +71,7 @@ function Write-LogFunctionEntry
     $Message = '{0};{1};{2};{3}' -f (Get-Date), $callerScriptName, $callerFunctionName, $Message
     $Message = ($Message -split ';')[2..3] -join ' '
 
-    Microsoft.PowerShell.Utility\Write-Verbose $Message
+    Write-PSFMessage -Message $Message
 }
 #endregion
 
@@ -115,7 +115,7 @@ function Write-LogFunctionExit
     $Message = '{0};{1};{2};{3};{4}' -f (Get-Date), $callerScriptName, $callerFunctionName, $Message, ("(Time elapsed: {0:hh}:{0:mm}:{0:ss}:{0:fff})" -f $ts)
     $Message = -join ($Message -split ';')[2..4]
 
-    Microsoft.PowerShell.Utility\Write-Verbose $Message
+    Write-PSFMessage -Message $Message
 }
 #endregion
 

--- a/PSLog/PSLog.psm1
+++ b/PSLog/PSLog.psm1
@@ -225,9 +225,9 @@ function Write-LogError
         $callerScriptName = Split-Path -Path $caller.ScriptName -Leaf
     }
 
-    if ($Excpetion)
+    if ($Exception)
     {
-        $Message = '{0};{1};{2};{3}' -f (Get-Date), $callerScriptName, $callerFunctionName, ('{0}: {1}' -f $Message, $Excpetion.Message)
+        $Message = '{0};{1};{2};{3}' -f (Get-Date), $callerScriptName, $callerFunctionName, ('{0}: {1}' -f $Message, $Exception.Message)
     }
     else
     {


### PR DESCRIPTION
## Description

Config file behavior changed. If a config file is used, do not add defaults unless they are missing from the config file. If role parameters are supplied, those will override the configuration file entries.

Formatting changed for SQL installation, Install-LabSoftwarePackage was configured with PassThru and returned the empty output of Install-SoftwarePackage. Both are not great choices.

Fixes #792 

- [X] - I have tested my changes.  
- [X] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [X] - The PR has a meaningful title.  
- [X] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Azure and OnPrem labs.