### PR TITLE
Checking the state of the 'smphost' service

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -30,9 +30,18 @@ function Enable-LabHostRemoting
     {
         Write-ScreenInfo 'Starting the WinRM service. This is required in order to read the WinRM configuration...' -NoNewLine
         Start-Service -Name WinRM
-        Start-Sleep -Seconds 5
+        Start-Sleep -Seconds 2
         Write-ScreenInfo done
     }
+
+    if ((Get-Service -Name smphost).StartType -eq 'Disabled')
+    {
+        Write-ScreenInfo "The StartupType of the service 'smphost' is set to disabled. Setting it to 'manual'. This is required in order to read use the cmdlets in the 'Storage' module..." -NoNewLine
+        Set-Service -Name smphost -StartupType Manual
+        Write-ScreenInfo done
+    }
+
+    #1067
 
     # force English language output for Get-WSManCredSSP call
     [Threading.Thread]::CurrentThread.CurrentUICulture = 'en-US'; $WSManCredSSP = Get-WSManCredSSP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed issue with CentOS8/RHEL8 kickstart files being undeployable (issue #1065)
 - Fixed issue with International module on PS Core not being imported (issue #1066)
+- Fixed issue when cmdlets of the 'Storage' module did not work if the 'smphost' is set to disabled (issue #1067)
 
 ## 5.32.0 (2020-12-31)
 


### PR DESCRIPTION
## Description

Fixes #1067

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Simple lab when service is set to disabled and then after calling 'Enable-LabHostRemoting'.