### PR TITLE
Disabling CredSsp for 'Enable-LabAutoLogon'

### DIFF
--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -1913,7 +1913,7 @@ function Enable-LabAutoLogon
             Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultDomainName -Value $parameters.DomainName -Type String -Force
             Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultPassword -Value $parameters.Password -Type String -Force
             Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultUserName -Value $parameters.UserName -Type String -Force
-        } -Variable (Get-Variable parameters) -NoDisplay
+        } -Variable (Get-Variable parameters) -DoNotUseCredSsp -NoDisplay
     }
 }
 #endregion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed module import loop (Fixes #869)
 - Release tagging updated
 - Fixed an issue where Azure labs would prompt the user even when in a non-interactive environment
+- 'Enable-LabAutoLogon' does no longer use CredSSP as this authentication protocol is not enabled at that early stage (fixes #880)
 
 ## 5.20.0 - 2020-04-20
 


### PR DESCRIPTION
## Description

This fixes #880.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
```powershell
New-LabDefinition -Name "TestSQLServerWinRMError" -DefaultVirtualizationEngine "HyperV" -ReferenceDiskSizeInGB 100
Add-LabIsoImageDefinition -Name SQLServer2017 -Path E:\LabSources\ISOs\SQLServer2017-x64-ENU.iso
$sqlRole = Get-LabMachineRoleDefinition -Role SQLServer2017
Add-LabMachineDefinition -Name "SQLServer2017" -OperatingSystem "Windows Server 2019 Standard (Desktop Experience)" -Roles $sqlRole
Install-Lab
```