### PR TITLE
Fixes #1081: Access is denied when creating AD Replication Sites 

### DIFF
--- a/AutomatedLab/AutomatedLabADDS.psm1
+++ b/AutomatedLab/AutomatedLabADDS.psm1
@@ -2096,8 +2096,7 @@ function New-LabADSite
         }
     }
 
-    $null = Invoke-LabCommand -ComputerName $rootDc -NoDisplay -PassThru -ScriptBlock `
-    {
+    $createSiteCmd = {
         param
         (
             $ComputerName, $SiteName, $SiteSubnet
@@ -2153,7 +2152,19 @@ function New-LabADSite
                 }
             }
         }
-    } -ArgumentList $ComputerName, $SiteName, $SiteSubnet
+    }
+
+    try
+    {
+        $null = Invoke-LabCommand -ComputerName $rootDc -NoDisplay -PassThru -ScriptBlock $createSiteCmd `
+        -ArgumentList $ComputerName, $SiteName, $SiteSubnet -ErrorAction Stop
+    }
+    catch {
+        Restart-LabVM -ComputerName $ComputerName -Wait
+        
+        Invoke-LabCommand -ComputerName $rootDc -NoDisplay -PassThru -ScriptBlock $createSiteCmd `
+        -ArgumentList $ComputerName, $SiteName, $SiteSubnet -ErrorAction Stop
+    }
 
     Write-LogFunctionExit
 }

--- a/AutomatedLab/AutomatedLabADDS.psm1
+++ b/AutomatedLab/AutomatedLabADDS.psm1
@@ -2161,6 +2161,7 @@ function New-LabADSite
     }
     catch {
         Restart-LabVM -ComputerName $ComputerName -Wait
+        Wait-LabADReady -ComputerName $ComputerName
         
         Invoke-LabCommand -ComputerName $rootDc -NoDisplay -PassThru -ScriptBlock $createSiteCmd `
         -ArgumentList $ComputerName, $SiteName, $SiteSubnet -ErrorAction Stop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - The parameter 'New-LabNetworkAdapterDefinition\InterfaceName' does not have an effect on the network adapter names
 - Fixed issue with Request-LabCertificate failing when multiple ComputerNames were specified (issue #1073)
 - Improved startup time for Linux VMs by setting boot order to boot from DVD instead of PXE
+- Fixed issue #1081, AD Replication Sites not beingt created
 
 ## 5.32.0 (2020-12-31)
 


### PR DESCRIPTION
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.  
- [x]  - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
```powershell
$labName = 'AdSiteTest'

New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV

Add-LabVirtualNetworkDefinition -Name $labName -AddressSpace 192.168.97.1/24

Add-LabDomainDefinition -Name contoso.com -AdminUser Install -AdminPassword Somepass1

$PSDefaultParameterValues = @{
    'Add-LabMachineDefinition:ToolsPath'= "$labSources\Tools"
    'Add-LabMachineDefinition:OperatingSystem'= 'Windows Server 2016 Datacenter (Desktop Experience)'
    'Add-LabMachineDefinition:Memory'= 1GB
}

#--------------------------------------------------------------------------------------------------------------------
Set-LabInstallationCredential -Username Install -Password Somepass1

$role = Get-LabMachineRoleDefinition -Role RootDC @{
    SiteName = 'Frankfurt'
    SiteSubnet = '192.168.97.0/24'
}
Add-LabMachineDefinition -Name adtDC1 -IpAddress 192.168.97.10 -DomainName contoso.com -Roles $role

Install-Lab -NoValidation

Show-LabDeploymentSummary -Detailed
```

