### PR TITLE
Make use of configurable lab sources

### DIFF
--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -897,16 +897,7 @@ function Update-LabSysinternalsTools
                 Start-Sleep -Seconds 1
                 
                 # Download Lab Sources
-                $labSources = Get-LabSourcesLocation -Local
-                if ($null -ne $labSources -and -not $($IsLinux -or $IsMacOs))
-                {
-                    $drive = ($labSources -split ':')[0]
-                    $null = New-LabSourcesFolder -DriveLetter $drive -Force -ErrorAction SilentlyContinue
-                }
-                elseif ($null -ne $labSources -and ($IsLinux -or $IsMacOs))
-                {
-                    $null = New-LabSourcesFolder -Force -ErrorAction SilentlyContinue
-                }
+                $null = New-LabSourcesFolder -Force -ErrorAction SilentlyContinue
 
                 # Download SysInternals suite
 

--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -759,6 +759,10 @@ function Get-LabSourcesLocationInternal
 
         Get-PSFConfigValue AutomatedLab.LabSourcesLocation
     }
+    elseif (($defaultEngine -eq 'HyperV' -or $Local) -and (Get-PSFConfig -Module AutomatedLab -Name LabSourcesLocation))
+    {
+        Get-PSFConfigValue -FullName AutomatedLab.LabSourcesLocation
+    }
     elseif ($defaultEngine -eq 'HyperV' -or $Local)
     {
         $hardDrives = (Get-CimInstance -NameSpace Root\CIMv2 -Class Win32_LogicalDisk | Where-Object DriveType -eq 3).DeviceID | Sort-Object -Descending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added NuGet custom role that uses open source NuGet server package
 - AL now deploys ARM templates instead of individual resources
 - Compatibility with Az module 4.1.0. The minimum version of Az is now 4.1.0
+- LabSources location can now be configured
 
 ### Bug Fixes
 


### PR DESCRIPTION
## Description

Makes use of configurable lab sources on Windows as well, if local lab sources are used. This change is not included in the MSI installer, I'm lacking the necessary skills to properly include it. Maybe a customaction could be used to register the configuration if a folder is selected that is not on some drive's root.

Fixes #477 

Code: 
```powershell
# One time
Set-PSFConfig -Module AutomatedLab -Name LabSourcesLocation -Value 'D:\Somewhere\Elsewhere'

# Permanent
Set-PSFConfig -Module AutomatedLab -Name LabSourcesLocation -Value 'D:\Somewhere\Elsewhere' -PassThru | Register-PSFConfig

# Important step if the folder is moved after ISOs have been added
Clear-LabCache
Get-LabAvailableOperatingSystem
```

If configured, this location is preferred and will be used with the automated $labsources and Get-labSourcesLocationInternal -Local

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Deployed a lab with my entire lab sources moved to another directory