### PR TITLE
Net Adapter Pattern fixed

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
@@ -67,7 +67,7 @@ function New-LWHypervNetworkSwitch
 
         if ($network.EnableManagementAdapter) {
 
-            $config = Get-NetAdapter | Where-Object Name -Match "vEthernet \($($network.Name)\) ?(\d{1,2})?"
+            $config = Get-NetAdapter | Where-Object Name -Match "^vEthernet \($($network.Name)\) ?(\d{1,2})?"
             if (-not $config)
             {
                 throw "The network adapter for network switch '$network' could not be found. Cannot set up address hence will not be able to contact the machines"


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Possible Bug in some OS builds, mine appeared on Build 19041. New-VMSwitch would create two network adapters. One proper one and a second one with a badly truncated name, which sadly for short VNet names even matches the pattern we use. Updated this pattern

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
HyperV Lab deployed, raised behavior as a bug for Windows