### PR TITLE
Update CM-1902.ps1

### DIFF
--- a/LabSources/SampleScripts/Scenarios/CM-1902.ps1
+++ b/LabSources/SampleScripts/Scenarios/CM-1902.ps1
@@ -343,7 +343,7 @@ switch ($true) {
     ((Get-VMSwitch).Name -notcontains $ExternalVMSwitchName) { 
         throw ("Hyper-V virtual switch '{0}' does not exist" -f $ExternalVMSwitchName)
     }
-    ((Get-VMSwitch -Name $ExternalVMSwitchName).SwitchType -ne "External") { 
+    ( Get-VMSwitch | ? { ($_.Name -eq $ExternalVMSwitchName) -and ($_.SwitchType -eq "External") } )  { 
         throw ("Hyper-V virtual switch '{0}' is not of External type" -f $ExternalVMSwitchName)
     }
     (-not(Test-Path $SQLConfigurationFile)) {


### PR DESCRIPTION
Adam,

1) The parameter -NoInternetAccess doesn't work, the script always wants External switch, works only detection of the both parameters presence at the same time:
line 340    ($NoInternetAccess.IsPresent -And $PSBoundParameters.ContainsKey("ExternalVMSwitchName")) {
line 341        throw "Can not use -NoInternetAccess and -ExternalVMSwitchName together"

afterwards in the next lines the script doesn't really care about the switch -NoInternetAccess in context of External adapter and the Internet. No fix proposal yet - more changes required - at least to name NoInternet switch.

2) What makes the script to fail is the Get-VMSwitch with -Name parameter returns empty result, so I can't run it at all, because false positive lack of External switch is detected.

Proposal to fix wrong detection of the External switch for example:

Change condition in line 346 to:
( Get-VMSwitch | ? { ($_.Name -eq $ExternalVMSwitchName) -and ($_.SwitchType -eq "External") } )  { 

or something like this

Some time ago I rewritten your old script that deployed CM1703 to deploy CM1902 and sent the code to Raimund via email (around April 2019). Lack of my knowledge about Git caused I couldn't put the project to Git as he asked.

Good luck with the superb project.
Mariusz

<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [X] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [ ] - The PR has a meaningful title.  
- [ ] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
I have rerun the scenario in my lab HV 2016, and the External adapter was recognized correctly.
 -->
