### PR TITLE
Network adapters are now named as defined on Hyper-V VMs

### DIFF
--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2635,7 +2635,7 @@ function Add-LabMachineDefinition
         foreach ($adapter in $NetworkAdapter)
         {
             $adapterVirtualNetwork = Get-LabVirtualNetworkDefinition -Name $adapter.VirtualSwitch
-            $adapter.InterfaceName = "Ethernet ($($adapterVirtualNetwork.Name))"
+
             #if there is no IPV4 address defined on the adapter
             if (-not $adapter.IpV4Address)
             {

--- a/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
@@ -263,7 +263,7 @@ function New-LabNetworkAdapterDefinition
         [Parameter(Mandatory)]
         [string]$VirtualSwitch,
 
-        [string]$InterfaceName = 'Ethernet',
+        [string]$InterfaceName,
 
         [Parameter(ParameterSetName = 'dhcp')]
         [switch]$UseDhcp,
@@ -342,8 +342,11 @@ function New-LabNetworkAdapterDefinition
             throw "VLAN tagging of interface '$InterfaceName' on non-external virtual switch '$VirtualSwitch' is not supported, either remove the AccessVlanID setting, or assign the interface to an external switch"
         }
     }
-
-    $adapter.InterfaceName = $InterfaceName
+    
+    if ($InterfaceName)
+    {
+        $adapter.InterfaceName = $InterfaceName
+    }
 
     foreach ($item in $Ipv4Address)
     {

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -1594,12 +1594,21 @@ function Repair-LWHypervNetworkConfig
         $newNames = @()
         foreach ($adapterInfo in $machine.NetworkAdapters)
         {
-            $newName = Add-StringIncrement -String $adapterInfo.VirtualSwitch.ResourceName
-            while ($newName -in $newNames)
+            $newName = if ($adapterInfo.InterfaceName)
             {
-                $newName = Add-StringIncrement -String $newName
+                $adapterInfo.InterfaceName
+            }
+            else
+            {
+                $tempName = Add-StringIncrement -String $adapterInfo.VirtualSwitch.ResourceName
+                while ($tempName -in $newNames)
+                {
+                    $tempName = Add-StringIncrement -String $tempName
+                }
+                $tempName
             }
             $newNames += $newName
+
             if (-not [string]::IsNullOrEmpty($adapterInfo.VirtualSwitch.FriendlyName))
             {
                 $adapterInfo.VirtualSwitch.FriendlyName = $newName

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed issue with CentOS8/RHEL8 kickstart files being undeployable (issue #1065)
 - Fixed issue with International module on PS Core not being imported (issue #1066)
+- The parameter 'New-LabNetworkAdapterDefinition\InterfaceName' does not have an effect on the network adapter names
 
 ## 5.32.0 (2020-12-31)
 


### PR DESCRIPTION
## Description

The interface name given was not considered yet. This is fixed now.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
```powershell
New-LabDefinition -Name NetTest1 -DefaultVirtualizationEngine HyperV

Add-LabVirtualNetworkDefinition -Name NetTest1 -AddressSpace 192.168.8.1/24
Add-LabVirtualNetworkDefinition -Name NetTest2 -AddressSpace 192.168.8.2/24

$netAdapter = @()
$netAdapter += New-LabNetworkAdapterDefinition -VirtualSwitch NetTest1 -Ipv4Address 192.168.8.10 -InterfaceName Internal
$netAdapter += New-LabNetworkAdapterDefinition -VirtualSwitch NetTest2 -Ipv4Address 192.168.8.20 -InterfaceName NLB
Add-LabMachineDefinition -Name NTM1 -NetworkAdapter $netAdapter -OperatingSystem 'Windows Server 2016 Datacenter (Desktop Experience)' -Memory 4GB

Install-Lab

Show-LabDeploymentSummary -Detailed
```