### PR TITLE
Issues with upcoming Windows builds

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
@@ -130,7 +130,8 @@ function New-LWHypervNetworkSwitch
                     }
 
                     $null = $config | Set-NetIPInterface -Dhcp Disabled
-                    $null = $config | Set-NetIPAddress -IPAddress $adapterIpAddress.AddressAsString -AddressFamily IPv4 -PrefixLength $network.AddressSpace.Netmask
+                    $null = $config | Remove-NetIPAddress -Confirm:$false
+                    $null = $config | New-NetIPAddress -IPAddress $adapterIpAddress.AddressAsString -AddressFamily IPv4 -PrefixLength $network.AddressSpace.Cidr
                 }
                 else
                 {

--- a/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
@@ -129,16 +129,8 @@ function New-LWHypervNetworkSwitch
                         $adapterIpAddress = $adapterIpAddress.Increment()
                     }
 
-                    $arguments = @{
-                        IPAddress = @($adapterIpAddress.AddressAsString)
-                        SubnetMask = @($network.AddressSpace.Netmask.AddressAsString)
-                    }
-
-                    $result = $config | Invoke-CimMethod -MethodName EnableStatic -Arguments $arguments
-                    if ($result.ReturnValue)
-                    {
-                        throw "Could not set the IP address '$($arguments.IPAddress)' with subnet mask '$($arguments.SubnetMask)' on adapter 'vEthernet ($($network.Name))'. The error code was $($result.ReturnValue). Lookup the documentation of the class Win32_NetworkAdapterConfiguration in the MSDN to get more information about the error code."
-                    }
+                    $null = $config | Set-NetIPInterface -Dhcp Disabled
+                    $null = $config | Set-NetIPAddress -IPAddress $adapterIpAddress.AddressAsString -AddressFamily IPv4 -PrefixLength $network.AddressSpace.Netmask
                 }
                 else
                 {

--- a/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
@@ -67,7 +67,7 @@ function New-LWHypervNetworkSwitch
 
         if ($network.EnableManagementAdapter) {
 
-            $config = Get-CimInstance -ClassName Win32_NetworkAdapter | Where-Object NetConnectionID -Match "vEthernet \($($network.Name)\) ?(\d{1,2})?" | Get-CimAssociatedInstance -ResultClassName Win32_NetworkAdapterConfiguration
+            $config = Get-NetAdapter | Where-Object Name -Match "vEthernet \($($network.Name)\) ?(\d{1,2})?"
             if (-not $config)
             {
                 throw "The network adapter for network switch '$network' could not be found. Cannot set up address hence will not be able to contact the machines"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixing an 'Cannot index into a null array' error when answering the very first telemetry question with 'Ask later' (fixes #884)
 - Fixing an 'Cannot index into a null array' error when answering the very first telemetry question with 'Ask later'
 - Several CM-1902 CustomRole fixes/improvements: Formatting and grammar, make -NoInteretAccess work, download SQL ISO directly rather than via downloader application, removed hardcoded VM specs for ConfigMgr VM, data and SQL VHDX names on host's disk match hostname of ConfigMgr VM.
+- Fixed an issue where the CimAssociatedInstances for the network adapter could not be reliably retrieved with the current insider builds.
 
 ## 5.20.0 - 2020-04-20
 


### PR DESCRIPTION
## Description

The CimAssociatedInstances for the network adapter cannot be reliably retrieved with the current insider builds as the NetConnectionId comes up $null. I have thus used the Get-NetAdapter cmdlet to do the same operations. Contrary to my observations these cdxml cmdlets work, where using the CIM cmdlets does not.

Even if this issue is fixed and was not intended, we should 

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Tested on build 19628 and my current build, 18362. Both work as intended, the adapter is configured with a static IP like before.