### PR TITLE
Increased speed of Get-LabAzureLabSourcesContent

### DIFF
--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -1343,6 +1343,10 @@ function Get-LabAzureLabSourcesContent
         [string]
         $RegexFilter,
 
+        # Path relative to labsources file share
+        [string]
+        $Path,
+
         [switch]
         $File,
 
@@ -1354,7 +1358,12 @@ function Get-LabAzureLabSourcesContent
 
     $azureShare = Get-AzStorageShare -Name labsources -Context (Get-LabAzureLabSourcesStorage).Context
 
-    $content = Get-LabAzureLabSourcesContentRecursive -StorageContext $azureShare
+    $params = @{
+        StorageContext = $azureShare
+    }
+    if ($Path) {$params.Path = $Path}
+
+    $content = Get-LabAzureLabSourcesContentRecursive @params
 
     if (-not [string]::IsNullOrWhiteSpace($RegexFilter))
     {
@@ -1363,17 +1372,17 @@ function Get-LabAzureLabSourcesContent
 
     if ($File)
     {
-        $content = $content | Where-Object -FilterScript {$PSItem.GetType().FullName -eq 'Microsoft.Azure.Storage.File.CloudFile'}
+        $content = $content | Where-Object -FilterScript { $PSItem.GetType().FullName -eq 'Microsoft.Azure.Storage.File.CloudFile' }
     }
 
     if ($Directory)
     {
-        $content = $content | Where-Object -FilterScript {$PSItem.GetType().FullName -eq 'Microsoft.Azure.Storage.File.CloudFileDirectory'}
+        $content = $content | Where-Object -FilterScript { $PSItem.GetType().FullName -eq 'Microsoft.Azure.Storage.File.CloudFileDirectory' }
     }
 
     $content = $content |
-    Add-Member -MemberType ScriptProperty -Name FullName -Value {$this.Uri.AbsoluteUri} -Force -PassThru |
-    Add-Member -MemberType ScriptProperty -Name Length -Force -Value {$this.Properties.Length} -PassThru
+    Add-Member -MemberType ScriptProperty -Name FullName -Value { $this.Uri.AbsoluteUri } -Force -PassThru |
+    Add-Member -MemberType ScriptProperty -Name Length -Force -Value { $this.Properties.Length } -PassThru
 
     return $content
 }
@@ -1384,14 +1393,26 @@ function Get-LabAzureLabSourcesContentRecursive
     param
     (
         [Parameter(Mandatory)]
-        [object]$StorageContext
+        [object]$StorageContext,
+
+        # Path relative to labsources file share
+        [string]
+        $Path
     )
 
     Test-LabHostConnected -Throw -Quiet
 
     $content = @()
 
-    $temporaryContent = $StorageContext | Get-AzStorageFile
+    $temporaryContent = if ($Path)
+    {
+        $StorageContext | Get-AzStorageFile -Path $Path -ErrorAction SilentlyContinue
+    }
+    else
+    {
+        $StorageContext | Get-AzStorageFile
+    }
+
     foreach ($item in $temporaryContent)
     {
         if ($item.CloudFileDirectory)

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1537,7 +1537,19 @@ function Add-LabIsoImageDefinition
     {
         if (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $Path)
         {
-            $isoFiles = Get-LabAzureLabSourcesContent -RegexFilter '\.iso' -File -ErrorAction SilentlyContinue
+            $isoRoot = 'ISOs'
+            if ($Path -notmatch 'ISOs$')
+            {
+                # Get relative path
+                $isoRoot = $Path.Replace($labSources, '')
+            }
+
+            if ($isoRoot.StartsWith('\') -or $isoRoot.StartsWith('/') )
+            {
+                $isoRoot = $isoRoot.Substring(1)
+            }
+
+            $isoFiles = Get-LabAzureLabSourcesContent -Path $isoRoot -RegexFilter '\.iso' -File -ErrorAction SilentlyContinue
 
             if ( -not $IsLinux -and [System.IO.Path]::HasExtension($Path) -or $IsLinux -and $Path -match '\.iso$')
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Added SCVMM Role to deploy SCVMM 2016 and 2019
 - 'FailoverStorage' is available as a separate install option
+- Speed of Add-LabIsoImageDefinition on Azure increased by adding Path parameter
 
 ### Fixes
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

When adding ISO files the Cmdlet took an obscene amount of time. I've added a Path parameter to Get-LabAzureLabSourcesContent so that Add-LabIsoImageDefinition can execute much, much faster on Azure.
Tested with individual files in LabSources, as well as the entire ISOs folder

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
1) Small lab with one machine, having used Clear-LabCache before to invalidate the cache
2) New LabDefinition and then Add-LabIsoImageDefinition for some SQL ISO