### PR TITLE
New-LabReleasePipeline and Get-LabTfsFeed on Azure fixed

### DIFF
--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -779,7 +779,7 @@ function New-LabReleasePipeline
 
             Set-Location -Path "C:\$ProjectName.temp\$ProjectName"
 
-            git remote add tfs $repository.remoteUrl
+            git remote add tfs $repoUrl
 
             $pattern = '(?>remotes\/origin\/)(?<BranchName>[\w\/]+)'
             $branches = git branch -a | Where-Object { $_ -cnotlike '*HEAD*' -and -not $_.StartsWith('*') }
@@ -800,7 +800,7 @@ function New-LabReleasePipeline
 
             Set-Location -Path C:\
             Remove-Item -Path "C:\$ProjectName.temp" -Recurse -Force
-        } -Variable (Get-Variable -Name repository, ProjectName)
+        } -Variable (Get-Variable -Name repoUrl, ProjectName)
     }
 
     if (-not ($role.Name -eq 'AzDevOps' -and $tfsVm.SkipDeployment))
@@ -812,7 +812,7 @@ function New-LabReleasePipeline
                 New-Item -ItemType Directory -Path C:\Git | Out-Null
             }
             Set-Location -Path C:\Git
-            git -c http.sslVerify=false clone $repository.remoteUrl 2>&1
+            git -c http.sslVerify=false clone $repoUrl 2>&1
 
         } -Variable (Get-Variable -Name repository, ProjectName)
     }

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -814,7 +814,7 @@ function New-LabReleasePipeline
             Set-Location -Path C:\Git
             git -c http.sslVerify=false clone $repoUrl 2>&1
 
-        } -Variable (Get-Variable -Name repository, ProjectName)
+        } -Variable (Get-Variable -Name repoUrl, ProjectName)
     }
 
     if ($BuildSteps.Count -gt 0)

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -1123,6 +1123,16 @@ function Get-LabTfsFeed
     $defaultParam['ApiVersion'] = '5.0-preview.1'
     
     $feed = Get-TfsFeed @defaultParam
+        
+    if (-not $tfsVm.SkipDeployment -and $(Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
+    {
+        $ismatch = $feed.url -match 'http(s?)://(?<Host>[\w\.]+):'
+        if ($ismatch)
+        {
+            $feed.url = $feed.url.Replace($Matches.Host, $tfsVm.AzureConnectionInfo.Fqdn)
+        }
+    }
+
     if ($feed.url -match '(?<url>http.*)\/_apis')
     {
         $nugetV2Url = '{0}/_packaging/{1}/nuget/v2' -f $Matches.url, $feed.name

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -596,10 +596,9 @@ function New-LabReleasePipeline
 
     if (-not $tfsVm.SkipDeployment -and $(Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
     {
-        $ismatch = $repository.remoteUrl -match 'http(s?)://(?<Host>[\w\.]+):'
-        if ($ismatch)
+        if ($repository.remoteUrl -match 'http(s?)://(?<Host>[\w\.]+):')
         {
-            $repository.remoteUrl = $repository.remoteUrl.Replace($Matches.Host, $tfsVm.AzureConnectionInfo.Fqdn)
+            $repository.remoteUrl = $repository.remoteUrl.Replace($Matches.Host, $tfsVm.AzureConnectionInfo.DnsName)
         }
     }
 
@@ -1126,10 +1125,10 @@ function Get-LabTfsFeed
         
     if (-not $tfsVm.SkipDeployment -and $(Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
     {
-        $ismatch = $feed.url -match 'http(s?)://(?<Host>[\w\.]+):'
-        if ($ismatch)
+        if ($feed.url -match 'http(s?)://(?<Host>[\w\.]+):(?<Port>\d+)/')
         {
-            $feed.url = $feed.url.Replace($Matches.Host, $tfsVm.AzureConnectionInfo.Fqdn)
+            $feed.url = $feed.url.Replace($Matches.Host, $tfsVm.AzureConnectionInfo.DnsName)
+            $feed.url = $feed.url.Replace($Matches.Port, $defaultParam.Port)
         }
     }
 

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -594,6 +594,15 @@ function New-LabReleasePipeline
     $repository = Get-TfsGitRepository @defaultParam
     $repository.remoteUrl = $repository.remoteUrl -replace $originalPort, $defaultParam.Port
 
+    if (-not $tfsVm.SkipDeployment -and $(Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
+    {
+        $ismatch = $repository.remoteUrl -match 'http(s?)://(?<Host>[\w\.]+):'
+        if ($ismatch)
+        {
+            $repository.remoteUrl = $repository.remoteUrl.Replace($Matches.Host, $tfsVm.AzureConnectionInfo.Fqdn)
+        }
+    }
+
     if ($SourceRepository)
     {
         if (-not $gitBinary)


### PR DESCRIPTION
RemoteUrl will properly be replaced

<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #945 by updating the cmdlets Get-LabTfsFeed and New-LabReleasePipeline. Machines in the lab should primarily access ADO via the public URL, for external access we rewrite the URL with the public DNS name and the load-balanced port.

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Deployed the DSCWorkshop lab customization steps on Azure
@raandree it looks good to me. During the last run I received a Permission Denied despite the feed permissions being set by your cmdlet. I can access the feed in a browser without issues, but the registration fails. Registering it interactively in a RD session with the exact same parameters works just fine. So maybe look out for that, it might have been some other issue.