### PR TITLE
Fixing #1073

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed issue with International module on PS Core not being imported (issue #1066)
 - Fixed issue when cmdlets of the 'Storage' module did not work if the 'smphost' is set to disabled (issue #1067)
 - The parameter 'New-LabNetworkAdapterDefinition\InterfaceName' does not have an effect on the network adapter names
+- Fixed issue with Request-LabCertificate failing when multiple ComputerNames were specified (issue #1073)
 
 ## 5.32.0 (2020-12-31)
 


### PR DESCRIPTION


<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Request-LabCertificate now groups VMs by domain name and requests certs accordingly. Fixes #1073 

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

```powershell
New-LabDefinition -Name MultiPki -DefaultVirtualizationEngine HyperV
Add-LabMachineDefinition -Name DC1 -Domain contoso.com -Roles RootDc,CARoot -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'
Add-LabMachineDefinition -Name DC2 -Domain partsunlimited.com -Roles RootDc,CARoot -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'

Add-LabMachineDefinition -Name DH1 -Domain contoso.com -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'
Add-LabMachineDefinition -Name DH2 -Domain partsunlimited.com -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'

Add-LabMachineDefinition -Name DH3 -Domain contoso.com -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'
Add-LabMachineDefinition -Name DH4 -Domain partsunlimited.com -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'

Add-LabMachineDefinition -Name NH1 -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'
Add-LabMachineDefinition -Name NH2 -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'

Install-Lab

# Fails for non-domain-joined as it should, other VMs get their certs
Request-LabCertificate -ComputerName (Get-LabVm) -TemplateName WebServer -subject 'CN=LoadBalancer'
# Fails as expected
Request-LabCertificate -ComputerName NH1,NH2 -TemplateName WebServer -Subject 'CN=NonDomJoined'
# Fails as expected, CA not in lab
Request-LabCertificate -ComputerName NH1,NH2 -TemplateName WebServer -Subject 'CN=NonDomJoined' -OnlineCA CA1
# Works as expected
Request-LabCertificate -ComputerName NH1,NH2 -TemplateName WebServer -Subject 'CN=NonDomJoined' -OnlineCA DC1
```