### PR TITLE
Added two new validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added SCVMM Role to deploy SCVMM 2016 and 2019
 - 'FailoverStorage' is available as a separate install option
 - Speed of Add-LabIsoImageDefinition on Azure increased by adding Path parameter
+- Added two new validators: DuplicateAddressAssigned, NonExistingDnsServerAssigned
 
 ### Fixes
 

--- a/LabXml/Validator/Network/DuplicateAddressAssigned.cs
+++ b/LabXml/Validator/Network/DuplicateAddressAssigned.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace AutomatedLab
+{
+    /// <summary>
+    /// New external switch has a name collision with an already exisitng private or internal one.
+    /// </summary>
+    public class DuplicateAddressAssigned : LabValidator, IValidate
+    {
+        public DuplicateAddressAssigned()
+        {
+            messageContainer = RunValidation();
+        }
+
+        public override IEnumerable<ValidationMessage> Validate()
+        {
+            var dupliateAddresses = lab.Machines.SelectMany(m => m.NetworkAdapters)
+                .SelectMany(n => n.Ipv4Address)
+                .GroupBy(ip => ip.IpAddress)
+                .Where(group => group.Count() > 1);
+
+            if (dupliateAddresses.Count() == 0)
+                yield break;
+
+            foreach (var dupliateAddress in dupliateAddresses)
+            {
+                yield return new ValidationMessage
+                {
+                    Message = string.Format("The IP address {0} is assigned multiple times", dupliateAddress.Key),
+                    TargetObject = dupliateAddress.ToList().Select(ip => ip.IpAddress.AddressAsString)
+                        .Aggregate((a, b) => a + ", " + b),
+                    Type = MessageType.Error
+                };
+            }
+        }
+    }
+}

--- a/LabXml/Validator/Network/NonExistingDnsServerAssigned.cs
+++ b/LabXml/Validator/Network/NonExistingDnsServerAssigned.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace AutomatedLab
+{
+    /// <summary>
+    /// New external switch has a name collision with an already exisitng private or internal one.
+    /// </summary>
+    public class NonExistingDnsServerAssigned : LabValidator, IValidate
+    {
+        public NonExistingDnsServerAssigned()
+        {
+            messageContainer = RunValidation();
+        }
+
+        public override IEnumerable<ValidationMessage> Validate()
+        {
+            var dnsServers = lab.Machines
+                .Where(m => m.Roles.Select(r => r.Name).Where(r => (AutomatedLab.Roles.ADDS & r) == r).Count() == 0)
+                .SelectMany(m =>m.NetworkAdapters)
+                .SelectMany(n => n.Ipv4DnsServers);
+
+            var nonExistingDnssServers = lab.Machines
+                .SelectMany(m => m.NetworkAdapters)
+                .SelectMany(n => n.Ipv4DnsServers)
+                .Where(dns => !dnsServers.Contains(dns));
+
+            if (nonExistingDnssServers.Count() == 0)
+                yield break;
+
+            foreach (var nonExistingDnssServer in nonExistingDnssServers)
+            {
+                yield return new ValidationMessage
+                {
+                    Message = string.Format("The DNS server client address {0} does not point to a valid DNS server in the lab", nonExistingDnssServer.AddressAsString),
+                    TargetObject = nonExistingDnssServer.AddressAsString,
+                    Type = MessageType.Error
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Added two new validators:
- DuplicateAddressAssigned
- NonExistingDnsServerAssigned

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [ ] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Simple test lab with duplicate IP addresses and incorrect DNS servers.
