### PR TITLE
Fixes #806: "Invoke-Command : Specified RemoteRunspaceInfo objects have duplicates"

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -2909,7 +2909,7 @@ function New-LabPSSession
 
                     Write-PSFMessage "Session $($internalSession[0].Name) is available and will be reused"
                     #Replaced Select-Object with array indexing because of https://github.com/PowerShell/PowerShell/issues/9185
-                    ($sessions += $internalSession | Where-Object State -eq 'Opened')[0] #| Select-Object -First 1
+                    $sessions += ($internalSession | Where-Object State -eq 'Opened')[0] #| Select-Object -First 1
                 }
             }
 

--- a/AutomatedLabWorker/AutomatedLabWorker.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psm1
@@ -91,7 +91,18 @@ function Invoke-LWCommand
     }
 
     $internalSession = New-Object System.Collections.ArrayList
-    $internalSession.AddRange(@($Session | Foreach-Object  {if ($_.State -eq 'Broken'){New-LabPSSession -Session $_} else {$_}}) )
+    $internalSession.AddRange(
+        @($Session | Foreach-Object {
+                if ($_.State -eq 'Broken')
+                {
+                    New-LabPSSession -Session $_
+                }
+                else
+                {
+                    $_
+                }
+        })
+    )
 
     if (-not $ActivityName)
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed domain join performance issue. Joining to a domain took at least 15 minutes.
 - Removed parameter 'Path' from 'New-LabDefinition' and help
 - Removed parameter 'NoAzurePublishSettingsFile' from 'New-LabDefinition' and help
+- Fixes #806, Invoke-Command : Specified RemoteRunspaceInfo objects have duplicates.
 
 ### Enhancements
 - SQL setup now does not override custom configuration file any longer when no other parameters are specified


### PR DESCRIPTION
## Description

Fixes #806.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Deployment of DscWorkshop and other small labs without issues.
