### PR TITLE
Transfer of ALCommon library for all VMs

### DIFF
--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -79,6 +79,7 @@
         'Clear-LabCache',
         'Connect-Lab',
         'Connect-LabVM',
+        'Copy-LabALCommon',
         'Disable-LabVMFirewallGroup',
         'Disconnect-Lab',
         'Dismount-LabIsoImage',

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -2522,35 +2522,12 @@ function Install-LabSoftwarePackage
 
     Write-PSFMessage -Message "Starting background job for '$($parameters.ActivityName)'"
 
-    # Transfer ALCommon library
-    $childPath = foreach ($vm in $ComputerName)
-    {
-        Invoke-LabCommand -ComputerName $vm -NoDisplay -PassThru { if ($PSEdition -eq 'Core'){'core'} else {'full'} } |
-        Add-Member -MemberType NoteProperty -Name ComputerName -Value $vm -Force -PassThru
-    }
-
-    $coreChild = @($childPath) -eq 'core'
-    $fullChild = @($childPath) -eq 'full'
-    $libLocation = Split-Path -Parent -Path (Split-Path -Path ([AutomatedLab.Common.Win32Exception]).Assembly.Location -Parent)
-
-    if ($coreChild -and @(Invoke-LabCommand -ComputerName $coreChild.ComputerName -NoDisplay -PassThru {Get-Item '/ALLibraries/core/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue}).Count -ne $coreChild.Count)
-    {
-        $coreLibraryFolder = Join-Path -Path $libLocation -ChildPath $coreChild[0]
-        Copy-LabFileItem -Path $coreLibraryFolder -ComputerName $coreChild.ComputerName -DestinationFolderPath '/ALLibraries'
-    }
-
-    if ($fullChild -and @(Invoke-LabCommand -ComputerName $fullChild.ComputerName -NoDisplay -PassThru {Get-Item '/ALLibraries/full/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue}).Count -ne $fullChild.Count)
-    {
-        $fullLibraryFolder = Join-Path -Path $libLocation -ChildPath $fullChild[0]
-        Copy-LabFileItem -Path $fullLibraryFolder -ComputerName $fullChild.ComputerName -DestinationFolderPath '/ALLibraries'
-    }
-
     $parameters.ScriptBlock = {
         if ($PSEdition -eq 'core')
         {
             Add-Type -Path '/ALLibraries/core/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
         }
-        elseif ([System.Environment]::OSVersion.Version -gt '6.3')
+        elseif ([System.Environment]::OSVersion.Version -ge '6.3')
         {
             Add-Type -Path '/ALLibraries/full/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
         }

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -753,6 +753,7 @@ function Wait-LabVM
                     $machineMetadata.InitState = [AutomatedLab.LabVMInitState]::ReachedByAutomatedLab
                     Set-LWHypervVMDescription -Hashtable $machineMetadata -ComputerName $machine
                     Enable-LabAutoLogon -ComputerName $ComputerName
+                    Copy-LabALCommon -ComputerName $ComputerName
                 }
 
                 if ($DoNotUseCredSsp -and ($machineMetadata.InitState -band [AutomatedLab.LabVMInitState]::EnabledCredSsp) -ne [AutomatedLab.LabVMInitState]::EnabledCredSsp)
@@ -2390,3 +2391,51 @@ function Get-LabMachineAutoShutdown
     }
 }
 #endregion
+
+#region Copy-LabALCommon
+function Copy-LabALCommon
+{
+    [CmdletBinding()]
+    param
+    ( 
+        [Parameter(Mandatory)]
+        [string[]]
+        $ComputerName
+    )
+    
+    $childPath = foreach ($vm in $ComputerName)
+    {
+        Invoke-LabCommand -ScriptBlock {
+            if ($PSEdition -eq 'Core')
+            {
+                'core'
+            } else
+            {
+                'full'
+            }
+        } -ComputerName $vm -NoDisplay -PassThru |
+        Add-Member -MemberType NoteProperty -Name ComputerName -Value $vm -Force -PassThru
+    }
+
+    $coreChild = @($childPath) -eq 'core'ithug
+    $fullChild = @($childPath) -eq 'full'
+    $libLocation = Split-Path -Parent -Path (Split-Path -Path ([AutomatedLab.Common.Win32Exception]).Assembly.Location -Parent)
+
+    if ($coreChild -and @(Invoke-LabCommand -ScriptBlock{
+                Get-Item -Path '/ALLibraries/core/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
+    } -ComputerName $coreChild.ComputerName -NoDisplay -PassThru).Count -ne $coreChild.Count)
+    {
+        $coreLibraryFolder = Join-Path -Path $libLocation -ChildPath $coreChild[0]
+        Copy-LabFileItem -Path $coreLibraryFolder -ComputerName $coreChild.ComputerName -DestinationFolderPath '/ALLibraries'
+    }
+
+    if ($fullChild -and @(Invoke-LabCommand -ScriptBlock {
+                Get-Item -Path '/ALLibraries/full/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
+    } -ComputerName $fullChild.ComputerName -NoDisplay -PassThru).Count -ne $fullChild.Count)
+    {
+        $fullLibraryFolder = Join-Path -Path $libLocation -ChildPath $fullChild[0]
+        Copy-LabFileItem -Path $fullLibraryFolder -ComputerName $fullChild.ComputerName -DestinationFolderPath '/ALLibraries'
+    }
+}
+#endregion Copy-LabALCommon
+ 

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1210,6 +1210,8 @@ function Initialize-LWAzureVM
         {
             $geoId = 244 #default is US
         }
+        
+        Copy-LabALCommon -ComputerName $Machine
 
         if (-not (Test-Path 'C:\AL'))
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   which can be used with our TFS cmdlets. Reduced a lot of duplicated code.
 - Connect-LabVM uses full screen mode by default
 - Fixed #561
+- Transfer of ALCommon library takes place in Wait-LabVM or Initialize-LWAzureVM now to have the lib on all lab VMs.
   
 ### Bug Fixes
 


### PR DESCRIPTION
## Description

To have the AL.Common libs on all machines, the code to copy the files was removed from the Install-LabSoftwarePackage function and moved to a separate one: Copy-LabALCommon. This function is called for any Azure or Hyper-V VM deployed.

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Deployment of some Azure and Hyper-V VMs.