### PR TITLE
Custom ScriptAnalyzer rule

### DIFF
--- a/scriptanalyzer/ALCustomRules.psm1
+++ b/scriptanalyzer/ALCustomRules.psm1
@@ -1,0 +1,84 @@
+function Test-SimpleNullComparsion
+{
+
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    param (
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]
+        $ScriptBlockAst
+    )
+
+    $binExpressionAsts = $ScriptBlockAst.FindAll( { $args[0] -is [System.Management.Automation.Language.BinaryExpressionAst] }, $false);
+
+    foreach ($binExpressionAst in $binExpressionAsts)
+    {
+        # If operator is eq, ceq,ieq: $null -eq $bla or $bla -eq $Null: Use simple comparison
+        # Suggested correction: -not $bla
+        # If operator ne,cne,ine: $null -ne $bla, $bla -ne $null
+        # Suggested correction $bla
+        if ($binExpressionAst.Operator -in 'Equals', 'Ieq', 'Ceq' -and ($binExpressionAst.Left.Extent.Text -eq '$null' -or $binExpressionAst.Right.Extent.Text -eq '$null'))
+        {
+            $theCorrectExtent = if ($binExpressionAst.Right.Extent.Text -eq '$null')
+            {
+                $binExpressionAst.Left.Extent.Text
+            }
+            else
+            {
+                $binExpressionAst.Right.Extent.Text
+            }
+
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
+
+                Message              = 'Try to use simple $null comparisons'
+                Extent               = $binExpressionAst.Extent
+                RuleName             = 'ALSimpleNullComparison'
+                Severity             = 'Warning'
+                SuggestedCorrections = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent[]](
+                    [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent]::new(
+                        $binExpressionAst.Extent.StartLineNumber,
+                        $binExpressionAst.Extent.EndLineNumber,
+                        $binExpressionAst.Extent.StartColumnNumber,
+                        $binExpressionAst.Extent.EndColumnNumber,
+                        "-not $theCorrectExtent",
+                        $binExpressionAst.Extent.File,
+                        'Try to use simple $null comparisons'
+                    )
+                )
+            }
+        }
+
+        if ($binExpressionAst.Operator -in 'Ne', 'Cne', 'Ine' -and ($binExpressionAst.Left.Extent.Text -eq '$null' -or $binExpressionAst.Right.Extent.Text -eq '$null'))
+        {
+            $theCorrectExtent = if ($binExpressionAst.Right.Extent.Text -eq '$null')
+            {
+                $binExpressionAst.Left.Extent.Text
+            }
+            else
+            {
+                $binExpressionAst.Right.Extent.Text
+            }
+
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
+
+                Message              = 'Try to use simple $null comparisons'
+                Extent               = $binExpressionAst.Extent
+                RuleName             = 'ALSimpleNullComparison'
+                Severity             = 'Warning'
+                SuggestedCorrections = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent[]](
+                    [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent]::new(
+                        $binExpressionAst.Extent.StartLineNumber,
+                        $binExpressionAst.Extent.EndLineNumber,
+                        $binExpressionAst.Extent.StartColumnNumber,
+                        $binExpressionAst.Extent.EndColumnNumber,
+                        $theCorrectExtent,
+                        $binExpressionAst.Extent.File,
+                        'Try to use simple $null comparisons'
+                    )
+                )
+            }
+        }
+    }
+}

--- a/scriptanalyzer/AutomatedLabRules.psd1
+++ b/scriptanalyzer/AutomatedLabRules.psd1
@@ -10,7 +10,8 @@
         'PSUseShouldProcessForStateChangingFunctions',
         'PSAvoidUsingInvokeExpression',
         'PSAvoidUsingConvertToSecureStringWithPlainText',
-        'PSAvoidUsingComputerNameHardcoded'
+        'PSAvoidUsingComputerNameHardcoded',
+        'PSPossibleIncorrectComparisonWithNull'
         )
     'Rules'        = @{
         PSUseCompatibleCommmands = @{
@@ -31,4 +32,5 @@
             )
         }
     }
+    CustomRulePath = '.\scriptanalyzer\ALCustomRules.psm1'
 }


### PR DESCRIPTION
Flags overly complex null comparison and supports `Fix` parameter of `Invoke-ScriptAnalyzer`

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [x] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Ran analysis against our code base, saw the correct issues flagged. `Fix` parameter potentially worked as well, maybe I'll fix the issues and open a separate PR.