### PR TITLE
Fixing a bug to handle download streams without a length info.

### DIFF
--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -547,17 +547,20 @@ function Get-LabInternetFile
                             $bytesProcessed += $bytesRead
 
                             [int]$percentageCompleted = $bytesProcessed / $response.ContentLength * 100
-                            if ($percentageCompletedPrev -ne $percentageCompleted)
+                            if ($percentageCompleted -gt 0)
                             {
-                                $percentageCompletedPrev = $percentageCompleted
-                                Write-Progress -Activity "Downloading file '$FileName'" `
-                                -Status ("{0:P} completed, {1:N2}MB of {2:N2}MB" -f ($percentageCompleted / 100), ($bytesProcessed / 1MB), ($response.ContentLength / 1MB)) `
-                                -PercentComplete ($percentageCompleted)
+                                if ($percentageCompletedPrev -ne $percentageCompleted)
+                                {
+                                    $percentageCompletedPrev = $percentageCompleted
+                                    Write-Progress -Activity "Downloading file '$FileName'" `
+                                    -Status ("{0:P} completed, {1:N2}MB of {2:N2}MB" -f ($percentageCompleted / 100), ($bytesProcessed / 1MB), ($response.ContentLength / 1MB)) `
+                                    -PercentComplete ($percentageCompleted)
+                                }
                             }
-                            #else
-                            #{
-                            #    Write-Verbose -Message "Could not determine the ContentLength of '$Uri'"
-                            #}
+                            else
+                            {
+                                Write-Verbose -Message "Could not determine the ContentLength of '$Uri'"
+                            }
                         } while ($bytesRead -gt 0)
                     }
 
@@ -623,8 +626,9 @@ function Get-LabInternetFile
         $PSBoundParameters.Remove('PassThru') | Out-Null
         try
         {
-            $result = Get-LabInternetFileInternal @PSBoundParameters -ErrorAction Stop
-            
+            $x = $PSBoundParameters
+            $result = Get-LabInternetFileInternal @PSBoundParameters
+
             $end = Get-Date
             Write-PSFMessage "Download has taken: $($end - $start)"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Rewritten some of the logic in Get-LabInternetFile.
   - Improves performance of Get-LabInternetFile.
   - Makes it working with more types of URLs.
+  - Fixed a newly introduced bug.
 
 ### Enhancements
 - SQL setup now does not override custom configuration file any longer when no other parameters are specified


### PR DESCRIPTION
## Description

See title

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
- DscWorkshop Deployment
- New installation of AL and download of LabSources folder