### PR TITLE
Azure: Check for interactive environment before prompting lab sources sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Bug Fixes
 
+- Fixed an issue where Azure labs would prompt the user even when in a non-interactive environment
+
 ## 5.20.0 - 2020-04-20
 
 ### Enhancements


### PR DESCRIPTION
## Description

Checking for interactive environment instead of prompting and thereby cancelling e.g. build processes or otherwise headless deployments of AL.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Ran an Azure-based lab on a hosted Azure DevOps build worker and was not asked to sync whereas I was asked on an interactive session