### PR TITLE
Fixes #884

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -707,8 +707,8 @@ function Install-Lab
         [switch]$HyperV,
         [switch]$StartRemainingMachines,
         [switch]$CreateCheckPoints,
-        [int]$DelayBetweenComputers,
-        [switch]$NoValidation
+        [switch]$NoValidation,
+        [int]$DelayBetweenComputers
     )
 
     Write-LogFunctionEntry
@@ -1100,11 +1100,16 @@ function Install-Lab
     if (($StartRemainingMachines -or $performAll) -and (Get-LabVM -IncludeLinux))
     {
         Write-ScreenInfo -Message 'Starting remaining machines' -TaskStart
+
+        if (-not $DelayBetweenComputers)
+        {
+            $hypervMachineCount = (Get-LabVM -IncludeLinux | Where-Object HostType -eq HyperV).Count
+            $DelayBetweenComputers = [System.Math]::Log($hypervMachineCount, 5) * 30
+            Write-ScreenInfo -Message "DelayBetweenComputers not defined, value calculated is $DelayBetweenComputers seconds"
+        }
+
         Write-ScreenInfo -Message 'Waiting for machines to start up...' -NoNewLine
 
-        if ($DelayBetweenComputers){
-            $DelayBetweenComputers = ([int]((Get-LabVM -IncludeLinux).HostType -contains 'HyperV') * 30)
-        }
         Start-LabVM -All -DelayBetweenComputers $DelayBetweenComputers -ProgressIndicator 30 -TimeoutInMinutes 60 -Wait
 
         Write-ScreenInfo -Message 'Done' -TaskEnd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Release tagging updated
 - Fixed an issue where Azure labs would prompt the user even when in a non-interactive environment
 - 'Enable-LabAutoLogon' does no longer use CredSSP as this authentication protocol is not enabled at that early stage (fixes #880)
+- DelayBetweenComputers works now if defined and if not is calculated based on the umber of machines
 
 ## 5.20.0 - 2020-04-20
 


### PR DESCRIPTION
## Description

Fixes #884 and adapts the automatically calculation of DelayBetweenComputers to the number of machines.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
```powershell
New-LabDefinition -Name Lab1 -DefaultVirtualizationEngine HyperV

1..10 | ForEach-Object {
    Add-LabMachineDefinition -Name "Client$_" -Memory 1GB -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'
}
Install-Lab -NetworkSwitches -BaseImages -VMs -Domains

Install-Lab -StartRemainingMachines #-DelayBetweenComputers 120

Show-LabDeploymentSummary -Detailed
```