### PR TITLE
Ensure drive letter gets assigned when mounting an image (Fixes #874)

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -514,7 +514,7 @@ function New-LWHypervVM
             If ($vhdOsPartition.NoDefaultDriveLetter) {
                 # Get all available drive letters, and store in a temporary variable.
                 $usedDriveLetters = @(Get-Volume | ForEach-Object { "$([char]$_.DriveLetter)" }) + @(Get-CimInstance -ClassName Win32_MappedLogicalDisk | ForEach-Object { $([char]$_.DeviceID.Trim(':')) })
-                $tempDriveLetters = @(Compare-Object -DifferenceObject $usedDriveLetters -ReferenceObject $( 67..90 | ForEach-Object { "$([char]$_)" } ) | Where-Object { $_.SideIndicator -eq '<=' } | ForEach-Object { $_.InputObject })
+                [char[]]$tempDriveLetters = Compare-Object -DifferenceObject $usedDriveLetters -ReferenceObject $( 67..90 | ForEach-Object { "$([char]$_)" }) -PassThru | Where-Object { $_.SideIndicator -eq '<=' }
                 # Sort the available drive letters to get the first available drive letter
                 $availableDriveLetters = ($TempDriveLetters | Sort-Object)
                 $firstAvailableDriveLetter = $availableDriveLetters[0]

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -513,7 +513,7 @@ function New-LWHypervVM
             # If no drive letter is assigned, make sure we assign it before continuing
             If ($vhdOsPartition.NoDefaultDriveLetter) {
                 # Get all available drive letters, and store in a temporary variable.
-                $usedDriveLetters = @(Get-Volume | ForEach-Object { "$([char]$_.DriveLetter)" }) + @(Get-WmiObject -Class Win32_MappedLogicalDisk | ForEach-Object { $([char]$_.DeviceID.Trim(':')) })
+                $usedDriveLetters = @(Get-Volume | ForEach-Object { "$([char]$_.DriveLetter)" }) + @(Get-CimInstance -ClassName Win32_MappedLogicalDisk | ForEach-Object { $([char]$_.DeviceID.Trim(':')) })
                 $tempDriveLetters = @(Compare-Object -DifferenceObject $usedDriveLetters -ReferenceObject $( 67..90 | ForEach-Object { "$([char]$_)" } ) | Where-Object { $_.SideIndicator -eq '<=' } | ForEach-Object { $_.InputObject })
                 # Sort the available drive letters to get the first available drive letter
                 $availableDriveLetters = ($TempDriveLetters | Sort-Object)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Get-LabInternetFile did not work on Azure when the Uri did not contain a file name like 'https://go.microsoft.com/fwlink/?Linkid=85215'.
 - Decreased runtime of installation on Azure by disabling the Azure LabSources check in Copy-LabAlCommon
 - Build Agent role on Azure can now again connect to its server (Fixes #938)
+- Ensure drive letter gets assigned when mounting an image (Fixes #874)
 
 ## 5.21.0 - 2020-05-26
 


### PR DESCRIPTION
## Description

A drive letter is not always assigned correctly when mounting a VHD image, during the creation of a Hyper-V Gen 2 Virtual Machine. This change will ensure one gets assigned if it is missing, allowing the rest of the VM creation process to proceed without failing.

- [X] - I have tested my changes.  
- [X] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [X] - The PR has a meaningful title.  
- [X] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [X] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

Manually tested by repeatedly building a single workstation lab, and subseuqently a more complex 5 server lab.
