### PR TITLE
Get-LabInternetFile fixed and role Office2019 fixed for Azure

### DIFF
--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -1297,7 +1297,7 @@ function Sync-LabAzureLabSources
             $azureFile = Get-AzStorageFile -Share (Get-AzStorageShare -Name labsources -Context $storageAccount.Context).CloudFileShare -Path $fileName -ErrorAction SilentlyContinue
             if ($azureFile)
             {
-                $azureHash = $azureFile.Properties.ContentMD5
+                $azureHash = $azureFile.CloudFile.Properties.ContentMD5
                 $fileHash = (Get-FileHash -Path $file.FullName -Algorithm MD5).Hash
                 Write-PSFMessage "$fileName already exists in Azure. Source hash is $fileHash and Azure hash is $azureHash"
             }

--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -569,20 +569,85 @@ function Get-LabInternetFile
     }
 
     $lab = Get-Lab -ErrorAction SilentlyContinue
+    if (-not $lab)
+    {
+        $lab = Get-LabDefinition -ErrorAction SilentlyContinue
+        $doNotGetVm = $true
+    }
 
     if ($lab.DefaultVirtualizationEngine -eq 'Azure')
     {
         if (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $Path)
         {
-            $machine = Get-LabVM -IsRunning | Select-Object -First 1
-            Write-PSFMessage "Target path is on AzureLabSources, invoking the copy job on the first available Azure machine."
+            # We need to test first, even if it takes a second longer.
+            if (-not $doNotGetVm)
+            {
+                $machine =  Invoke-LabCommand -PassThru -NoDisplay -ComputerName $(Get-LabVM -IsRunning) -ScriptBlock {
+                    hostname
+                } -ErrorAction SilentlyContinue | Select-Object -First 1 
+                Write-PSFMessage "Target path is on AzureLabSources, invoking the copy job on the first available Azure machine."
 
-            $argumentList = $Uri, $Path, $FileName
+                $argumentList = $Uri, $Path, $FileName
 
-            $argumentList += if ($NoDisplay) { $true } else { $false }
-            $argumentList += if ($Force) { $true } else { $false }
+                $argumentList += if ($NoDisplay) { $true } else { $false }
+                $argumentList += if ($Force) { $true } else { $false }
+            }
 
-            $result = Invoke-LabCommand -ActivityName "Downloading file from '$Uri'" -ComputerName $machine -ScriptBlock (Get-Command -Name Get-LabInternetFileInternal).ScriptBlock -ArgumentList $argumentList -PassThru
+            if ($machine)
+            {
+                $result = Invoke-LabCommand -ActivityName "Downloading file from '$Uri'" -ComputerName $machine -ScriptBlock (Get-Command -Name Get-LabInternetFileInternal).ScriptBlock -ArgumentList $argumentList -PassThru
+            }
+            elseif (Get-LabAzureSubscription -ErrorAction SilentlyContinue)
+            {
+                $blob = $Path.Replace("$(Get-LabSourcesLocation)\",'')
+                $PSBoundParameters.Remove('PassThru') | Out-Null
+                $param = Sync-Parameter -Command (Get-Command Get-LabInternetFileInternal) -Parameters $PSBoundParameters
+                $param['Path'] = $Path.Replace((Get-LabSourcesLocation), (Get-LabSourcesLocation -Local))
+
+                $result = Get-LabInternetFileInternal @param
+                $fullName = Join-Path -Path $param.Path.Replace($FileName,'') -ChildPath (?? { $FileName } { $FileName } { $result.FileName })
+                $storageAccount = Get-AzStorageAccount -ResourceGroupName automatedlabsources | Where-Object StorageAccountName -like automatedlabsources?????
+                
+                $container = Split-Path -Path $blob
+                $blobName = Split-Path -Path $blob -Leaf
+                New-AzStorageDirectory -Share (Get-AzStorageShare -Name labsources -Context $storageAccount.Context).CloudFileShare -Path $container -ErrorVariable err -ErrorAction SilentlyContinue | Out-Null
+                Write-PSFMessage "Created directory $($container) in labsources"
+                if ($err)
+                {
+                    $err = $null
+
+                    # Use an error variable and check the HttpStatusCode since there is no cmdlet to get or test a StorageDirectory
+                    New-AzStorageDirectory -Share (Get-AzStorageShare -Name labsources -Context $storageAccount.Context).CloudFileShare -Path $container -ErrorVariable err -ErrorAction SilentlyContinue | Out-Null
+                    Write-PSFMessage "Created directory '$container' in labsources"
+                    if ($err)
+                    {
+                        if ($err[0].Exception.RequestInformation.HttpStatusCode -ne 409)
+                        {
+                            throw "An error ocurred during file upload: $($err[0].Exception.Message)"
+                        }
+                    }
+                }
+
+                $azureFile = Get-AzStorageFile -Share (Get-AzStorageShare -Name labsources -Context $storageAccount.Context).CloudFileShare -Path $blobName -ErrorAction SilentlyContinue
+                if ($azureFile)
+                {
+                    $azureHash = $azureFile.CloudFile.Properties.ContentMD5
+                    $fileHash = (Get-FileHash -Path $fullName -Algorithm MD5).Hash
+                    Write-PSFMessage "$blobName already exists in Azure. Source hash is $fileHash and Azure hash is $azureHash"
+                }
+
+                if (-not $azureFile -or ($azureFile -and $fileHash -ne $azureHash))
+                {
+                    $null = Set-AzStorageFileContent -Share (Get-AzStorageShare -Name labsources -Context $storageAccount.Context).CloudFileShare -Source $fullName -Path $blobName -ErrorAction SilentlyContinue -Force
+                    Write-PSFMessage "Azure file $blobName successfully uploaded. Generating file hash..."
+                }
+            }
+            else
+            {
+                Write-ScreenInfo -Type Erro -Message "Unable to upload file to Azure lab sources - No VM is available and no Azure subscription was added to the lab`r`n
+                Please at least execute New-LabDefinition and Add-LabAzureSubscription before using Get-LabInternetFile"
+                return
+            }
         }
         else
         {


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #959 . Get-LabInternetFile can now download files to Azure storage account if the lab is not yet deployed. Minimum viable configuration is a New-LabDefinition and Add-LabAzureSubscription.

Office 2019 Role updated so that it should run on Azure.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Ran one onprem and one Azure lab deploying Office 2019