### PR TITLE
Only the first 10 disks were initialized

### DIFF
--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1331,7 +1331,7 @@ function Initialize-LWAzureVM
 
             foreach ($line in $disks)
             {
-                if ($line -match 'Disk (?<DiskNumber>\d{1,3}) \s+(?<State>Online|Offline)\s+(?<Size>\d+) (KB|MB|GB|TB)\s+(?<Free>\d+) (B|KB|MB|GB)')
+                if ($line -match 'Disk (?<DiskNumber>\d{1,3}) \s+(?<State>Online|Offline)\s+(?<Size>\d+) (KB|MB|GB|TB)\s+(?<Free>\d+) (B|KB|MB|GB|TB)')
                 {
                     $nextDriveLetter = [char[]](67..90) |
                         Where-Object { (Get-WmiObject -Class Win32_LogicalDisk |

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1331,7 +1331,7 @@ function Initialize-LWAzureVM
 
             foreach ($line in $disks)
             {
-                if ($line -match 'Disk (?<DiskNumber>\d) \s+(Online|Offline)\s+(?<Size>\d+) GB\s+(?<Free>\d+) (B|GB)')
+                if ($line -match 'Disk (?<DiskNumber>\d{1,3}) \s+(?<State>Online|Offline)\s+(?<Size>\d+) (KB|MB|GB|TB)\s+(?<Free>\d+) (B|KB|MB|GB)')
                 {
                     $nextDriveLetter = [char[]](67..90) |
                         Where-Object { (Get-WmiObject -Class Win32_LogicalDisk |

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -602,7 +602,7 @@ Windows Registry Editor Version 5.00
 Start-Transcript -Path C:\DeployDebug\AdditionalDisksOnline.log
 $diskpartCmd = 'LIST DISK'
 $disks = $diskpartCmd | diskpart.exe
-$pattern = 'Disk (?<DiskNumber>\d{1,3}) \s+(?<State>Online|Offline)\s+(?<Size>\d+) (KB|MB|GB|TB)\s+(?<Free>\d+) (B|KB|MB|GB)'
+$pattern = 'Disk (?<DiskNumber>\d{1,3}) \s+(?<State>Online|Offline)\s+(?<Size>\d+) (KB|MB|GB|TB)\s+(?<Free>\d+) (B|KB|MB|GB|TB)'
 foreach ($line in $disks)
 {
     if ($line -match $pattern)

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -602,7 +602,7 @@ Windows Registry Editor Version 5.00
 Start-Transcript -Path C:\DeployDebug\AdditionalDisksOnline.log
 $diskpartCmd = 'LIST DISK'
 $disks = $diskpartCmd | diskpart.exe
-$pattern = 'Disk (?<DiskNumber>\d) \s+(?<State>Online|Offline)\s+(?<Size>\d+) (KB|MB|GB|TB)\s+(?<Free>\d+) (B|KB|MB|GB)'
+$pattern = 'Disk (?<DiskNumber>\d{1,3}) \s+(?<State>Online|Offline)\s+(?<Size>\d+) (KB|MB|GB|TB)\s+(?<Free>\d+) (B|KB|MB|GB)'
 foreach ($line in $disks)
 {
     if ($line -match $pattern)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 
 - Fix unnessary UEFI dependency of Update-LabIsoImage
+- Fixed that only the first additional 10 disks were initialized
 
 ## 5.30.0 (2020-12-15)
 


### PR DESCRIPTION
## Description

Fixed that only the first 10 disks were initialized.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
```powershell
New-LabDefinition -Name LabDev1 -DefaultVirtualizationEngine HyperV

Add-LabVirtualNetworkDefinition -Name Lab1

#defining default parameter values, as these ones are the same for all the machines
$PSDefaultParameterValues = @{
    'Add-LabMachineDefinition:Memory' = 1GB
    'Add-LabMachineDefinition:OperatingSystem' = 'Windows Server 2019 Datacenter (Desktop Experience)'
    'Add-LabMachineDefinition:Network' = 'Lab1'
}

$disks = @()
$letter = 68
1..15 | ForEach-Object {
    $disks += Add-LabDiskDefinition -Name "D$_" -DiskSizeInGb $_ -Label "D$_" -DriveLetter ([char]$letter) -PassThru
    $letter++
}

Add-LabMachineDefinition -Name T1 -DiskName $disks

Install-Lab

Show-LabDeploymentSummary -Detailed
```