### PR TITLE
TFS/AzDevOps Agent custom capabilities

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -376,6 +376,7 @@ Set-PSFConfig -Module AutomatedLab -Name ValidationSettings -Value @{
             'AgentPool'
             'PAT'
             'Organisation'
+            'Capabilities'
         )
     }
     MandatoryRoleProperties = @{

--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -220,6 +220,7 @@
         'Get-LabCache',
         'New-LabReleasePipeline',
         'Get-LabAzureLoadBalancedPort',
+        'Get-LabTfsParameter',
         'Open-LabTfsSite'
         'Enable-LabTelemetry',
         'Disable-LabTelemetry',

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -1207,6 +1207,11 @@ function Get-LabTfsParameter
         SkipCertificateCheck = $true
     }
 
+    if (-not $role)
+    {
+        $role = (Get-LabVm -ComputerName $bwrole.Properties.TfsServer).Roles | Where-Object -Property Name -match 'Tfs\d{4}|AzDevOps'
+    }
+
     $defaultParam.ApiVersion = switch ($role.Name)
     {
         'Tfs2015' { '2.0'; break }

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -1203,6 +1203,11 @@ function Get-LabTfsParameter
         default { '2.0' }
     }
 
+    if (($tfsVm.Roles.Name -eq 'AzDevOps' -and $tfsVm.SkipDeployment) -or ($bwRole -and $bwRole.Properties.ContainsKey('Organisation')))
+    {
+        $defaultParam.ApiVersion = '5.1'
+    }
+
     if ($accessToken)
     {
         $defaultParam.PersonalAccessToken = $accessToken

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -1152,7 +1152,13 @@ function Get-LabTfsParameter
 
     if ((Get-Lab).DefaultVirtualizationEngine -eq 'Azure' -and -not ($tfsVm.Roles.Name -eq 'AzDevOps' -and $tfsVm.SkipDeployment))
     {
-        $tfsPort = (Get-LWAzureLoadBalancedPort -DestinationPort $tfsPort -ComputerName $tfsVm -ErrorAction SilentlyContinue).FrontendPort
+        $tfsPort = if ($bwRole) {
+            (Get-LWAzureLoadBalancedPort -DestinationPort $tfsPort -ComputerName $bwRole.Properties.TfsServer -ErrorAction SilentlyContinue).FrontendPort
+        }
+        else
+        {
+            (Get-LWAzureLoadBalancedPort -DestinationPort $tfsPort -ComputerName $tfsVm -ErrorAction SilentlyContinue).FrontendPort
+        }
 
         if (-not $tfsPort)
         {
@@ -1160,7 +1166,13 @@ function Get-LabTfsParameter
             return
         }
 
-        $tfsInstance = $tfsVm.AzureConnectionInfo.DnsName
+        $tfsInstance = if ($bwRole) {
+            (Get-LabVm $bwRole.Properties.TfsServer).AzureConnectionInfo.DnsName
+        }
+        else
+        {
+            $tfsVm.AzureConnectionInfo.DnsName
+        }
     }
 
     if ($role -and $role.Properties.ContainsKey('InitialCollection'))

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerNetwork.psm1
@@ -369,9 +369,9 @@ function Add-LWAzureLoadBalancedPort
     $nsg = Get-AzNetworkSecurityGroup -Name "$($lab.Name)nsg" -ResourceGroupName $resourceGroup
 
     $rule = $nsg | Get-AzNetworkSecurityRuleConfig -Name NecessaryPorts
-    if (-not $rule.DestinationPortRange.Contains($DestinationPort))
+    if (-not $rule.DestinationPortRange.Contains($Port))
     {
-        $rule.DestinationPortRange.Add($DestinationPort)
+        $rule.DestinationPortRange.Add($Port)
         
         # Update the NSG.
         $nsg = $nsg | Set-AzNetworkSecurityRuleConfig -Name $rule.Name -DestinationPortRange $rule.DestinationPortRange -Protocol $rule.Protocol -SourcePortRange $rule.SourcePortRange -SourceAddressPrefix $rule.SourceAddressPrefix -DestinationAddressPrefix $rule.DestinationAddressPrefix -Access Allow -Priority $rule.Priority -Direction $rule.Direction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## Unreleased
 <!-- SCROLL DOWN TO ENHANCEMENTS AND BUG FIXES PLEASE --> 
 
-### Enhancements 
+### Enhancements
+
+- Build Agent role can now get Capabilities through its role definition
+  - New key Capabilities which contains a hashtable (within the realms of what is possible with Azure DevOps)
+- New cmdlet Get-LabTfsParameter to retrieve standard parameter dictionary
+  which can be used with our TFS cmdlets. Reduced a lot of duplicated code.
 
 ### Bug Fixes
 


### PR DESCRIPTION
## Description

- New Cmdlet Get-LabTfsParameter: Retrieve default parameters to use our TFS cmdlets. Reduced a whole lot of code
- New internal Cmdlet Set-LabBuildWorkerCapability to enable capabilities
- Capabilities are defined as a JSON string in the role property  
```code  
Get-LabMachineRoleDefinition -Role TfsBuildWorker -Properties @{
        Organisation = 'japete'
        PAT                = 'abc'
        AgentPool    = 'OnPremLab'
        Capabilities   = [string](@{AutomatedLab = 'IsAwesome'} | ConvertTo-Json -Compress)
    }
```
- Capabilities will only be applied once a new release of AutomatedLab.Common is out, cmdlet should fail silently if the Add-TfsAgentUserCapabilitiy cmdlet is not found.


- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Tested the new tagging in a small lab with the build agent connected to Azure DevOps Cloud
Tested if any issues appeared through this change by deploying the workshop lab on Hyper-V
DSC workshop lab on Azure: First deployment worked, second deployment did not, AzDevOps was simply unreachable. I am not really sure if that has to do with the changes proposed here.