### PR TITLE
Updated release tagging and fixed module import loop (Fixes #869)

### DIFF
--- a/.build/psake.ps1
+++ b/.build/psake.ps1
@@ -24,7 +24,7 @@ Task BuildDebianPackage -Depends Test {
 
     # Build debian package structure
     $null = New-Item -ItemType Directory -Path ./deb/automatedlab/usr/local/share/powershell/Modules -Force
-    $null = New-Item -ItemType Directory -Path ./deb/automatedlab/usr/share/AutomatedLab/assets -Force
+    $null = New-Item -ItemType Directory -Path ./deb/automatedlab/usr/share/AutomatedLab/Assets -Force
     $null = New-Item -ItemType Directory -Path ./deb/automatedlab/usr/share/AutomatedLab/Stores -Force
     $null = New-Item -ItemType Directory -Path ./deb/automatedlab/usr/share/AutomatedLab/Labs -Force
     $null = New-Item -ItemType Directory -Path ./deb/automatedlab/usr/share/AutomatedLab/LabSources -Force
@@ -59,7 +59,7 @@ Installed-Size: $('{0:0}' -f ((Get-ChildItem -Path $env:APPVEYOR_BUILD_FOLDER -E
     $confPath = "./deb/automatedlab/usr/local/share/powershell/Modules/AutomatedLab/$($env:APPVEYOR_BUILD_VERSION)/AutomatedLab.init.ps1"
     Add-Content -Path $confPath -Value 'Set-PSFConfig -Module AutomatedLab -Name LabSourcesLocation -Description "Location of lab sources folder" -Validation string -Value "/usr/share/AutomatedLab/LabSources"'
 
-    Copy-Item -Path ./Assets/* -Recurse -Destination ./deb/automatedlab/usr/share/AutomatedLab/assets -Force
+    Copy-Item -Path ./Assets/* -Recurse -Destination ./deb/automatedlab/usr/share/AutomatedLab/Assets -Force
     Copy-Item -Path ./LabSources/* -Recurse -Destination ./deb/automatedlab/usr/share/AutomatedLab/LabSources -Force
 
     # Update permissions on AL folder to allow non-root access to configs

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -3564,7 +3564,7 @@ if (-not (Test-Path -Path (Split-Path $productKeyFilePath -Parent)))
 
 if (-not (Test-Path -Path $productKeyFilePath))
 {
-    Get-LabInternetFile -Uri $productKeyFileLink -Path $productKeyFilePath
+    Invoke-RestMethod -Method Get -Uri $productKeyFileLink -OutFile $productKeyFilePath
 }
 
 $productKeyCustomFilePath = Get-PSFConfigValue AutomatedLab.ProductKeyFilePathCustom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ### Bug Fixes
 
+- Fixed module import loop (Fixes #869)
+- Release tagging updated
+
 ## 5.20.0 - 2020-04-20
 
 ### Enhancements

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,8 +46,6 @@ for:
       project: AutomatedLab.sln
     deploy:
       - provider: GitHub
-        release: AutomatedLab-v$(appveyor_build_version)
-        tag: v$(appveyor_build_version)
         description: 'This is an automated deployment'
         auth_token:
           secure: 0gI2mQ864yW9/wSMzuKz4vqrHZ8hOEWcLdxTxvcH/U13he2WSmRyNIxN7Rebersx # your encrypted token from GitHub
@@ -65,8 +63,6 @@ for:
     build_script: dotnet build -f netcoreapp2.2 LabXml/LabXml.csproj
     deploy:
       - provider: GitHub
-        release: AutomatedLab-v$(appveyor_build_version)
-        tag: v$(appveyor_build_version)
         description: 'This is an automated deployment'
         auth_token:
           secure: 0gI2mQ864yW9/wSMzuKz4vqrHZ8hOEWcLdxTxvcH/U13he2WSmRyNIxN7Rebersx # your encrypted token from GitHub


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Removed optional release tagging, future releases are call 5.21.0 instead of v5.21.0.

Additionally I fixed an issue I observed on a fresh system where the ProductKeys.xml file was missing: An import loop. Fixes #869

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Ran Import-Module on a fresh system and observed the improvement in the verbose output