### PR TITLE
Fix for Issue921

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -97,6 +97,7 @@ Set-PSFConfig -Module 'AutomatedLab' -Name MacAddressPrefix -Value '0017FB' -Ini
 
 #Host Settings
 Set-PSFConfig -Module 'AutomatedLab' -Name DiskDeploymentInProgressPath -Value (Join-Path -Path (Get-PSFConfigValue -FullName AutomatedLab.LabAppDataRoot) -ChildPath "LabDiskDeploymentInProgress.txt") -Initialize -Validation string -Description 'The file indicating that Hyper-V disks are being configured to reduce disk congestion'
+Set-PSFConfig -Module 'AutomatedLab' -Name SkipHostFileModification -Value $false -Initialize -Validation bool -Description 'Indicates that the hosts file should not be modified when deploying a new lab.'
 
 #Azure
 Set-PSFConfig -Module 'AutomatedLab' -Name MinimumAzureModuleVersion -Value '4.1.0' -Initialize -Validation string -Description 'The minimum expected Azure module version'

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -448,7 +448,7 @@ function Import-Lab
 
             foreach ($machine in (Get-LabMachineDefinition | Where-Object HostType -in 'HyperV', 'VMware' ))
             {
-                if ((Get-HostEntry -HostName $machine) -and (Get-HostEntry -HostName $machine).IpAddress.IPAddressToString -ne $machine.IpV4Address)
+                if ((Get-LabConfigurationItem -Name SkipHostFileModification) -and (Get-HostEntry -HostName $machine) -and (Get-HostEntry -HostName $machine).IpAddress.IPAddressToString -ne $machine.IpV4Address)
                 {
                     throw "There is already an entry for machine '$($machine.Name)' in the hosts file pointing to other IP address(es) ($((Get-HostEntry -HostName $machine).IpAddress.IPAddressToString -join ',')) than the machine '$($machine.Name)' in this lab will have ($($machine.IpV4Address)). Cannot continue."
                 }

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -835,7 +835,7 @@ function Install-Lab
             $hostFileAddedEntries = 0
             foreach ($machine in $Script:data.Machines)
             {
-                if ($machine.Hosttype -eq 'HyperV' -and $machine.NetworkAdapters[0].Ipv4Address)
+                if ($machine.Hosttype -eq 'HyperV' -and $machine.NetworkAdapters[0].Ipv4Address -and -not (Get-LabConfigurationItem -Name SkipHostFileModification))
                 {
                     $hostFileAddedEntries += Add-HostEntry -HostName $machine.Name -IpAddress $machine.IpV4Address -Section $Script:data.Name
                     $hostFileAddedEntries += Add-HostEntry -HostName $machine.FQDN -IpAddress $machine.IpV4Address -Section $Script:data.Name

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -110,10 +110,16 @@ function New-LabPSSession
             }
             elseif ($m.HostType -eq 'HyperV' -or $m.HostType -eq 'VMWare')
             {
+                # DoNotUseGetHostEntryInNewLabPSSession is used when existing DNS is possible
+                # SkipHostFileModification is used when the local hosts file should not be used
                 $doNotUseGetHostEntry = Get-LabConfigurationItem -Name DoNotUseGetHostEntryInNewLabPSSession
                 if (-not $doNotUseGetHostEntry)
                 {
                     $name = (Get-HostEntry -Hostname $m).IpAddress.IpAddressToString
+                }
+                elseif (Get-LabConfigurationItem -Name SkipHostFileModification)
+                {
+                    $name = $m.IpV4Address
                 }
 
                 if ($name)
@@ -345,6 +351,10 @@ function Remove-LabPSSession
             if (Get-LabConfigurationItem -Name DoNotUseGetHostEntryInNewLabPSSession)
             {
                 $param.Add('ComputerName', $m.Name)
+            }
+            elseif (Get-LabConfigurationItem -Name SkipHostFileModification)
+            {
+                $param.Add('ComputerName', $m.IpV4Address)
             }
             else
             {
@@ -860,6 +870,10 @@ function New-LabCimSession
                 {
                     $name = (Get-HostEntry -Hostname $m).IpAddress.IpAddressToString
                 }
+                elseif (Get-LabConfigurationItem -Name SkipHostFileModification)
+                {
+                    $name = $m.IpV4Address
+                }
 
                 if ($name)
                 {
@@ -1070,6 +1084,10 @@ function Remove-LabCimSession
             if (Get-LabConfigurationItem -Name DoNotUseGetHostEntryInNewLabPSSession)
             {
                 $param.Add('ComputerName', $m.Name)
+            }
+            elseif (Get-LabConfigurationItem -Name SkipHostFileModification)
+            {
+                $param.Add('ComputerName', $m.IpV4Address)
             }
             else
             {

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -1188,6 +1188,17 @@ function Connect-LabVM
             $cmd = 'cmdkey /delete:TERMSRV/"{0}"' -f $cn.DnsName
             Invoke-Expression $cmd | Out-Null
         }
+        elseif (Get-LabConfigurationItem -Name SkipHostFileModification)
+        (
+            $cmd = 'cmdkey.exe /add:"TERMSRV/{0}" /user:"{1}" /pass:"{2}"' -f $machine.IpAddress.ipaddress.AddressAsString, $cred.UserName, $cred.GetNetworkCredential().Password
+            Invoke-Expression $cmd | Out-Null
+            mstsc.exe "/v:$($machine.IpAddress.ipaddress.AddressAsString)" /f
+
+            Start-Sleep -Seconds 1 #otherwise credentials get deleted too quickly
+
+            $cmd = 'cmdkey /delete:TERMSRV/"{0}"' -f $machine.IpAddress.ipaddress.AddressAsString
+            Invoke-Expression $cmd | Out-Null
+        )
         else
         {
             $cmd = 'cmdkey.exe /add:"TERMSRV/{0}" /user:"{1}" /pass:"{2}"' -f $machine.Name, $cred.UserName, $cred.GetNetworkCredential().Password
@@ -1196,7 +1207,7 @@ function Connect-LabVM
 
             Start-Sleep -Seconds 1 #otherwise credentials get deleted too quickly
 
-            $cmd = 'cmdkey /delete:TERMSRV/"{0}"' -f $cn.DnsName
+            $cmd = 'cmdkey /delete:TERMSRV/"{0}"' -f $machine.Name
             Invoke-Expression $cmd | Out-Null
         }
     }

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -998,6 +998,11 @@ function Remove-LabVM
             $computerName = (Get-HostEntry -Hostname $machine).IpAddress.IpAddressToString
         }
 
+        if (Get-LabConfigurationItem -Name SkipHostFileModification)
+        {
+            $computerName = $machine.IPV4Address
+        }
+
         <#
                 removed 161023, might not be required
                 if ((Get-LabVMStatus -ComputerName $machine) -eq 'Unknown')
@@ -2122,16 +2127,7 @@ function Checkpoint-LabVM
         return
     }
 
-    foreach ($machine in $machines)
-    {
-        $ip = (Get-HostEntry -Hostname $machine).IpAddress.IPAddressToString
-        $sessions = Get-PSSession | Where-Object { $_.ComputerName -eq $ip }
-        if ($sessions)
-        {
-            Write-PSFMessage "Removing $($sessions.Count) open sessions to the machine"
-            $sessions | Remove-PSSession
-        }
-    }
+    Remove-LabPSSession -ComputerName $machines
 
     switch ($lab.DefaultVirtualizationEngine)
     {
@@ -2186,16 +2182,7 @@ function Restore-LabVMSnapshot
         return
     }
 
-    foreach ($machine in $machines)
-    {
-        $ip = (Get-HostEntry -Hostname $machine).IpAddress.IPAddressToString
-        $sessions = Get-PSSession | Where-Object { $_.ComputerName -eq $ip }
-        if ($sessions)
-        {
-            Write-PSFMessage "Removing $($sessions.Count) open sessions to the machine '$machine'"
-            $sessions | Remove-PSSession
-        }
-    }
+    Remove-LabPSSession -ComputerName $machines
 
     switch ($lab.DefaultVirtualizationEngine)
     {

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -1194,7 +1194,7 @@ function Connect-LabVM
             Invoke-Expression $cmd | Out-Null
         }
         elseif (Get-LabConfigurationItem -Name SkipHostFileModification)
-        (
+        {
             $cmd = 'cmdkey.exe /add:"TERMSRV/{0}" /user:"{1}" /pass:"{2}"' -f $machine.IpAddress.ipaddress.AddressAsString, $cred.UserName, $cred.GetNetworkCredential().Password
             Invoke-Expression $cmd | Out-Null
             mstsc.exe "/v:$($machine.IpAddress.ipaddress.AddressAsString)" /f
@@ -1203,7 +1203,7 @@ function Connect-LabVM
 
             $cmd = 'cmdkey /delete:TERMSRV/"{0}"' -f $machine.IpAddress.ipaddress.AddressAsString
             Invoke-Expression $cmd | Out-Null
-        )
+        }
         else
         {
             $cmd = 'cmdkey.exe /add:"TERMSRV/{0}" /user:"{1}" /pass:"{2}"' -f $machine.Name, $cred.UserName, $cred.GetNetworkCredential().Password


### PR DESCRIPTION
## Description

Fixes #921 by adding another configurable setting. If I remember correctly, we use DoNotUseGetHostEntryInNewLabPSSession when existing DNS is possible.

The additional parameter SkipHostFileModification is used when the local hosts file should not be used. I hope I discovered all places where we would use DNS or the hosts file through Get-HostEntry.

Setting the new parameter:

```powershell
# temporary
Set-PSFConfig -FullName AutomatedLab.SkipHostFileModification -Value $true

# Persistent
Set-PSFConfig -FullName AutomatedLab.SkipHostFileModification -Value $true -Passthru | Register-PSFConfig
```

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Deployed a single VM lab just to see if it works in general. No host entries were created and establishing sessions to the lab VMs worked as intended.