### PR TITLE
'Test-LabPathIsOnLabAzureLabSourcesStorage' is only called if lab's DefaultVirtualizationEngine is Azure

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -2456,7 +2456,7 @@ function Install-LabSoftwarePackage
     Write-LogFunctionEntry
     $parameterSetName = $PSCmdlet.ParameterSetName
 
-    if ($Path)
+    if ($Path -and (Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
     {
         if (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $Path)
         {
@@ -2909,7 +2909,7 @@ function New-LabPSSession
 
                     Write-PSFMessage "Session $($internalSession[0].Name) is available and will be reused"
                     #Replaced Select-Object with array indexing because of https://github.com/PowerShell/PowerShell/issues/9185
-                    ($sessions += $internalSession | Where-Object State -eq 'Opened')[0] #| Select-Object -First 1
+                    $sessions += ($internalSession | Where-Object State -eq 'Opened')[0] #| Select-Object -First 1
                 }
             }
 
@@ -3237,7 +3237,10 @@ function Invoke-LabCommand
     
     if ($FilePath)
     {
-        $isLabPathIsOnLabAzureLabSourcesStorage = Test-LabPathIsOnLabAzureLabSourcesStorage -Path $FilePath
+        $isLabPathIsOnLabAzureLabSourcesStorage = if ((Get-Lab).DefaultVirtualizationEngine = 'Azure')
+        {
+            Test-LabPathIsOnLabAzureLabSourcesStorage -Path $FilePath
+        }
         if ($isLabPathIsOnLabAzureLabSourcesStorage)
         {
             Write-PSFMessage "$FilePath is on Azure. Skipping test."

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -683,7 +683,7 @@ function New-LabDefinition
 
         [int]$ReferenceDiskSizeInGB = 50,
 
-        [int]$MaxMemory = 0,
+        [long]$MaxMemory = 0,
 
         [hashtable]$Notes,
 
@@ -1503,21 +1503,24 @@ function Add-LabIsoImageDefinition
         $cachedIsos = New-Object $type
     }
 
-    if (Test-LabPathIsOnLabAzureLabSourcesStorage $Path)
+    if ((Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
     {
-        $isoFiles = Get-LabAzureLabSourcesContent -RegexFilter '\.iso' -File -ErrorAction SilentlyContinue
-
-        if ( [System.IO.Path]::HasExtension($Path))
+        if (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $Path)
         {
-            $isoFiles = $isoFiles | Where-Object {$_.Name -eq (Split-Path -Path $Path -Leaf)}
+            $isoFiles = Get-LabAzureLabSourcesContent -RegexFilter '\.iso' -File -ErrorAction SilentlyContinue
 
-            if (-not $isoFiles -and $Name)
+            if ( [System.IO.Path]::HasExtension($Path))
             {
-                $filterPath = Split-Path -Path $Path -Leaf
-                Write-PSFMessage -Message "Syncing $filterPath with Azure lab sources storage in case it does not already exist"
-                Sync-LabAzureLabSources -Filter $filterPath
+                $isoFiles = $isoFiles | Where-Object {$_.Name -eq (Split-Path -Path $Path -Leaf)}
 
-                $isoFiles = Get-LabAzureLabSourcesContent -RegexFilter '\.iso' -File -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq (Split-Path -Path $Path -Leaf)}
+                if (-not $isoFiles -and $Name)
+                {
+                    $filterPath = Split-Path -Path $Path -Leaf
+                    Write-PSFMessage -Message "Syncing $filterPath with Azure lab sources storage in case it does not already exist"
+                    Sync-LabAzureLabSources -Filter $filterPath
+
+                    $isoFiles = Get-LabAzureLabSourcesContent -RegexFilter '\.iso' -File -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq (Split-Path -Path $Path -Leaf)}
+                }
             }
         }
     }

--- a/AutomatedLabWorker/AutomatedLabWorker.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psm1
@@ -74,7 +74,11 @@ function Invoke-LWCommand
 
     if ($DependencyFolderPath)
     {
-        if (-not (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $DependencyFolderPath) -and -not (Test-Path -Path $DependencyFolderPath))
+        $result = ?? { (Get-Lab).DefaultVirtualizationEngine -eq 'Azure' } `
+        { Test-LabPathIsOnLabAzureLabSourcesStorage -Path $DependencyFolderPath } `
+        { Test-Path -Path $DependencyFolderPath }
+        
+        if (-not $result)
         {
             Write-Error "The DependencyFolderPath '$DependencyFolderPath' could not be found"
             return
@@ -83,7 +87,11 @@ function Invoke-LWCommand
 
     if ($ScriptFilePath)
     {
-        if (-not (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $ScriptFilePath) -and -not (Test-Path -Path $ScriptFilePath -PathType Leaf))
+        $result = ?? { (Get-Lab).DefaultVirtualizationEngine -eq 'Azure' } `
+        { Test-LabPathIsOnLabAzureLabSourcesStorage -Path $ScriptFilePath } `
+        { Test-Path -Path $ScriptFilePath }
+        
+        if (-not $result)
         {
             Write-Error "The ScriptFilePath '$ScriptFilePath' could not be found"
             return
@@ -91,7 +99,18 @@ function Invoke-LWCommand
     }
 
     $internalSession = New-Object System.Collections.ArrayList
-    $internalSession.AddRange(@($Session | Foreach-Object  {if ($_.State -eq 'Broken'){New-LabPSSession -Session $_} else {$_}}) )
+    $internalSession.AddRange(
+        @($Session | Foreach-Object {
+                if ($_.State -eq 'Broken')
+                {
+                    New-LabPSSession -Session $_
+                }
+                else
+                {
+                    $_
+                }
+        })
+    )
 
     if (-not $ActivityName)
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed domain join performance issue. Joining to a domain took at least 15 minutes.
 - Removed parameter 'Path' from 'New-LabDefinition' and help
 - Removed parameter 'NoAzurePublishSettingsFile' from 'New-LabDefinition' and help
+- 'Test-LabPathIsOnLabAzureLabSourcesStorage' is only called if lab's DefaultVirtualizationEngine is Azure.
 
 ### Enhancements
 - SQL setup now does not override custom configuration file any longer when no other parameters are specified


### PR DESCRIPTION
## Description

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Hyper-V and Azure Deployment.