### PR TITLE
Making 'FailoverStorage' deployment a separate install option

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -714,6 +714,7 @@ function Install-Lab
         [switch]$Office2016,
         [switch]$AzureServices,
         [switch]$TeamFoundation,
+        [switch]$FailoverStorage,
         [switch]$FailoverCluster,
         [switch]$FileServer,
         [switch]$HyperV,
@@ -979,10 +980,20 @@ function Install-Lab
 
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }
-
-    if (($FailoverCluster -or $performAll) -and (Get-LabVM -Role FailoverNode,FailoverStorage | Where-Object { -not $_.SkipDeployment }))
+    
+    if (($FailoverStorage -or $performAll) -and (Get-LabVM -Role FailoverStorage | Where-Object { -not $_.SkipDeployment }))
     {
-        Write-ScreenInfo -Message 'Installing Failover cluster' -TaskStart
+        Write-ScreenInfo -Message 'Installing Failover Storage' -TaskStart
+
+        Start-LabVM -RoleName FailoverStorage -ProgressIndicator 15 -PostDelaySeconds 5 -Wait
+        Install-LabFailoverStorage
+
+        Write-ScreenInfo -Message 'Done' -TaskEnd
+    }
+
+    if (($FailoverCluster -or $performAll) -and (Get-LabVM -Role FailoverNode, FailoverStorage | Where-Object { -not $_.SkipDeployment }))
+    {
+        Write-ScreenInfo -Message 'Installing Failover Cluster' -TaskStart
 
         Start-LabVM -RoleName FailoverNode,FailoverStorage -ProgressIndicator 15 -PostDelaySeconds 5 -Wait
         Install-LabFailoverCluster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Enhancements
 
 - Added SCVMM Role to deploy SCVMM 2016 and 2019
+- 'FailoverStorage' is available as a separate install option
 
 ### Fixes
 


### PR DESCRIPTION
## Description

In some scenarios, iSCSI storage is needed but not the installation of the cluster. 

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Tested with 'Failover Clustering 2 (Shared Storage).ps1'