### PR TITLE
Linux path issues, TFS deployment issue, Azure SQL image issue

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -71,6 +71,7 @@ Set-PSFConfig -Module 'AutomatedLab' -Name Timeout_Sql2014Installation -Value 90
 Set-PSFConfig -Module 'AutomatedLab' -Name Timeout_VisualStudio2013Installation -Value 90 -Initialize -Validation integer -Description 'Timeout in minutes for VS 2013'
 Set-PSFConfig -Module 'AutomatedLab' -Name Timeout_VisualStudio2015Installation -Value 90 -Initialize -Validation integer -Description 'Timeout in minutes for VS 2015'
 Set-PSFConfig -Module 'AutomatedLab' -Name DefaultProgressIndicator -Value 10 -Initialize -Validation integer -Description 'After how many minutes will a progress indicator be written'
+Set-PSFConfig -Module 'AutomatedLab' -Name DisableConnectivityCheck -Value $false -Initialize -Validation bool -Description 'Indicates whether connectivity checks should be skipped. Certain systems like Azure DevOps build workers do not send ICMP packges and the method might always fail'
 
 #PSSession settings
 Set-PSFConfig -Module 'AutomatedLab' -Name InvokeLabCommandRetries -Value 3 -Initialize -Validation integer -Description 'Number of retries for Invoke-LabCommand'

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -8,6 +8,8 @@ function Enable-LabHostRemoting
         [switch]$NoDisplay
     )
 
+    if ($IsLinux) { return }
+
     Write-LogFunctionEntry
 
     if (-not (Test-IsAdministrator))
@@ -206,6 +208,7 @@ function Undo-LabHostRemoting
         [switch]$NoDisplay
     )
 
+    if ($IsLinux) { return }
     Write-LogFunctionEntry
 
     if (-not (Test-IsAdministrator))
@@ -277,6 +280,7 @@ function Test-LabHostRemoting
     [CmdletBinding()]
     param()
 
+    if ($IsLinux) { return }
     Write-LogFunctionEntry
 
     $configOk = $true
@@ -3537,7 +3541,15 @@ function Test-LabHostConnected
         elseif ($IsLinux)
         {
             # Due to an unadressed issue with Test-Connection on Linux
-            [System.Net.NetworkInformation.Ping]::new().Send('automatedlab.org').Status -eq 'Success'
+            $portOpen = Test-Port -ComputerName automatedlab.org -Port 443
+            if (-not $portOpen.Open)
+            {
+                [System.Net.NetworkInformation.Ping]::new().Send('automatedlab.org').Status -eq 'Success'
+            }
+            else
+            {
+                $portOpen.Open
+            }
         }
         else
         {

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -2475,7 +2475,7 @@ function Install-LabSoftwarePackage
             $parameters.Add('DependencyFolderPath', $Path)
         }
 
-        $installPath = Join-Path -Path C:\ -ChildPath (Split-Path -Path $Path -Leaf)
+        $installPath = Join-Path -Path / -ChildPath (Split-Path -Path $Path -Leaf)
     }
     elseif ($parameterSetName -eq 'SingleLocalPackage')
     {
@@ -2492,7 +2492,7 @@ function Install-LabSoftwarePackage
             $parameters.Add('DependencyFolderPath', $SoftwarePackage.Path)
         }
 
-        $installPath = Join-Path -Path C:\ -ChildPath (Split-Path -Path $SoftwarePackage.Path -Leaf)
+        $installPath = Join-Path -Path / -ChildPath (Split-Path -Path $SoftwarePackage.Path -Leaf)
     }
 
     $installParams = @{

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -3527,6 +3527,11 @@ function Test-LabHostConnected
         $Quiet
     )
 
+    if (Get-LabConfigurationItem -Name DisableConnectivityCheck)
+    {
+        $script:connected = $true
+    }
+
     if (-not $script:connected)
     {
         $script:connected = if (Get-Command Get-NetConnectionProfile -ErrorAction SilentlyContinue)

--- a/AutomatedLab/AutomatedLabADCS.psm1
+++ b/AutomatedLab/AutomatedLabADCS.psm1
@@ -1506,7 +1506,7 @@ function Get-LabIssuingCA
     }
 
     $issuingCAs = Invoke-LabCommand -ComputerName $machines -ScriptBlock {
-        Start-Service -Name CertSrv -ErrorAction SilentlyContinue
+        Start-Service -Name CertSvc -ErrorAction SilentlyContinue
         $templates = certutil.exe -CATemplates
         if ($templates -like '*Machine*')
         {
@@ -1574,7 +1574,7 @@ function Request-LabCertificate
     }
 
     # Especially on Azure, the CertSrv was sometimes stopped for no apparent reason
-    Invoke-LabCommand -ComputerName $onlineCAVM -ScriptBlock { Start-Service CertSrv }
+    Invoke-LabCommand -ComputerName $onlineCAVM -ScriptBlock { Start-Service CertSvc }
 
     #machine was found so only the machine name was given. Get the full CA path.
     if ($onlineCAVM)

--- a/AutomatedLab/AutomatedLabADCS.psm1
+++ b/AutomatedLab/AutomatedLabADCS.psm1
@@ -1565,15 +1565,18 @@ function Request-LabCertificate
     }
     if ($OnlineCA)
     {
-        $onlienCAVM = Get-LabVM -ComputerName $OnlineCA
+        $onlineCAVM = Get-LabVM -ComputerName $OnlineCA
     }
     else
     {
-        $onlienCAVM = Get-LabIssuingCA -DomainName (Get-LabVM -ComputerName $ComputerName).DomainName
+        $onlineCAVM = Get-LabIssuingCA -DomainName (Get-LabVM -ComputerName $ComputerName).DomainName
     }
 
+    # Especially on Azure, the CertSrv was sometimes stopped for no apparent reason
+    Invoke-LabCommand -ComputerName $onlineCAVM -ScriptBlock { Start-Service CertSrv }
+
     #machine was found so only the machine name was given. Get the full CA path.
-    if ($onlienCAVM)
+    if ($onlineCAVM)
     {
         #$OnlineCA = Get-LabIssuingCA | Where-Object Name -eq $OnlineCA | Select-Object -ExpandProperty CaPath
         $PSBoundParameters.OnlineCA = Get-LabIssuingCA | Where-Object Name -eq $OnlineCA | Select-Object -ExpandProperty CaPath

--- a/AutomatedLab/AutomatedLabADCS.psm1
+++ b/AutomatedLab/AutomatedLabADCS.psm1
@@ -1506,6 +1506,7 @@ function Get-LabIssuingCA
     }
 
     $issuingCAs = Invoke-LabCommand -ComputerName $machines -ScriptBlock {
+        Start-Service -Name CertSrv -ErrorAction SilentlyContinue
         $templates = certutil.exe -CATemplates
         if ($templates -like '*Machine*')
         {

--- a/AutomatedLab/AutomatedLabADCS.psm1
+++ b/AutomatedLab/AutomatedLabADCS.psm1
@@ -1580,7 +1580,7 @@ function Request-LabCertificate
     if ($onlineCAVM)
     {
         #$OnlineCA = Get-LabIssuingCA | Where-Object Name -eq $OnlineCA | Select-Object -ExpandProperty CaPath
-        $PSBoundParameters.OnlineCA = Get-LabIssuingCA | Where-Object Name -eq $OnlineCA | Select-Object -ExpandProperty CaPath
+        $PSBoundParameters.OnlineCA = (Get-LabIssuingCA | Where-Object Name -eq $OnlineCA).CaPath
     }
 
     $variables = Get-Variable -Name PSBoundParameters

--- a/AutomatedLab/AutomatedLabADCS.psm1
+++ b/AutomatedLab/AutomatedLabADCS.psm1
@@ -3001,7 +3001,7 @@ function Publish-LabCAInstallCertificates
         foreach ($certfile in (Get-ChildItem -Path "$((Get-Lab).LabPath)\Certificates"))
         {
             Write-PSFMessage -Message "Send file '$($certfile.FullName)' to 'C:\Windows\$($certfile.BaseName).crt'"
-            Send-File -SourceFilePath $certfile.FullName -DestinationFolderPath C:\Windows -Session $machineSession
+            Send-File -SourceFilePath $certfile.FullName -DestinationFolderPath /Windows -Session $machineSession
         }
 
         $scriptBlock = {

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -80,6 +80,7 @@ function Add-LabAzureSubscription
 
         [string]$DefaultLocationName,
 
+        [ObsoleteAttribute()]
         [string]$DefaultStorageAccountName,
 
         [string]$DefaultResourceGroupName,
@@ -477,40 +478,8 @@ Have a look at Get-Command -Syntax Sync-LabAzureLabSources for additional inform
     $script:lab.AzureSettings.VirtualMachines = [AutomatedLab.Azure.AzureVirtualMachine]::Create($vms)
     Write-PSFMessage "Added $($script:lab.AzureSettings.VirtualMachines.Count) virtual machines"
 
-    #$script:lab.AzureSettings.DefaultStorageAccount cannot be set when creating the definitions but is during the import process
-    if (-not $script:lab.AzureSettings.DefaultStorageAccount)
-    {
-        Write-ScreenInfo -Message 'No default storage account exist. Determining storage account now' -Type Info
-        if (-not $DefaultStorageAccountName)
-        {
-            $DefaultStorageAccountName = ($script:lab.AzureSettings.StorageAccounts | Where-Object StorageAccountName -like 'automatedlab????????' | Select-Object -First 1).StorageAccountName
-        }
-
-        if (-not $DefaultStorageAccountName)
-        {
-            Write-ScreenInfo -Message 'No storage account for AutomatedLab found. Creating a storage account now'
-            New-LabAzureDefaultStorageAccount -LocationName $DefaultLocationName -ResourceGroupName $DefaultResourceGroupName
-        }
-        else
-        {
-            try
-            {
-                Set-LabAzureDefaultStorageAccount -Name $DefaultStorageAccountName -ErrorAction Stop
-                Write-ScreenInfo -Message "Using Azure Storage Account '$DefaultStorageAccountName'" -Type Info
-            }
-            catch
-            {
-                throw 'Cannot proceed with an invalid default storage account'
-            }
-        }
-        Write-PSFMessage "Mapping storage account '$((Get-LabAzureDefaultStorageAccount).StorageAccountName)' to resource group $DefaultResourceGroupName'"
-        [void](Set-AzCurrentStorageAccount -Name $((Get-LabAzureDefaultStorageAccount).StorageAccountName) -ResourceGroupName $DefaultResourceGroupName)
-    }
-
     Write-ScreenInfo -Message "Azure default resource group name will be '$($script:lab.Name)'"
-
     Write-ScreenInfo -Message "Azure data center location will be '$DefaultLocationName'" -Type Info
-
     Write-ScreenInfo -Message 'Finished adding Azure subscription data' -Type Info -TaskEnd
 
     if ($PassThru)
@@ -689,6 +658,9 @@ function Set-LabAzureDefaultStorageAccount
         [string]$Name
     )
 
+    Write-ScreenInfo -Type Warning -Message 'Set-LabAzureDefaultStorageAccount is obsolete'
+    return
+
     Write-LogFunctionEntry
 
     Update-LabAzureSettings
@@ -708,6 +680,9 @@ function Get-LabAzureDefaultStorageAccount
 {
     [CmdletBinding()]
     param ()
+
+    Write-ScreenInfo -Type Warning -Message 'Set-LabAzureDefaultStorageAccount is obsolete'
+    return
 
     Write-LogFunctionEntry
 
@@ -733,6 +708,9 @@ function New-LabAzureDefaultStorageAccount
         [Parameter(Mandatory)]
         [string]$ResourceGroupName
     )
+
+    Write-ScreenInfo -Type Warning -Message 'Set-LabAzureDefaultStorageAccount is obsolete'
+    return
 
     Test-LabHostConnected -Throw -Quiet
 

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -357,7 +357,7 @@ Have a look at Get-Command -Syntax Sync-LabAzureLabSources for additional inform
 "@
         # Detecting Interactivity this way only works in .NET Full - .NET Core always defaults to $true
         # Last Resort is checking the CommandLine Args
-        $choice = if ([Environment]::UserInteractive -or ([Environment]::GetCommandLineArgs() -match "^-Non"))
+        $choice = if (($PSVersionTable.PSEdition -eq 'Desktop' -and [Environment]::UserInteractive) -or ($PSVersionTable.PSEdition -eq 'Core' -and [string][Environment]::GetCommandLineArgs() -notmatch "-Non"))
         {
             Read-Choice -ChoiceList '&Yes', '&No, do not ask me again', 'N&o, not this time' -Caption 'Sync lab sources to Azure?' -Message $syncText -Default 0
         }

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -355,7 +355,9 @@ execute Sync-LabAzureLabSources manually. The maximum file size for the automati
 be set in your settings with the setting LabSourcesMaxFileSizeMb.
 Have a look at Get-Command -Syntax Sync-LabAzureLabSources for additional information.
 "@
-        $choice = if ([Environment]::UserInteractive)
+        # Detecting Interactivity this way only works in .NET Full - .NET Core always defaults to $true
+        # Last Resort is checking the CommandLine Args
+        $choice = if ([Environment]::UserInteractive -or ([Environment]::GetCommandLineArgs() -match "^-Non"))
         {
             Read-Choice -ChoiceList '&Yes', '&No, do not ask me again', 'N&o, not this time' -Caption 'Sync lab sources to Azure?' -Message $syncText -Default 0
         }

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -424,13 +424,9 @@ Have a look at Get-Command -Syntax Sync-LabAzureLabSources for additional inform
 
         Write-PSFMessage "Read $($global:cacheVmImages.Count) OS images from the cache"
 
-        if ($global:cacheVmImages)
-        {
-            Write-PSFMessage ("Azure OS Cache was older than {0:yyyy-MM-dd HH:mm:ss}. Cache date was {1:yyyy-MM-dd HH:mm:ss}" -f (Get-Date).AddDays(-7) , $global:cacheVmImages.TimeStamp)
-        }
-
         if ($global:cacheVmImages -and $global:cacheVmImages.TimeStamp -gt (Get-Date).AddDays(-7))
         {
+            Write-PSFMessage ("Azure OS Cache was older than {0:yyyy-MM-dd HH:mm:ss}. Cache date was {1:yyyy-MM-dd HH:mm:ss}" -f (Get-Date).AddDays(-7) , $global:cacheVmImages.TimeStamp)
             Write-ScreenInfo 'Querying available operating system images (using cache)'
             $vmImages = $global:cacheVmImages
         }

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -1299,12 +1299,18 @@ function Sync-LabAzureLabSources
 
             # Try to set the file hash
             $uploadedFile = Get-AzStorageFile -Share (Get-AzStorageShare -Name labsources -Context $storageAccount.Context) -Path $fileName -ErrorAction SilentlyContinue
-            $uploadedFile.Properties.ContentMD5 = (Get-FileHash -Path $file.FullName -Algorithm MD5).Hash
-            $apiResponse = $uploadedFile.SetPropertiesAsync()
-            if (-not $apiResponse.Status -eq "RanToCompletion")
+            try
             {
-                Write-ScreenInfo "Could not generate MD5 hash for file $fileName. Status was $($apiResponse.Status)" -Type Warning
-                continue
+                $uploadedFile.Properties.ContentMD5 = (Get-FileHash -Path $file.FullName -Algorithm MD5).Hash
+                $apiResponse = $uploadedFile.SetPropertiesAsync()
+                if (-not $apiResponse.Status -eq "RanToCompletion")
+                {
+                    Write-ScreenInfo "Could not generate MD5 hash for file $fileName. Status was $($apiResponse.Status)" -Type Warning
+                }
+            }
+            catch
+            {
+                Write-ScreenInfo "Could not generate MD5 hash for file $fileName." -Type Warning
             }
 
             Write-PSFMessage "Azure file $fileName successfully uploaded and hash generated"

--- a/AutomatedLab/AutomatedLabHyperV.psm1
+++ b/AutomatedLab/AutomatedLabHyperV.psm1
@@ -11,12 +11,15 @@ function Install-LabHyperV
 
     Write-ScreenInfo -Message 'Exposing virtualization extensions...' -NoNewLine
     $hyperVVms = $vms | Where-Object -Property HostType -eq HyperV
-    $enableVirt = $vms | Where-Object {-not ($_ | Get-VmProcessor).ExposeVirtualizationExtensions}
-    if ($null -ne $enableVirt)
+    if ($hyperVVms)
     {
-        Stop-LabVm -Wait -ComputerName $enableVirt
-        $enableVirt | Set-VMProcessor -ExposeVirtualizationExtensions $true
-		$enableVirt | Get-VMNetworkAdapter | Set-VMNetworkAdapter -MacAddressSpoofing On
+        $enableVirt = $vms | Where-Object {-not ($_ | Get-VmProcessor).ExposeVirtualizationExtensions}
+        if ($null -ne $enableVirt)
+        {
+            Stop-LabVm -Wait -ComputerName $enableVirt
+            $enableVirt | Set-VMProcessor -ExposeVirtualizationExtensions $true
+            $enableVirt | Get-VMNetworkAdapter | Set-VMNetworkAdapter -MacAddressSpoofing On
+        }
     }
 
     Start-LabVm -Wait -ComputerName $vms # Start all, regardless of Hypervisor
@@ -45,56 +48,42 @@ function Install-LabHyperV
     Restart-LabVm -ComputerName $vms -Wait -NoDisplay
     Write-ScreenInfo -Message 'Done'
 
-    #Configure
-    $settingsTable = @{ }
-
-    # Correct data types for individual settings
-    $parametersAndTypes = @{
-        MaximumStorageMigrations                  = [uint32]
-        MaximumVirtualMachineMigrations           = [uint32]
-        VirtualMachineMigrationAuthenticationType = [Microsoft.HyperV.PowerShell.MigrationAuthenticationType]
-        UseAnyNetworkForMigration                 = [bool]
-        VirtualMachineMigrationPerformanceOption  = [Microsoft.HyperV.PowerShell.VMMigrationPerformance]
-        ResourceMeteringSaveInterval              = [timespan]
-        NumaSpanningEnabled                       = [bool]
-        EnableEnhancedSessionMode                 = [bool]
-    }
-
-    foreach ($vm in $vms)
+    $jobs = foreach ($vm in $vms)
     {
-        [hashtable]$roleParameters = ($vm.Roles | Where-Object Name -eq HyperV).Properties
-        if ($roleParameters.Count -eq 0) { continue }
-
-        $parameters = Sync-Parameter -Command (Get-Command Set-VMHost) -Parameters $roleParameters
-        foreach ($parameter in $parameters.Clone().GetEnumerator())
-        {
-            $type = $parametersAndTypes[$parameter.Key]
-
-            if ($type -eq [bool])
-            {
-                $parameters[$parameter.Key] = [Convert]::ToBoolean($parameter.Value)
+        Invoke-LabCommand -ActivityName 'Configuring VM Host settings' -ComputerName $settingsTable.Keys -Variable (Get-Variable -Name vm) -ScriptBlock {
+            Import-Module Hyper-V
+            # Correct data types for individual settings
+            $parametersAndTypes = @{
+                MaximumStorageMigrations                  = [uint32]
+                MaximumVirtualMachineMigrations           = [uint32]
+                VirtualMachineMigrationAuthenticationType = [Microsoft.HyperV.PowerShell.MigrationAuthenticationType]
+                UseAnyNetworkForMigration                 = [bool]
+                VirtualMachineMigrationPerformanceOption  = [Microsoft.HyperV.PowerShell.VMMigrationPerformance]
+                ResourceMeteringSaveInterval              = [timespan]
+                NumaSpanningEnabled                       = [bool]
+                EnableEnhancedSessionMode                 = [bool]
             }
-            else
+
+            [hashtable]$roleParameters = ($vm.Roles | Where-Object Name -eq HyperV).Properties
+            if ($roleParameters.Count -eq 0) { continue }
+            $parameters = Sync-Parameter -Command (Get-Command Set-VMHost) -Parameters $roleParameters
+            
+            foreach ($parameter in $parameters.Clone().GetEnumerator())
             {
-                $parameters[$parameter.Key] = $parameter.Value -as $type
+                $type = $parametersAndTypes[$parameter.Key]
+
+                if ($type -eq [bool])
+                {
+                    $parameters[$parameter.Key] = [Convert]::ToBoolean($parameter.Value)
+                }
+                else
+                {
+                    $parameters[$parameter.Key] = $parameter.Value -as $type
+                }
             }
-        }
 
-        $settingsTable.Add($vm.Name, $parameters)
-    }
-
-    if ($settingsTable.Keys.Count -eq 0)
-    {
-        return
-    }
-
-    Invoke-LabCommand -ActivityName 'Configuring VM Host settings' -ComputerName $settingsTable.Keys -Variable (Get-Variable -Name settingsTable) -ScriptBlock {
-        $vmParameters = $settingsTable[$env:COMPUTERNAME]
-
-        if ($vmParameters)
-        {
-            Set-VMHost @vmParameters
-        }
+            Set-VMHost @parameters
+        } -Function (Get-Command -Name Sync-Parameter) -AsJob
     }
 
     Write-LogFunctionExit

--- a/AutomatedLab/AutomatedLabHyperV.psm1
+++ b/AutomatedLab/AutomatedLabHyperV.psm1
@@ -83,8 +83,10 @@ function Install-LabHyperV
             }
 
             Set-VMHost @parameters
-        } -Function (Get-Command -Name Sync-Parameter) -AsJob
+        } -Function (Get-Command -Name Sync-Parameter) -AsJob -PassThru
     }
+
+    Wait-LWLabJob -Job $jobs
 
     Write-LogFunctionExit
 }

--- a/AutomatedLab/AutomatedLabHyperV.psm1
+++ b/AutomatedLab/AutomatedLabHyperV.psm1
@@ -50,7 +50,7 @@ function Install-LabHyperV
 
     $jobs = foreach ($vm in $vms)
     {
-        Invoke-LabCommand -ActivityName 'Configuring VM Host settings' -ComputerName $settingsTable.Keys -Variable (Get-Variable -Name vm) -ScriptBlock {
+        Invoke-LabCommand -ActivityName 'Configuring VM Host settings' -ComputerName $vm -Variable (Get-Variable -Name vm) -ScriptBlock {
             Import-Module Hyper-V
             # Correct data types for individual settings
             $parametersAndTypes = @{

--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -606,22 +606,21 @@ function Get-LabInternetFile
 
             $end = Get-Date
             Write-PSFMessage "Download has taken: $($end - $start)"
-
-            if ($PassThru)
-            {
-                $uri2 = New-Object System.Uri($Uri)
-                New-Object PSObject -Property @{
-                    Uri = $Uri
-                    Path = $Path
-                    FileName = ?? { $FileName } { $FileName } { $script:FileName}
-                    FullName = Join-Path -Path $Path -ChildPath (?? { $FileName } { $FileName } { $script:FileName})
-                    Length = $result.ContentLength
-                }
-            }
         }
         catch
         {
             Write-Error -ErrorRecord $_
+        }
+    }
+
+    if ($PassThru)
+    {
+        New-Object PSObject -Property @{
+            Uri = $Uri
+            Path = $Path
+            FileName = ?? { $FileName } { $FileName } { $script:FileName}
+            FullName = Join-Path -Path $Path -ChildPath (?? { $FileName } { $FileName } { $script:FileName})
+            Length = $result.ContentLength
         }
     }
 }

--- a/AutomatedLab/AutomatedLabOffice.psm1
+++ b/AutomatedLab/AutomatedLabOffice.psm1
@@ -230,7 +230,7 @@ function Install-LabOffice2016
         $tempFile = (Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'Configuration.xml')
 
         $config2016Xml | Out-File -FilePath $tempFile -Force
-        Copy-LabFileItem -Path $tempFile -ComputerName $machine -DestinationFolderPath C:\Office
+        Copy-LabFileItem -Path $tempFile -ComputerName $machine -DestinationFolderPath /Office
 
         Remove-Item -Path $tempFile
 

--- a/AutomatedLab/AutomatedLabSharePoint.psm1
+++ b/AutomatedLab/AutomatedLabSharePoint.psm1
@@ -146,7 +146,7 @@ function Install-LabSharePoint
         Get-LabInternetFile -Uri (Get-LabConfigurationItem -Name $thing) -Path $labsources\SoftwarePackages -FileName $fName -NoDisplay
     }
 
-    Copy-LabFileItem -Path $labsources\SoftwarePackages\vcredist_64_2012.exe, $labsources\SoftwarePackages\vcredist_64_2015.exe, $labsources\SoftwarePackages\vcredist_64_2017.exe -ComputerName $machines  -DestinationFolderPath "C:\SPInstall\prerequisiteinstallerfiles"
+    Copy-LabFileItem -Path $labsources\SoftwarePackages\vcredist_64_2012.exe, $labsources\SoftwarePackages\vcredist_64_2015.exe, $labsources\SoftwarePackages\vcredist_64_2017.exe -ComputerName $machines  -DestinationFolderPath "/SPInstall\prerequisiteinstallerfiles"
 
     # Download and copy Prerequisite Files to server
     Write-ScreenInfo -Message "Downloading and copying prerequisite files to servers"
@@ -180,7 +180,7 @@ function Install-LabSharePoint
             }
         }
 
-        Copy-LabFileItem -ComputerName $group.Group -Path $labsources\SoftwarePackages\$($group.Name)\* -DestinationFolderPath "C:\SPInstall\prerequisiteinstallerfiles"
+        Copy-LabFileItem -ComputerName $group.Group -Path $labsources\SoftwarePackages\$($group.Name)\* -DestinationFolderPath "/SPInstall\prerequisiteinstallerfiles"
 
         # Installing Prereqs
         Write-ScreenInfo -Message "Installing prerequisite files for $($group.Name) on server" -Type Verbose

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -738,11 +738,11 @@ function New-LabReleasePipeline
 
         if ($repositoryPath)
         {
-            Copy-LabFileItem -Path $repositoryPath -ComputerName $tfsVm -DestinationFolderPath "C:\$ProjectName.temp" -Recurse
+            Copy-LabFileItem -Path $repositoryPath -ComputerName $tfsVm -DestinationFolderPath "/$ProjectName.temp" -Recurse
         }
         else
         {
-            Copy-LabFileItem -Path $SourcePath -ComputerName $tfsVm -DestinationFolderPath "C:\$ProjectName.temp" -Recurse
+            Copy-LabFileItem -Path $SourcePath -ComputerName $tfsVm -DestinationFolderPath "/$ProjectName.temp" -Recurse
         }
 
         Invoke-LabCommand -ActivityName 'Push code to TFS/AZDevOps' -ComputerName $tfsVm -ScriptBlock {

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -311,11 +311,12 @@ function Install-LabBuildWorker
             {
                 Write-ScreenInfo -Message "No TFS server called $($role.Properties['TfsServer']) found in lab." -NoNewLine -Type Warning
                 $tfsServer = Get-LabVM -Role Tfs2015, Tfs2017, Tfs2018, AzDevOps | Select-Object -First 1
-                $useSsl = $tfsServer.InternalNotes.ContainsKey('CertificateThumbprint') -or ($tfsServer.Roles.Name -eq 'AzDevOps' -and $tfsServer.SkipDeployment)
                 $role.Properties['TfsServer'] = $tfsServer.Name
                 $shouldExport = $true
                 Write-ScreenInfo -Message " Selecting $tfsServer instead." -Type Warning
             }
+
+            $useSsl = $tfsServer.InternalNotes.ContainsKey('CertificateThumbprint') -or ($tfsServer.Roles.Name -eq 'AzDevOps' -and $tfsServer.SkipDeployment)
         }
         else
         {
@@ -334,7 +335,7 @@ function Install-LabBuildWorker
         }
 
         $tfsRole = $tfsServer.Roles | Where-Object Name -match 'Tfs\d{4}|AzDevOps'
-        if ($null -ne $tfsRole -and $tfsRole.Properties.ContainsKey('Port'))
+        if ($tfsRole -and $tfsRole.Properties.ContainsKey('Port'))
         {
             $tfsPort = $tfsRole.Properties['Port']
         }

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1538,7 +1538,7 @@ function Add-LabIsoImageDefinition
         {
             $isoFiles = Get-LabAzureLabSourcesContent -RegexFilter '\.iso' -File -ErrorAction SilentlyContinue
 
-            if ( [System.IO.Path]::HasExtension($Path))
+            if ( -not $IsLinux -and [System.IO.Path]::HasExtension($Path) -or $IsLinux -and $Path -match '\.iso$')
             {
                 $isoFiles = $isoFiles | Where-Object {$_.Name -eq (Split-Path -Path $Path -Leaf)}
 

--- a/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
@@ -55,7 +55,7 @@ function Add-LabVirtualNetworkDefinition
         throw 'The Hyper-V tools are not installed. Please install them first to use AutomatedLab with Hyper-V. Alternatively, you can use AutomatedLab with Microsoft Azure.'
     }
 
-    if ($VirtualizationEngine -eq 'Azure' -and -not $script:lab.AzureSettings.DefaultStorageAccount)
+    if ($VirtualizationEngine -eq 'Azure' -and -not $script:lab.AzureSettings.DefaultResourceGroup)
     {
         Add-LabAzureSubscription
     }

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -600,9 +600,9 @@ function Get-LWAzureSku
         $machineOs = New-Object AutomatedLab.OperatingSystem($machine.OperatingSystem)
         $vmImage = $sqlServerImages | Where-Object { $_.SqlVersion -eq $sqlServerVersion -and $_.OS.Version -eq $machineOs.Version } |
             Sort-Object -Property SqlServicePack -Descending | Select-Object -First 1
-        $offerName = $vmImageName = $vmImage | Select-Object -ExpandProperty Offer
-        $publisherName = $vmImage | Select-Object -ExpandProperty PublisherName
-        $skusName = $vmImage | Select-Object -ExpandProperty Skus
+        $offerName = $vmImageName = $vmImage.Offer
+        $publisherName = $vmImage.PublisherName
+        $skusName = $vmImage.Skus
 
         if (-not $vmImageName)
         {

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1369,25 +1369,24 @@ function Stop-LWAzureVM
         {
             $vm = $azureVms | Where-Object Name -eq $name
             $vm | Stop-AzVM -Force -StayProvisioned:$StayProvisioned -AsJob
+        }
 
-            Wait-LWLabJob -Job $jobs -NoDisplay -ProgressIndicator $ProgressIndicator
-            $failedJobs = $jobs | Where-Object {$_.State -eq 'Failed'}
-            if ($failedJobs)
-            {
-                $jobNames = ($failedJobs | ForEach-Object {
-                        if ($_.Name.StartsWith("StopAzureVm_"))
-                        {
-                            ($_.Name -split "_")[1]
-                        }
-                        elseif ($_.Name  -match "Long Running Operation for 'Stop-AzVM' on resource '(?<MachineName>[\w-]+)'")
-                        {
-                            $Matches.MachineName
-                        }
-                    }) -join ", "
+        Wait-LWLabJob -Job $jobs -NoDisplay -ProgressIndicator $ProgressIndicator
+        $failedJobs = $jobs | Where-Object {$_.State -eq 'Failed'}
+        if ($failedJobs)
+        {
+            $jobNames = ($failedJobs | ForEach-Object {
+                    if ($_.Name.StartsWith("StopAzureVm_"))
+                    {
+                        ($_.Name -split "_")[1]
+                    }
+                    elseif ($_.Name  -match "Long Running Operation for 'Stop-AzVM' on resource '(?<MachineName>[\w-]+)'")
+                    {
+                        $Matches.MachineName
+                    }
+                }) -join ", "
 
-                Write-ScreenInfo -Message "Could not stop Azure VM(s): '$jobNames'" -Type Error
-            }
-
+            Write-ScreenInfo -Message "Could not stop Azure VM(s): '$jobNames'" -Type Error
         }
     }
 

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1379,6 +1379,10 @@ function Stop-LWAzureVM
                         {
                             ($_.Name -split "_")[1]
                         }
+                        elseif ($_.Name  -match "Long Running Operation for 'Stop-AzVM' on resource '(?<MachineName>[\w-]+)'")
+                        {
+                            $Matches.MachineName
+                        }
                     }) -join ", "
 
                 Write-ScreenInfo -Message "Could not stop Azure VM(s): '$jobNames'" -Type Error

--- a/AutomatedLabWorker/AutomatedLabWorker.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psm1
@@ -627,12 +627,12 @@ function Install-LWAzureWindowsFeature
         {
             if ($m.OperatingSystem.Installation -eq 'Client')
             {
-                $cmd = [scriptblock]::Create("Enable-WindowsOptionalFeature -Online -FeatureName $($FeatureName -join ', ') -Source ""`$(@(Get-WmiObject -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -All:`$$IncludeAllSubFeature -NoRestart -WarningAction SilentlyContinue")
+                $cmd = [scriptblock]::Create("Enable-WindowsOptionalFeature -Online -FeatureName $($FeatureName -join ', ') -Source 'C:\Windows\WinSXS' -All:`$$IncludeAllSubFeature -NoRestart -WarningAction SilentlyContinue")
                 $result += Invoke-LabCommand -ComputerName $m -ActivityName $activityName -NoDisplay -ScriptBlock $cmd -UseLocalCredential:$UseLocalCredential -AsJob:$AsJob -PassThru:$PassThru
             }
             else
             {
-                $cmd = [scriptblock]::Create("Install-WindowsFeature $($FeatureName -join ', ') -Source ""`$(@(Get-WmiObject -Class Win32_CDRomDrive)[-1].Drive)\sources\sxs"" -IncludeAllSubFeature:`$$IncludeAllSubFeature -IncludeManagementTools:`$$IncludeManagementTools -WarningAction SilentlyContinue")
+                $cmd = [scriptblock]::Create("Install-WindowsFeature $($FeatureName -join ', ') -Source 'C:\Windows\WinSXS' -IncludeAllSubFeature:`$$IncludeAllSubFeature -IncludeManagementTools:`$$IncludeManagementTools -WarningAction SilentlyContinue")
                 $result += Invoke-LabCommand -ComputerName $m -ActivityName $activityName -NoDisplay -ScriptBlock $cmd -UseLocalCredential:$UseLocalCredential -AsJob:$AsJob -PassThru:$PassThru
             }
         }

--- a/AutomatedLabWorker/AutomatedLabWorker.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psm1
@@ -137,11 +137,11 @@ function Invoke-LWCommand
             {
                 if ((Get-Item -Path $DependencyFolderPath).PSIsContainer)
                 {
-                    Send-Directory -SourceFolderPath $DependencyFolderPath -DestinationFolder (Join-Path -Path C:\ -ChildPath (Split-Path -Path $DependencyFolderPath -Leaf)) -Session $internalSession
+                    Send-Directory -SourceFolderPath $DependencyFolderPath -DestinationFolder (Join-Path -Path / -ChildPath (Split-Path -Path $DependencyFolderPath -Leaf)) -Session $internalSession
                 }
                 else
                 {
-                    Send-File -SourceFilePath $DependencyFolderPath -DestinationFolderPath C:\ -Session $internalSession
+                    Send-File -SourceFilePath $DependencyFolderPath -DestinationFolderPath / -Session $internalSession
                 }
             }
         }
@@ -151,7 +151,7 @@ function Invoke-LWCommand
             $cmd = ''
             if ($ScriptFileName)
             {
-                $cmd += "& '$(Join-Path -Path C:\ -ChildPath (Split-Path $DependencyFolderPath -Leaf))\$ScriptFileName'"
+                $cmd += "& '$(Join-Path -Path / -ChildPath (Split-Path $DependencyFolderPath -Leaf))\$ScriptFileName'"
             }
             if ($ParameterVariableName)
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Fixing an 'Cannot index into a null array' error when answering the very first telemetry question with 'Ask later' (fixes #884)
 - Fixing an 'Cannot index into a null array' error when answering the very first telemetry question with 'Ask later'
 - Several CM-1902 CustomRole fixes/improvements: Formatting and grammar, make -NoInteretAccess work, download SQL ISO directly rather than via downloader application, removed hardcoded VM specs for ConfigMgr VM, data and SQL VHDX names on host's disk match hostname of ConfigMgr VM.
+- Updated some paths to work cross-platform
+  - i.e. Join-Path fails when the drive does not exist, so all calls to e.g. Send-File with a destination like C: would
+    fail on Linux, eventhough the target would always be a Windows machine. Replaced those paths with forward slash
+    which defaults to the system root on Windows and can be resolved cross-platform
 
 ## 5.20.0 - 2020-04-20
 

--- a/LabSources/CustomRoles/Exchange2013/HostStart.ps1
+++ b/LabSources/CustomRoles/Exchange2013/HostStart.ps1
@@ -68,12 +68,12 @@ function Copy-ExchangeSources
         {
             if (-not $script:useISO)
             {
-                Copy-LabFileItem -Path $exchangeInstallFile.FullName -DestinationFolderPath C:\Install -ComputerName $vm
+                Copy-LabFileItem -Path $exchangeInstallFile.FullName -DestinationFolderPath /Install -ComputerName $vm
             }
 
-            Copy-LabFileItem -Path $ucmaInstallFile.FullName -DestinationFolderPath C:\Install -ComputerName $vm
-            Copy-LabFileItem -Path $dotnetInstallFile.FullName -DestinationFolderPath C:\Install -ComputerName $vm
-            Copy-LabFileItem -Path $vcredistInstallFile.FullName -DestinationFolderPath C:\Install -ComputerName $vm
+            Copy-LabFileItem -Path $ucmaInstallFile.FullName -DestinationFolderPath /Install -ComputerName $vm
+            Copy-LabFileItem -Path $dotnetInstallFile.FullName -DestinationFolderPath /Install -ComputerName $vm
+            Copy-LabFileItem -Path $vcredistInstallFile.FullName -DestinationFolderPath /Install -ComputerName $vm
         }
         Write-ScreenInfo 'Done' -TaskEnd
     }

--- a/LabSources/CustomRoles/MDT/InstallMDT.ps1
+++ b/LabSources/CustomRoles/MDT/InstallMDT.ps1
@@ -423,13 +423,13 @@ function Install-MDT {
     $mdtInstallFile = Get-LabInternetFile -Uri $MdtDownloadUrl -Path $downloadTargetFolder -PassThru -ErrorAction Stop
    
     Write-ScreenInfo "Copying MDT Install Files to server '$ComputerName'..."
-    Copy-LabFileItem -Path (Join-Path -Path $downloadTargetFolder -ChildPath $mdtInstallFile.FileName) -DestinationFolderPath C:\Install -ComputerName $ComputerName
+    Copy-LabFileItem -Path (Join-Path -Path $downloadTargetFolder -ChildPath $mdtInstallFile.FileName) -DestinationFolderPath /Install -ComputerName $ComputerName
 
     Write-ScreenInfo "Copying ADK Install Files to server '$ComputerName'..."
-    Copy-LabFileItem -Path (Join-Path -Path $downloadTargetFolder -ChildPath 'ADK') -DestinationFolderPath C:\Install -ComputerName $ComputerName -Recurse
+    Copy-LabFileItem -Path (Join-Path -Path $downloadTargetFolder -ChildPath 'ADK') -DestinationFolderPath /Install -ComputerName $ComputerName -Recurse
 
     Write-ScreenInfo "Copying ADK Windows PE Addons Install Files to server '$ComputerName'..."
-    Copy-LabFileItem -Path (Join-Path -Path $downloadTargetFolder -ChildPath 'ADKWinPEAddons') -DestinationFolderPath C:\Install -ComputerName $ComputerName -Recurse
+    Copy-LabFileItem -Path (Join-Path -Path $downloadTargetFolder -ChildPath 'ADKWinPEAddons') -DestinationFolderPath /Install -ComputerName $ComputerName -Recurse
 
     Write-ScreenInfo "Installing ADK and on server '$ComputerName'..."
     Install-LabSoftwarePackage -ComputerName $ComputerName -LocalPath C:\Install\ADK\adksetup.exe -CommandLine '/norestart /q /ceip off /features OptionId.DeploymentTools OptionId.UserStateMigrationTool OptionId.ImagingAndConfigurationDesigner'

--- a/LabSources/CustomRoles/Office2019/HostStart.ps1
+++ b/LabSources/CustomRoles/Office2019/HostStart.ps1
@@ -65,7 +65,7 @@ Install-LabSoftwarePackage -Path $officeDeploymentToolFilePath -CommandLine '/ex
 $tempFile = (Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'Configuration.xml')
 
 $config2019Xml | Out-File -FilePath $tempFile -Force
-Copy-LabFileItem -Path $tempFile -ComputerName $ComputerName -DestinationFolderPath C:\Office
+Copy-LabFileItem -Path $tempFile -ComputerName $ComputerName -DestinationFolderPath /Office
 
 Remove-Item -Path $tempFile
 Dismount-LabIsoImage -ComputerName $ComputerName -SupressOutput

--- a/LabSources/CustomRoles/SCCM/InstallSCCM.ps1
+++ b/LabSources/CustomRoles/SCCM/InstallSCCM.ps1
@@ -92,9 +92,9 @@ function Install-SCCM {
     }
 
     #Copy the SCCM Binaries
-    Copy-LabFileItem -Path $SccmBinariesDirectory -DestinationFolderPath C:\Install -ComputerName $SccmServerName -Recurse
+    Copy-LabFileItem -Path $SccmBinariesDirectory -DestinationFolderPath /Install -ComputerName $SccmServerName -Recurse
     #Copy the SCCM Prereqs (must have been previously downloaded)
-    Copy-LabFileItem -Path $SccmPreReqsDirectory -DestinationFolderPath C:\Install -ComputerName $SccmServerName -Recurse
+    Copy-LabFileItem -Path $SccmPreReqsDirectory -DestinationFolderPath /Install -ComputerName $SccmServerName -Recurse
 
     #Extend the AD Schema
     Invoke-LabCommand -ActivityName 'Extend AD Schema' -ComputerName $SccmServerName -ScriptBlock {
@@ -151,10 +151,10 @@ function Install-SCCM {
     $mdtInstallFile = Get-LabInternetFile -Uri $mdtDownloadLocation -Path $downloadTargetFolder -ErrorAction Stop -PassThru
 
     Write-ScreenInfo "Copying MDT Install Files to server '$SccmServerName'..."
-    Copy-LabFileItem -Path $mdtInstallFile.FullName -DestinationFolderPath C:\Install -ComputerName $SccmServerName
+    Copy-LabFileItem -Path $mdtInstallFile.FullName -DestinationFolderPath /Install -ComputerName $SccmServerName
 
     Write-ScreenInfo "Copying ADK Install Files to server '$SccmServerName'..."
-    Copy-LabFileItem -Path "$downloadTargetFolder\ADK" -DestinationFolderPath C:\Install -ComputerName $SccmServerName -Recurse
+    Copy-LabFileItem -Path "$downloadTargetFolder\ADK" -DestinationFolderPath /Install -ComputerName $SccmServerName -Recurse
 
     Write-ScreenInfo "Installing ADK on server '$SccmServerName'..." -NoNewLine
     $job = Install-LabSoftwarePackage -LocalPath C:\Install\ADK\adksetup.exe -CommandLine "/norestart /q /ceip off /features OptionId.WindowsPreinstallationEnvironment OptionId.DeploymentTools OptionId.UserStateMigrationTool OptionId.ImagingAndConfigurationDesigner" `
@@ -237,7 +237,7 @@ UseProxy=0
     #Save the config file to disk, and copy it to the SCCM Server
     $setupConfigFileContent | Out-File -FilePath "$($lab.LabPath)\ConfigMgrUnattend.ini" -Encoding ascii
 
-    Copy-LabFileItem -Path "$($lab.LabPath)\ConfigMgrUnattend.ini" -DestinationFolderPath C:\Install -ComputerName $SccmServerName
+    Copy-LabFileItem -Path "$($lab.LabPath)\ConfigMgrUnattend.ini" -DestinationFolderPath /Install -ComputerName $SccmServerName
 
     $sccmComputerAccount = '{0}\{1}$' -f
     $sccmServer.DomainName.Substring(0, $sccmServer.DomainName.IndexOf('.')),

--- a/LabSources/CustomRoles/WindowsAdminCenter/HostStart.ps1
+++ b/LabSources/CustomRoles/WindowsAdminCenter/HostStart.ps1
@@ -27,7 +27,7 @@ if (-not $lab)
 
 $labMachine = Get-LabVm -ComputerName $ComputerName
 $wacDownload = Get-LabInternetFile -Uri $WacDownloadLink -Path "$labSources\SoftwarePackages" -FileName WAC.msi -PassThru -NoDisplay
-Copy-LabFileItem -Path $wacDownload.FullName -DestinationFolderPath C:\ -ComputerName $labMachine
+Copy-LabFileItem -Path $wacDownload.FullName -ComputerName $labMachine
 
 if ($labMachine.IsDomainJoined -and (Get-LabIssuingCA -DomainName $labMachine.DomainName -ErrorAction SilentlyContinue) )
 {

--- a/LabSources/SampleScripts/Scenarios/DSC Pull Scenario 1 (Pull Configuration, SQL Reporting).ps1
+++ b/LabSources/SampleScripts/Scenarios/DSC Pull Scenario 1 (Pull Configuration, SQL Reporting).ps1
@@ -78,7 +78,7 @@ Get-Job -Name 'Installation of*' | Wait-Job | Out-Null
 
 Install-LabWindowsFeature -ComputerName DPULL1 -FeatureName Web-Mgmt-Console
 
-Copy-LabFileItem -Path $labSources\PostInstallationActivities\SetupDscPullServer\CreateDscSqlDatabase.ps1 -DestinationFolderPath C:\ -ComputerName DSQL
+Copy-LabFileItem -Path $labSources\PostInstallationActivities\SetupDscPullServer\CreateDscSqlDatabase.ps1 -ComputerName DSQL
 Invoke-LabCommand -ActivityName 'Create SQL Database for DSC Reporting' -ComputerName DSQL -ScriptBlock {
     C:\CreateDscSqlDatabase.ps1 -DomainAndComputerName CONTOSO\DPULL1
 }

--- a/PSFileTransfer/PSFileTransfer.psm1
+++ b/PSFileTransfer/PSFileTransfer.psm1
@@ -513,7 +513,7 @@ function Copy-LabFileItem
 
                     $destination = if (-not $DestinationFolderPath)
                     {
-                        'C:\'
+                        '/'
                     }
                     else
                     {
@@ -541,7 +541,7 @@ function Copy-LabFileItem
                 $session = New-LabPSSession -ComputerName $machine
                 $destination = if (-not $DestinationFolderPath)
                 {
-                    Join-Path -Path C:\ -ChildPath (Split-Path -Path $p -Leaf)
+                    Join-Path -Path / -ChildPath (Split-Path -Path $p -Leaf)
                 }
                 else
                 {


### PR DESCRIPTION
## Description

Multiple issues. Paths converted to cross-platform (/ is C:\  on Windows, / is / on Linux).

Issues with Azure deployments fixed where SQL image would not be serializable to ARM template. Fixed an issue with TFS deployments when the $UseSsl flag was not set.

Fixed an issue where Get-LabInternetFile would return $null after downloading something to the LabSources file storage.

Reference to Azure SharePoint SKU removed as it seems to be not actively developed and thus useless for our purposes.

Attempted to fix an issue that was hard to track on Linux where Get-LabIssuingCa never returned the CA - in some cases due to double auth issue, in some cases due to CertSvc not running despite a successful CA deployment. Weird.

Connectivity check is now configurable if e.g. we work in Azure Cloud Shell, where outgoing ICMP packages are blocked.

Deprecated the StorageAccount parameter as we do not use a storage account for each lab any longer (due to managed disks)

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Deployed the DSC workshop lab on Windows 10/Hyper-V and Ubuntu 18.04/Azure. Azure lab on Linux had ongoing issues with Get-LabIssuingCa that I would like to fix in a later PR, if I am able to. 