### PR TITLE
Remove-LabVm now removes assoc resources on Azure

### DIFF
--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -1264,7 +1264,7 @@ function Sync-LabAzureLabSources
         }
         $files = Get-ChildItem @fileParams
 
-        Write-ScreenInfo "with $($files.Count) files" -NoNewLine
+        Write-ScreenInfo "$($files.Count) files" -NoNewLine
         foreach ($file in $files)
         {
             Write-ProgressIndicator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed issue with Install-LabSoftwarePackage not working for Azure VMs outside of $LabSources (Issue #989)
 - Installing RDS certificates and calling the Pester tests only if $performAll or explicitly defined. Before Install-Lab 
   threw errors in case only some parts of the lab deployment should be done.
+- Remove-LabVm now removes associated resources on Azure (Issue #998 and #997)
 
 ## 5.22.0 - 2020-07-10
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #997 and fixes #998 . Parameter name of Remove-LWAzureVm has been unified to Name instead of ComputerName. Remove-LWAzureVm now removes all resources related to the machine: Disk, Inbound NAT rules and NIC

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Deployed a lab on Azure, used Remove-LabVm to remove a VM and observed that all related resources were removed as well