### PR TITLE
Drives with underscores and hyphens have not been named correctly

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -626,7 +626,7 @@ foreach ($line in $disks)
 }
 foreach ($volume in (Get-WmiObject -Class Win32_Volume))
 {
-    if ($volume.Label -notmatch '(?<Label>[\w\d]+)_AL_(?<DriveLetter>[A-Z])')
+    if ($volume.Label -notmatch '(?<Label>[-_\w\d]+)_AL_(?<DriveLetter>[A-Z])')
     {
         continue
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fix unnessary UEFI dependency of Update-LabIsoImage
 - Fixed that only the first additional 10 disks were initialized
+- Fixed regex, considering drives with underscores and hyphens in the name now
 
 ## 5.30.0 (2020-12-15)
 


### PR DESCRIPTION
## Description

Fixed the regex. Now drives with underscores and hyphens in the name are renamed correctly

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
```powershell
New-LabDefinition -Name LabDev1 -DefaultVirtualizationEngine Azure

Add-LabVirtualNetworkDefinition -Name Lab1 -AddressSpace 192.168.10.0/24

#defining default parameter values, as these ones are the same for all the machines
$PSDefaultParameterValues = @{
    'Add-LabMachineDefinition:Memory' = 1GB
    'Add-LabMachineDefinition:OperatingSystem' = 'Windows Server 2019 Datacenter (Desktop Experience)'
    'Add-LabMachineDefinition:Network' = 'Lab1'
}

$disks = @()
$letter = 68
1..3 | ForEach-Object {
    $disks += Add-LabDiskDefinition -Name "D$_" -DiskSizeInGb $_ -Label "Disk-Name-for-D$_" -DriveLetter ([char]$letter) -PassThru
    $letter++
}

Add-LabMachineDefinition -Name T1 -DiskName $disks

Install-Lab

Show-LabDeploymentSummary -Detailed
```
