### PR TITLE
Install-Lab sometimes threw errors when not installing the at once

### DIFF
--- a/AutomatedLab.sln
+++ b/AutomatedLab.sln
@@ -231,6 +231,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scenarios", "Scenarios", "{
 		LabSources\SampleScripts\Scenarios\DSC Pull Scenario 2 (Pull Partial Configuration).ps1 = LabSources\SampleScripts\Scenarios\DSC Pull Scenario 2 (Pull Partial Configuration).ps1
 		LabSources\SampleScripts\Scenarios\DSC With Release Pipeline.ps1 = LabSources\SampleScripts\Scenarios\DSC With Release Pipeline.ps1
 		LabSources\SampleScripts\Scenarios\Failover Clustering 1.ps1 = LabSources\SampleScripts\Scenarios\Failover Clustering 1.ps1
+		LabSources\SampleScripts\Scenarios\Failover Clustering 2 (Shared Storage).ps1 = LabSources\SampleScripts\Scenarios\Failover Clustering 2 (Shared Storage).ps1
 		LabSources\SampleScripts\Scenarios\Hybrid Environment HyperV and Azure 1.ps1 = LabSources\SampleScripts\Scenarios\Hybrid Environment HyperV and Azure 1.ps1
 		LabSources\SampleScripts\Scenarios\Lab in a Box 1 - HyperV.ps1 = LabSources\SampleScripts\Scenarios\Lab in a Box 1 - HyperV.ps1
 		LabSources\SampleScripts\Scenarios\Lab in a Box 2 - Azure.ps1 = LabSources\SampleScripts\Scenarios\Lab in a Box 2 - Azure.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Aligned the name of the 'DscMofEncryption' template with its display name
 - Fixed issue with Install-LabSoftwarePackage not working for Azure VMs outside of $LabSources (Issue #989)
+- Installing RDS certificates and calling the Pester tests only if $performAll or explicitly defined. Before Install-Lab 
+  threw errors in case only some parts of the lab deployment should be done.
 
 ## 5.22.0 - 2020-07-10
 

--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -123,6 +123,7 @@
                 <File Id='Sample_DSCCICD' Name='DSC With Release Pipeline.ps1' DiskId='1' Source='$(var.SolutionDir)LabSources\SampleScripts\Scenarios\DSC With Release Pipeline.ps1' />
                 <File Id='Sample_MultiAdForest1' Name='Multi-AD Forest with Trusts.ps1' DiskId='1' Source='$(var.SolutionDir)LabSources\SampleScripts\Scenarios\Multi-AD Forest with Trusts.ps1' />
                 <File Id='Sample_FailoverClustering1' Name='Failover Clustering 1.ps1' DiskId='1' Source='$(var.SolutionDir)LabSources\SampleScripts\Scenarios\Failover Clustering 1.ps1' />
+                <File Id='Sample_FailoverClustering2' Name='Failover Clustering 2 (Shared Storage).ps1' DiskId='1' Source='$(var.SolutionDir)LabSources\SampleScripts\Scenarios\Failover Clustering 2 (Shared Storage).ps1' />
                 <File Id='Sample_HybridEnvironmentHyperVandAzure1' Name='Hybrid Environment HyperV and Azure 1.ps1' DiskId='1' Source='$(var.SolutionDir)LabSources\SampleScripts\Scenarios\Hybrid Environment HyperV and Azure 1.ps1' />
                 <File Id='Sample_Tfs2015Environment' Name='TFS 2015 Deployment.ps1' DiskId='1' Source='$(var.SolutionDir)LabSources\SampleScripts\Scenarios\TFS 2015 Deployment.ps1' />
                 <File Id='Sample_Tfs2017Environment' Name='TFS 2017 Deployment.ps1' DiskId='1' Source='$(var.SolutionDir)LabSources\SampleScripts\Scenarios\TFS 2017 Deployment.ps1' />


### PR DESCRIPTION
## Description

Installing RDS certificates and calling the Pester tests only if $performAll or explicitly defined.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Some simple lab deployments.