### PR TITLE
[Azure] Fix Get-LabInternetFile

### DIFF
--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -583,7 +583,10 @@ function Get-LabInternetFile
             if (-not $doNotGetVm)
             {
                 $machine =  Invoke-LabCommand -PassThru -NoDisplay -ComputerName $(Get-LabVM -IsRunning) -ScriptBlock {
-                    hostname
+                    if (Get-NetConnectionProfile -IPv4Connectivity Internet -ErrorAction SilentlyContinue)
+                    {
+                        hostname
+                    }
                 } -ErrorAction SilentlyContinue | Select-Object -First 1 
                 Write-PSFMessage "Target path is on AzureLabSources, invoking the copy job on the first available Azure machine."
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

In addition to the changes already proposed we now add a reboot for Azure VMs that are not connected after the deployment is done (just before the PostInstall activities run).

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Deployed another Azure lab to try and reproduce the issue to see if the fix solved things. Set NetConnectionProfile to Disconnected on one VM and noticed that as intended a different VM is selected.