### PR TITLE
Removed module-breaking dependencies

### DIFF
--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -63,9 +63,6 @@
         'AutomatedLabNotifications',
         @{ModuleName='AutomatedLab.Common'; ModuleVersion='2.0.188'; }
         'PSFramework'
-        'xPSDesiredStateConfiguration'
-        'xDscDiagnostics'
-        'xWebAdministration'
     )
 
     CmdletsToExport        = @()

--- a/AutomatedLab/AutomatedLabDsc.psm1
+++ b/AutomatedLab/AutomatedLabDsc.psm1
@@ -105,6 +105,21 @@ function Install-LabDscPullServer
     if ($Online)
     {
         Invoke-LabCommand -ActivityName 'Setup Dsc Pull Server 1' -ComputerName $machines -ScriptBlock {
+            # Due to changes in the gallery: Accept TLS12
+            try
+            {
+                #https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netcore-2.0#System_Net_SecurityProtocolType_SystemDefault
+                if ($PSVersionTable.PSVersion.Major -lt 6 -and [Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12')
+                {
+                    Write-Verbose -Message 'Adding support for TLS 1.2'
+                    [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+                }
+            }
+            catch
+            {
+                Write-Warning -Message 'Adding TLS 1.2 to supported security protocols was unsuccessful.'
+            }
+
             Install-WindowsFeature -Name DSC-Service
             Install-PackageProvider -Name NuGet -Force
             Install-Module -Name $requiredModules -Force
@@ -119,6 +134,19 @@ function Install-LabDscPullServer
         else
         {
             Write-ScreenInfo "Downloading the modules '$($requiredModules -join ', ')' locally and copying them to the DSC Pull Servers."
+            try
+            {
+                #https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netcore-2.0#System_Net_SecurityProtocolType_SystemDefault
+                if ($PSVersionTable.PSVersion.Major -lt 6 -and [Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12')
+                {
+                    Write-Verbose -Message 'Adding support for TLS 1.2'
+                    [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+                }
+            }
+            catch
+            {
+                Write-Warning -Message 'Adding TLS 1.2 to supported security protocols was unsuccessful.'
+            }
 
             Install-PackageProvider -Name NuGet -Force | Out-Null
             Install-Module -Name $requiredModules -Force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - TFS Build Worker Role was undeployable when parameter TfsServer was used (#852).
 - Resolves a terminating error thrown by ConvertFrom-StringData if strings contained a non-escaped backslash.
 - Fixed an issue installing .net 4.8 in SQL server issue.
+- Fixed an issue with the new dependencies and moved them to offline installer
 
 ## 5.19.0 - 2020-04-03
 

--- a/Installer/.Build/PostBuild.ps1
+++ b/Installer/.Build/PostBuild.ps1
@@ -4,7 +4,7 @@
 
     [Parameter()]
     [string[]]
-    $ExternalDependency = @('PSFramework', 'newtonsoft.json', 'SHiPS'),
+    $ExternalDependency = @('PSFramework', 'newtonsoft.json', 'SHiPS', 'xPSDesiredStateConfiguration', 'xDscDiagnostics', 'xWebAdministration'),
 
     [Parameter()]
     [string[]]

--- a/Installer/.Build/PreBuild.ps1
+++ b/Installer/.Build/PreBuild.ps1
@@ -15,6 +15,19 @@ Write-Host "Init task - compiling help for Installer"
 if (-not (Get-Module -List PlatyPs))
 {
     Write-Host 'Installing Package Provider'
+    try
+    {
+        #https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netcore-2.0#System_Net_SecurityProtocolType_SystemDefault
+        if ($PSVersionTable.PSVersion.Major -lt 6 -and [Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12')
+        {
+            Write-Verbose -Message 'Adding support for TLS 1.2'
+            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+        }
+    }
+    catch
+    {
+        Write-Warning -Message 'Adding TLS 1.2 to supported security protocols was unsuccessful.'
+    }
     Install-PackageProvider nuget -Force
     Write-Host 'Installing Module PlatyPS'
     Install-Module PlatyPS -Force -AllowClobber -SkipPublisherCheck

--- a/LabSources/SampleScripts/Scenarios/Lab in a Box 1 - HyperV.ps1
+++ b/LabSources/SampleScripts/Scenarios/Lab in a Box 1 - HyperV.ps1
@@ -48,6 +48,20 @@ Invoke-LabCommand -ActivityName 'Install AutomatedLab and create LabSources fold
 
     #Add the AutomatedLab Telemetry setting to default to allow collection, otherwise will prompt during installation
     [System.Environment]::SetEnvironmentVariable('AUTOMATEDLAB_TELEMETRY_OPTOUT', '0')
+    try
+    {
+        #https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netcore-2.0#System_Net_SecurityProtocolType_SystemDefault
+        if ($PSVersionTable.PSVersion.Major -lt 6 -and [Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12')
+        {
+            Write-Verbose -Message 'Adding support for TLS 1.2'
+            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+        }
+    }
+    catch
+    {
+        Write-Warning -Message 'Adding TLS 1.2 to supported security protocols was unsuccessful.'
+    }
+
     Install-PackageProvider -Name Nuget -ForceBootstrap -Force -ErrorAction Stop | Out-Null
     Install-Module -Name AutomatedLab -AllowClobber -Force -ErrorAction Stop
 

--- a/LabSources/SampleScripts/Scenarios/Lab in a Box 2 - Azure.ps1
+++ b/LabSources/SampleScripts/Scenarios/Lab in a Box 2 - Azure.ps1
@@ -55,6 +55,19 @@ Invoke-LabCommand -ActivityName 'Install AutomatedLab and create LabSources fold
 
     #Add the AutomatedLab Telemetry setting to default to allow collection, otherwise will prompt during installation
     [System.Environment]::SetEnvironmentVariable('AUTOMATEDLAB_TELEMETRY_OPTOUT', '0')
+    try
+    {
+        #https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netcore-2.0#System_Net_SecurityProtocolType_SystemDefault
+        if ($PSVersionTable.PSVersion.Major -lt 6 -and [Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12')
+        {
+            Write-Verbose -Message 'Adding support for TLS 1.2'
+            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+        }
+    }
+    catch
+    {
+        Write-Warning -Message 'Adding TLS 1.2 to supported security protocols was unsuccessful.'
+    }
 
     Install-PackageProvider -Name Nuget -ForceBootstrap -Force -ErrorAction Stop | Out-Null
     Install-Module -Name AutomatedLab -AllowClobber -Force -ErrorAction Stop

--- a/LabSources/SampleScripts/Scenarios/ProGet Lab - Azure.ps1
+++ b/LabSources/SampleScripts/Scenarios/ProGet Lab - Azure.ps1
@@ -53,6 +53,19 @@ $progetUrl = "http://$($progetServer.FQDN)/nuget/PowerShell"
 $firstDomain = (Get-Lab).Domains[0]
 $nuGetApiKey = "$($firstDomain.Administrator.UserName)@$($firstDomain.Name):$($firstDomain.Administrator.Password)"
 Invoke-LabCommand -ActivityName RegisterPSRepository -ComputerName PGClient1 -ScriptBlock {
+    try
+    {
+        #https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netcore-2.0#System_Net_SecurityProtocolType_SystemDefault
+        if ($PSVersionTable.PSVersion.Major -lt 6 -and [Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12')
+        {
+            Write-Verbose -Message 'Adding support for TLS 1.2'
+            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+        }
+    }
+    catch
+    {
+        Write-Warning -Message 'Adding TLS 1.2 to supported security protocols was unsuccessful.'
+    }
     Install-PackageProvider -Name NuGet -Force
 
     $targetPath = 'C:\ProgramData\Microsoft\Windows\PowerShell\PowerShellGet'

--- a/LabSources/SampleScripts/Scenarios/ProGet Lab - HyperV.ps1
+++ b/LabSources/SampleScripts/Scenarios/ProGet Lab - HyperV.ps1
@@ -55,6 +55,19 @@ $progetUrl = "http://$($progetServer.FQDN)/nuget/PowerShell"
 $firstDomain = (Get-Lab).Domains[0]
 $nuGetApiKey = "$($firstDomain.Administrator.UserName)@$($firstDomain.Name):$($firstDomain.Administrator.Password)"
 Invoke-LabCommand -ActivityName RegisterPSRepository -ComputerName PGClient1 -ScriptBlock {
+    try
+    {
+        #https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netcore-2.0#System_Net_SecurityProtocolType_SystemDefault
+        if ($PSVersionTable.PSVersion.Major -lt 6 -and [Net.ServicePointManager]::SecurityProtocol -notmatch 'Tls12')
+        {
+            Write-Verbose -Message 'Adding support for TLS 1.2'
+            [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+        }
+    }
+    catch
+    {
+        Write-Warning -Message 'Adding TLS 1.2 to supported security protocols was unsuccessful.'
+    }
     Install-PackageProvider -Name NuGet -Force
 
     $targetPath = 'C:\ProgramData\Microsoft\Windows\PowerShell\PowerShellGet'

--- a/scriptanalyzer/AutomatedLabRules.psd1
+++ b/scriptanalyzer/AutomatedLabRules.psd1
@@ -9,7 +9,9 @@
         'PSAvoidUsingEmptyCatchBlock',
         'PSUseShouldProcessForStateChangingFunctions',
         'PSAvoidUsingInvokeExpression',
-        'PSAvoidUsingConvertToSecureStringWithPlainText')
+        'PSAvoidUsingConvertToSecureStringWithPlainText',
+        'PSAvoidUsingComputerNameHardcoded'
+        )
     'Rules'        = @{
         PSUseCompatibleCommmands = @{
             Enable = $true


### PR DESCRIPTION


<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

These modules are downloaded in any case and really do not need to be a hard requirement. Especially not for all users - not every user of AutomatedLab will deploy a DSC Pull Server and those who do will automatically download them during the deployment. In fully offline environments, the module is not downloaded in any way, since the installer has not been updated. This PR amends this and adds these "dependencies" to the installer.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Imported module on Linux/Core and it worked again. DSC deployment still works as usual, as the modules are installed anyway through AutomatedLabDsc.psm1 lines 105-136.