### PR TITLE
[CustomRoles] Enabling non-string parameters

### DIFF
--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -582,7 +582,7 @@ function Invoke-LabCommand
                     {
                         if (-not $script:data) {$script:data = Get-Lab}
                         $hostStartScript = Get-Command -Name $hostStartPath
-                        $hostStartParam = Sync-Parameter -Command $hostStartScript -Parameters $item.Properties
+                        $hostStartParam = Sync-Parameter -Command $hostStartScript -Parameters $item.Properties -ConvertValue
                         if ($hostStartScript.Parameters.ContainsKey('ComputerName'))
                         {
                             $hostStartParam['ComputerName'] = $machine.Name

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -3222,7 +3222,8 @@ function Get-LabPostInstallationActivity
             {
                 foreach ($kvp in $Properties.GetEnumerator())
                 {
-                    $activity.Properties.Add($kvp.Key, $kvp.Value)
+                    [object[]]$toList = $kvp.Value
+                    $activity.Properties.Add($kvp.Key, $toList )
                 }
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Connect-LabVM uses full screen mode by default
 - Fixed #561
 - Transfer of ALCommon library takes place in Wait-LabVM or Initialize-LWAzureVM now to have the lib on all lab VMs.
+- Custom Roles can now have any parameter type they would like, fixing #925
   
 ### Bug Fixes
 

--- a/LabSources/CustomRoles/WindowsAdminCenter/HostStart.ps1
+++ b/LabSources/CustomRoles/WindowsAdminCenter/HostStart.ps1
@@ -12,9 +12,8 @@
     [uint16]
     $Port = 443,
 
-    [ValidateSet('True', 'False')]
-    [string]
-    $EnableDevMode = 'False'
+    [bool]
+    $EnableDevMode
 )
 
 $lab = Import-Lab -Name $data.Name -NoValidation -NoDisplay -PassThru
@@ -44,7 +43,7 @@ $arguments = @(
     "SME_PORT=$Port"
 )
 
-if ([Convert]::ToBoolean($EnableDevMode))
+if ($EnableDevMode)
 {
     $arguments += 'DEV_MODE=1'
 }


### PR DESCRIPTION
## Description

Custom Roles suffer from inflexible parameters, which makes life hard for our users when supplying parameters to these roles. It also complicates things for developers of custom roles. Fixes #925

I updated Sync-Parameter and added a ConvertValue parameter to attempt to convert the parameter value as well. This worked so far in my tests with the custom roles.

If this PR makes sense, https://github.com/AutomatedLab/AutomatedLab.Common/pull/92 needs to be merged and the module needs to be released before we can use this code.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Deployed a NuGet server with the correct parameter type