### PR TITLE
Replaced 'Get-Lab' call with lab definition data already available.

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -3237,7 +3237,7 @@ function Invoke-LabCommand
     
     if ($FilePath)
     {
-        $isLabPathIsOnLabAzureLabSourcesStorage = if ((Get-Lab).DefaultVirtualizationEngine = 'Azure')
+        $isLabPathIsOnLabAzureLabSourcesStorage = if ((Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
         {
             Test-LabPathIsOnLabAzureLabSourcesStorage -Path $FilePath
         }

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1488,7 +1488,6 @@ function Add-LabIsoImageDefinition
         throw 'Please create a lab before using this cmdlet. To create a new lab, call New-LabDefinition'
     }
 
-
     $type = Get-Type -GenericType AutomatedLab.ListXmlStore -T AutomatedLab.IsoImage
     #read the cache
     try
@@ -1503,7 +1502,7 @@ function Add-LabIsoImageDefinition
         $cachedIsos = New-Object $type
     }
 
-    if ((Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
+    if ($script:lab -eq 'Azure')
     {
         if (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $Path)
         {

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1502,7 +1502,7 @@ function Add-LabIsoImageDefinition
         $cachedIsos = New-Object $type
     }
 
-    if ($script:lab -eq 'Azure')
+    if ($script:lab.DefaultVirtualizationEngine -eq 'Azure')
     {
         if (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $Path)
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,29 @@
 # Changelog
 
 ## Unreleased
-- Fixed domain join performance issue. Joining to a domain took at least 15 minutes.
-- Removed parameter 'Path' from 'New-LabDefinition' and help.
-- Removed parameter 'NoAzurePublishSettingsFile' from 'New-LabDefinition' and help.
-- 'Test-LabPathIsOnLabAzureLabSourcesStorage' is only called if lab's DefaultVirtualizationEngine is Azure.
-- Fixes #806, Invoke-Command : Specified RemoteRunspaceInfo objects have duplicates.
-- Rewritten some of the logic in Get-LabInternetFile.
-  - Improves performance of Get-LabInternetFile.
-  - Makes it working with more types of URLs.
-  - Fixed a newly introduced bug.
 
 ### Enhancements
-- SQL setup now does not override custom configuration file any longer when no other parameters are specified
-- Add-LabMachineDefinition now assumes the most recent OS as a default if no system is specified
+- SQL setup now does not override custom configuration file any longer when no other parameters are specified.
+- Add-LabMachineDefinition now assumes the most recent OS as a default if no system is specified.
 - Added System Center Configuration Manager 1902 custom role - Thank you @codaamok !
-- Lab Sources folder is automatically updated now, too
+- Lab Sources folder is automatically updated now, too.
   - Will reduce issues with missing dependencies on post install activities that get renamed without an info...
 
 ### Bug Fixes
 - Fixes hardcode reference to a SQL configuration file with the path supplied in SQL role's properties `ConfigurationFile` - Thank you @codaamok !
 - Fixes timing issues with ADDS on Azure by skipping the wait period for guest reboots on Azure.
+- Rewritten some of the logic in Get-LabInternetFile.
+  - Improves performance of Get-LabInternetFile.
+  - Makes it working with more types of URLs.
+  - Fixed a newly introduced bug.
+- Replaced 'Get-Lab' call with lab definition data already available. 'Get-Lab' does not work as the deployment hasn't yet started.
+- Fixed a bug that prevented the call of 'Stop-LabVM2'.
+- Fixed a type (= != -eq).
+- Fixed domain join performance issue. Joining to a domain took at least 15 minutes.
+- Removed parameter 'Path' from 'New-LabDefinition' and help.
+- Removed parameter 'NoAzurePublishSettingsFile' from 'New-LabDefinition' and help.
+- 'Test-LabPathIsOnLabAzureLabSourcesStorage' is only called if lab's DefaultVirtualizationEngine is Azure.
+- Fixes #806, Invoke-Command : Specified RemoteRunspaceInfo objects have duplicates.
 
 ## 5.17.0 - 2020-01-08
 


### PR DESCRIPTION
## Description

- Replaced 'Get-Lab' call with lab definition data already available. 'Get-Lab' does not work as the deployment hasn't yet started.
- Fixed a bug that prevented the call of 'Stop-LabVM2'.
- Fixed a type (= != -eq).

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Some deps.