### PR TITLE
Fixed issue with Test-Connection failing

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1,4 +1,4 @@
-#region Enable-LabHostRemoting
+﻿#region Enable-LabHostRemoting
 function Enable-LabHostRemoting
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCompatibleCmdlets", "")]
@@ -1365,7 +1365,7 @@ function Get-LabAvailableOperatingSystem
         foreach ($os in $cachedSkus)
         {
             $cachedOs = [AutomatedLab.OperatingSystem]::new($os.Skus, $true)
-            if ($null -ne $cachedOs.OperatingSystemName) {$cachedOsList.Add($cachedOs)}
+            if ($cachedOs.OperatingSystemName) {$cachedOsList.Add($cachedOs)}
         }
 
         if ($UseOnlyCache)
@@ -2872,7 +2872,7 @@ function Set-LabInstallationCredential
 
     if ((Get-LabDefinition).DefaultVirtualizationEngine -eq 'Azure')
     {
-        if ($null -ne $Password -and $azurePasswordBlacklist -contains $Password)
+        if ($Password -and $azurePasswordBlacklist -contains $Password)
         {
             throw "Password '$Password' is in the list of forbidden passwords for Azure VMs: $($azurePasswordBlacklist -join ', ')"
         }
@@ -2890,7 +2890,7 @@ function Set-LabInstallationCredential
             $Password.Length -ge 8
         )
 
-        if ($null -ne $Password -and $checks -contains $false)
+        if ($Password -and $checks -contains $false)
         {
             throw "Passwords for Azure VM administrator have to:
                 Be at least 8 characters long
@@ -3487,7 +3487,7 @@ function Get-LabConfigurationItem
     if ($Name)
     {
         $setting = (Get-PSFConfig -Module AutomatedLab -Name $Name).Value
-        if ($null -eq $setting -and $null -ne $Default)
+        if (-not $setting -and $Default)
         {
             return $Default
         }
@@ -3504,6 +3504,7 @@ function Test-LabHostConnected
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCompatibleCmdlets", "")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingComputerNameHardcoded", "")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("ALSimpleNullComparison", "", Justification="We want a boolean")]
     [CmdletBinding()]
     param
     (
@@ -3525,9 +3526,14 @@ function Test-LabHostConnected
             # Assuming that we are in Azure Cloud Console aka Cloud Shell which is connected but cannot send ICMP packages
             $true
         }
+        elseif ($IsLinux)
+        {
+            # Due to an unadressed issue with Test-Connection on Linux
+            [System.Net.NetworkInformation.Ping]::new().Send('automatedlab.org').Status -eq 'Success'
+        }
         else
         {
-            Test-Connection -ComputerName 8.8.8.8 -Count 4 -Quiet -ErrorAction SilentlyContinue -InformationAction Ignore
+            Test-Connection -ComputerName automatedlab.org -Count 4 -Quiet -ErrorAction SilentlyContinue -InformationAction Ignore
         }
     }
 


### PR DESCRIPTION
## Description

Test-Connection randomly fails in PowerShell Core, whereas the .NET Ping.Send method works well in those edge cases.

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Azure lab deployment on Azure DevOps hosted Ubuntu agent, which threw the initial error. Retested on Ubuntu WSL and CentOS