### PR TITLE
Special characters are not required

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -2887,7 +2887,6 @@ function Set-LabInstallationCredential
             $Password -match '[A-Z]'
             $Password -match '[a-z]'
             $Password -match '\d'
-            $Password -match '[\W_]'
             $Password.Length -ge 8
         )
 
@@ -2898,7 +2897,6 @@ function Set-LabInstallationCredential
                 Have lower characters
                 Have upper characters
                 Have a digit
-                Have a special character (Regex match [\W_])
             "
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Transfer of ALCommon library takes place in Wait-LabVM or Initialize-LWAzureVM now to have the lib on all lab VMs.
 - Custom Roles can now have any parameter type they would like, fixing #925
 - Install-Lab imports the VMs RDP certificates and Remove-Lab removes them to enable seamless Connect-LabVm
+- Relaxed Azure password policy as special characters are not mandatory.
   
 ### Bug Fixes
 


### PR DESCRIPTION
## Description

Azure does not require password to contain special characters (\W). When creating machines through the portal, passwords must be 12 characters long and contain \d, \w. Using ARM or PowerShell it is also \d and \w but only 8 characters. Hence, we can use the same usual password for Hyper-V and Azure.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
DscWorkshop