### PR TITLE
EnableManagementAdapter never really set to false

### DIFF
--- a/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
@@ -123,7 +123,7 @@ function Add-LabVirtualNetworkDefinition
     $network.Name = $Name
     if ($HyperVProperties.SwitchType) { $network.SwitchType = $HyperVProperties.SwitchType }
     if ($HyperVProperties.AdapterName) {$network.AdapterName = $HyperVProperties.AdapterName }
-    if ($HyperVProperties.ManagementAdapter -eq $false) {$network.EnableManagementAdapter = $false }
+    if (-not $HyperVProperties -or ($HyperVProperties -and -not $HyperVProperties.ContainsKey('ManagementAdapter') -or $HyperVProperties.ManagementAdapter -eq $false)) {$network.EnableManagementAdapter = $false }
     if ($ManagementAdapter) {$network.ManagementAdapter = $ManagementAdapter}
 
     #VLAN's are not supported on non-external interfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Get-LabInternetFile did not work on Azure when the Uri did not contain a file name like 'https://go.microsoft.com/fwlink/?Linkid=85215'.
 - Decreased runtime of installation on Azure by disabling the Azure LabSources check in Copy-LabAlCommon
 - Build Agent role on Azure can now again connect to its server (Fixes #938)
+- EnableManagementAdapter was never actually set to false, thus potentially causing issues
 
 ## 5.21.0 - 2020-05-26
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Due to the property EnableManagementAdapter never being set to false and its default being true, we entered a code path we should not enter. This, on my Win10 2004 dev host, lead to persistent issues

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Deploy any Hyper-V lab. Could not test the actual management adapter functionality but I have to assume it still works.