### PR TITLE
Removed unnecessary recreation of sessions

### DIFF
--- a/AutomatedLab/AutomatedLabHyperV.psm1
+++ b/AutomatedLab/AutomatedLabHyperV.psm1
@@ -83,7 +83,7 @@ function Install-LabHyperV
             }
 
             Set-VMHost @parameters
-        } -Function (Get-Command -Name Sync-Parameter) -AsJob -PassThru
+        } -Function (Get-Command -Name Sync-Parameter) -AsJob -PassThru -IgnoreAzureLabSources
     }
 
     Wait-LWLabJob -Job $jobs

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -211,7 +211,8 @@ function New-LabPSSession
                     $internalSession = New-PSSession @param -ErrorAction SilentlyContinue -ErrorVariable sessionError
                     $internalSession | Add-Member -Name LabMachineName -MemberType ScriptProperty -Value { $this.Name.Substring(0, $this.Name.IndexOf('_')) }
 
-                    if ($internalSession)
+                    # Additional check here for availability/state due to issues with Azure IaaS
+                    if ($internalSession -and $internalSession.Availability -eq 'Available' -and $internalSession.State -eq 'Opened')
                     {
                         Write-PSFMessage "Session to computer '$($param.ComputerName)' created"
                         $sessions += $internalSession

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -22,7 +22,9 @@ function New-LabPSSession
 
         [int]$Interval = 5,
 
-        [switch]$UseSSL
+        [switch]$UseSSL,
+
+        [switch]$IgnoreAzureLabSources
     )
 
     begin
@@ -170,7 +172,7 @@ function New-LabPSSession
             if ($internalSession)
             {
                 if ($internalSession.Runspace.ConnectionInfo.AuthenticationMechanism -eq 'CredSsp' -and
-                    -not $internalSession.ALLabSourcesMapped -and
+                    -not (-not $IgnoreAzureLabSources .IsPresent -and $internalSession.ALLabSourcesMapped) -and
                     (Get-LabVM -ComputerName $internalSession.LabMachineName).HostType -eq 'Azure'
                 )
                 {

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -172,7 +172,7 @@ function New-LabPSSession
             if ($internalSession)
             {
                 if ($internalSession.Runspace.ConnectionInfo.AuthenticationMechanism -eq 'CredSsp' -and
-                    -not (-not $IgnoreAzureLabSources .IsPresent -and $internalSession.ALLabSourcesMapped) -and
+                    -not (-not $IgnoreAzureLabSources.IsPresent -and $internalSession.ALLabSourcesMapped) -and
                     (Get-LabVM -ComputerName $internalSession.LabMachineName).HostType -eq 'Azure'
                 )
                 {

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -172,7 +172,7 @@ function New-LabPSSession
             if ($internalSession)
             {
                 if ($internalSession.Runspace.ConnectionInfo.AuthenticationMechanism -eq 'CredSsp' -and
-                    -not (-not $IgnoreAzureLabSources.IsPresent -and $internalSession.ALLabSourcesMapped) -and
+                    -not $IgnoreAzureLabSources.IsPresent -and -not $internalSession.ALLabSourcesMapped -and
                     (Get-LabVM -ComputerName $internalSession.LabMachineName).HostType -eq 'Azure'
                 )
                 {

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -485,7 +485,9 @@ function Invoke-LabCommand
 
         [switch]$PassThru,
 
-        [switch]$NoDisplay
+        [switch]$NoDisplay,
+
+        [switch]$IgnoreAzureLabSources
     )
 
     Write-LogFunctionEntry
@@ -604,7 +606,7 @@ function Invoke-LabCommand
                 $param.Add('ComputerName', $ComputerName)
 
                 Write-PSFMessage "Creating session to computers) '$ComputerName'"
-                $session = New-LabPSSession -ComputerName $ComputerName -DoNotUseCredSsp:$item.DoNotUseCredSsp
+                $session = New-LabPSSession -ComputerName $ComputerName -DoNotUseCredSsp:$item.DoNotUseCredSsp -IgnoreAzureLabSources:$IgnoreAzureLabSources.IsPresent
                 if (-not $session)
                 {
                     Write-LogFunctionExitWithError "Could not create a session to machine '$ComputerName'"
@@ -692,7 +694,7 @@ function Invoke-LabCommand
         $param.Add('ComputerName', $machines)
 
         Write-PSFMessage "Creating session to computer(s) '$machines'"
-        $session = @(New-LabPSSession -ComputerName $machines -DoNotUseCredSsp:$DoNotUseCredSsp -UseLocalCredential:$UseLocalCredential -Credential $credential)
+        $session = @(New-LabPSSession -ComputerName $machines -DoNotUseCredSsp:$DoNotUseCredSsp -UseLocalCredential:$UseLocalCredential -Credential $credential -IgnoreAzureLabSources:$IgnoreAzureLabSources.IsPresent)
         if (-not $session)
         {
             Write-LogFunctionExitWithError "Could not create a session to machine '$machines'"

--- a/AutomatedLab/AutomatedLabSQL.psm1
+++ b/AutomatedLab/AutomatedLabSQL.psm1
@@ -56,7 +56,6 @@ function Install-LabSqlServers
         foreach ($machine in $azureMachines)
         {
             Write-ScreenInfo -Type Verbose -Message "Configuring Azure SQL Server '$machine'"
-            Write-ScreenInfo -Message (Get-Date)
             $sqlCmd = {
                 $query = @"
 USE [master]
@@ -87,18 +86,17 @@ GO
             Where-Object Name -like 'SQL*').Properties.Keys |
     Where-Object {$_ -ne 'InstallSampleDatabase'})}
 
-    $downloadTargetFolder = "$labSources\SoftwarePackages"
-    $cppRedist64_2017 = Get-LabInternetFile -Uri (Get-LabConfigurationItem -Name cppredist64_2017) -Path $downloadTargetFolder -FileName vcredist_x64_2017.exe -PassThru
-    $cppredist32_2017 = Get-LabInternetFile -Uri (Get-LabConfigurationItem -Name cppredist32_2017) -Path $downloadTargetFolder -FileName vcredist_x86_2017.exe -PassThru
-    $cppRedist64_2015 = Get-LabInternetFile -Uri (Get-LabConfigurationItem -Name cppredist64_2015) -Path $downloadTargetFolder -FileName vcredist_x64_2015.exe -PassThru
-    $cppredist32_2015 = Get-LabInternetFile -Uri (Get-LabConfigurationItem -Name cppredist32_2015) -Path $downloadTargetFolder -FileName vcredist_x86_2015.exe -PassThru
-    $dotnet48DownloadLink = Get-LabConfigurationItem -Name dotnet48DownloadLink
-
-    Write-ScreenInfo -Message "Downloading .net Framework 4.8 from '$dotnet48DownloadLink'"
-    $dotnet48InstallFile = Get-LabInternetFile -Uri $dotnet48DownloadLink -Path $downloadTargetFolder -PassThru -ErrorAction Stop
-
     if ($onPremisesMachines)
     {
+        $downloadTargetFolder = "$labSources\SoftwarePackages"
+        $cppRedist64_2017 = Get-LabInternetFile -Uri (Get-LabConfigurationItem -Name cppredist64_2017) -Path $downloadTargetFolder -FileName vcredist_x64_2017.exe -PassThru
+        $cppredist32_2017 = Get-LabInternetFile -Uri (Get-LabConfigurationItem -Name cppredist32_2017) -Path $downloadTargetFolder -FileName vcredist_x86_2017.exe -PassThru
+        $cppRedist64_2015 = Get-LabInternetFile -Uri (Get-LabConfigurationItem -Name cppredist64_2015) -Path $downloadTargetFolder -FileName vcredist_x64_2015.exe -PassThru
+        $cppredist32_2015 = Get-LabInternetFile -Uri (Get-LabConfigurationItem -Name cppredist32_2015) -Path $downloadTargetFolder -FileName vcredist_x86_2015.exe -PassThru
+        $dotnet48DownloadLink = Get-LabConfigurationItem -Name dotnet48DownloadLink
+
+        Write-ScreenInfo -Message "Downloading .net Framework 4.8 from '$dotnet48DownloadLink'"
+        $dotnet48InstallFile = Get-LabInternetFile -Uri $dotnet48DownloadLink -Path $downloadTargetFolder -PassThru -ErrorAction Stop
         $parallelInstalls = 4
         Write-ScreenInfo -Type Verbose -Message "Parallel installs: $parallelInstalls"
         $machineIndex = 0

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -2426,7 +2426,7 @@ function Copy-LabALCommon
     } -ComputerName $coreChild.ComputerName -NoDisplay -PassThru).Count -ne $coreChild.Count)
     {
         $coreLibraryFolder = Join-Path -Path $libLocation -ChildPath $coreChild[0]
-        Copy-LabFileItem -Path $coreLibraryFolder -ComputerName $coreChild.ComputerName -DestinationFolderPath '/ALLibraries'
+        Copy-LabFileItem -Path $coreLibraryFolder -ComputerName $coreChild.ComputerName -DestinationFolderPath '/ALLibraries' -UseAzureLabSourcesOnAzureVm $false
     }
 
     if ($fullChild -and @(Invoke-LabCommand -ScriptBlock {
@@ -2434,7 +2434,7 @@ function Copy-LabALCommon
     } -ComputerName $fullChild.ComputerName -NoDisplay -PassThru).Count -ne $fullChild.Count)
     {
         $fullLibraryFolder = Join-Path -Path $libLocation -ChildPath $fullChild[0]
-        Copy-LabFileItem -Path $fullLibraryFolder -ComputerName $fullChild.ComputerName -DestinationFolderPath '/ALLibraries'
+        Copy-LabFileItem -Path $fullLibraryFolder -ComputerName $fullChild.ComputerName -DestinationFolderPath '/ALLibraries' -UseAzureLabSourcesOnAzureVm $false
     }
 }
 #endregion Copy-LabALCommon

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -2413,7 +2413,7 @@ function Copy-LabALCommon
             {
                 'full'
             }
-        } -ComputerName $vm -NoDisplay -PassThru |
+        } -ComputerName $vm -NoDisplay -IgnoreAzureLabSources -PassThru |
         Add-Member -MemberType NoteProperty -Name ComputerName -Value $vm -Force -PassThru
     }
 
@@ -2423,7 +2423,7 @@ function Copy-LabALCommon
 
     if ($coreChild -and @(Invoke-LabCommand -ScriptBlock{
                 Get-Item -Path '/ALLibraries/core/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
-    } -ComputerName $coreChild.ComputerName -NoDisplay -PassThru).Count -ne $coreChild.Count)
+    } -ComputerName $coreChild.ComputerName -IgnoreAzureLabSources -NoDisplay -PassThru).Count -ne $coreChild.Count)
     {
         $coreLibraryFolder = Join-Path -Path $libLocation -ChildPath $coreChild[0]
         Copy-LabFileItem -Path $coreLibraryFolder -ComputerName $coreChild.ComputerName -DestinationFolderPath '/ALLibraries' -UseAzureLabSourcesOnAzureVm $false
@@ -2431,7 +2431,7 @@ function Copy-LabALCommon
 
     if ($fullChild -and @(Invoke-LabCommand -ScriptBlock {
                 Get-Item -Path '/ALLibraries/full/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
-    } -ComputerName $fullChild.ComputerName -NoDisplay -PassThru).Count -ne $fullChild.Count)
+    } -ComputerName $fullChild.ComputerName -IgnoreAzureLabSources -NoDisplay -PassThru).Count -ne $fullChild.Count)
     {
         $fullLibraryFolder = Join-Path -Path $libLocation -ChildPath $fullChild[0]
         Copy-LabFileItem -Path $fullLibraryFolder -ComputerName $fullChild.ComputerName -DestinationFolderPath '/ALLibraries' -UseAzureLabSourcesOnAzureVm $false

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1366,7 +1366,7 @@ function Initialize-LWAzureVM
     }
 
     Wait-LWLabJob -Job $jobs -ProgressIndicator 5 -Timeout 30 -NoDisplay
-    Copy-LabFileItem -Path (Get-ChildItem -Path "$((Get-Module -Name AutomatedLab)[0].ModuleBase)\Tools\HyperV\*") -DestinationFolderPath /AL -ComputerName $Machine -UseAzureLabSourcesOnAzureVm:$false
+    Copy-LabFileItem -Path (Get-ChildItem -Path "$((Get-Module -Name AutomatedLab)[0].ModuleBase)\Tools\HyperV\*") -DestinationFolderPath /AL -ComputerName $Machine -UseAzureLabSourcesOnAzureVm $false
     Copy-LabALCommon -ComputerName $Machine
     Write-ScreenInfo -Message 'Finished' -TaskEnd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   
 ### Bug Fixes
 - Get-LabInternetFile did not work on Azure when the Uri did not contain a file name like 'https://go.microsoft.com/fwlink/?Linkid=85215'.
-
+- Decreased runtime of installation on Azure by disabling the Azure LabSources check in Copy-LabAlCommon
 - Build Agent role on Azure can now again connect to its server (Fixes #938)
 
 ## 5.21.0 - 2020-05-26

--- a/PSFileTransfer/PSFileTransfer.psm1
+++ b/PSFileTransfer/PSFileTransfer.psm1
@@ -507,7 +507,7 @@ function Copy-LabFileItem
                     continue
                 }
 
-                $session = New-LabPSSession -ComputerName $machine
+                $session = New-LabPSSession -ComputerName $machine -IgnoreAzureLabSources
                 foreach ($p in $Path)
                 {
 


### PR DESCRIPTION
## Description

Copy-LabAlCommon required Copy-LabFileItem to use a PSSession with the lab sources storage mapped, which leads to countless warnings and a long lab runtime until the lab DNS forwarders are set properly.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
During the deployment of the DSC workshop I got thoroughly annoyed by the warnings and used it to test my change.