### PR TITLE
ISO Caching (#1068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 ### Enhancements
 - Add superseeded updates cleanup to Update-LabIsoImage (Issue #1061)
 - Add Cmdlet Enable-LabInternalRouting to configure routing between networks connected to routing VM
+- Caching of ISO files updated to be more user-friendly (issue #1068)
+  - Allows multiple ISO locations and adding individual files
+  - Cache eviction based on availability of ISO
+  - Cache rebuild based on new ISOs
+  - Cache will not entirely be rebuilt, additional OSs will be added
 
 ### Fixes
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

It is now possible to add individual ISO files to the cache. The cache eviction is now based on the existence of the ISOs. If the list of files is different to the cache content, the cache is rebuilt. During rebuilding, only new OS are added. Existing ones are not analyzed again.

Fixes #1068

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

```powershell
Remove-ItemProperty HKCU:\software\AutomatedLab\Cache -name LocalOperatingSystems
Get-LabAvailableOperatingSystem -UseOnlyCache # Fails as expected

New-SmbShare -Path D:\tmp -Name ISOs -FullAccess janhe
Copy-Item D:\LabSources\ISOs\Windows_InsiderPreview_Server_vNext_en-us_20292.iso -Destination D:\tmp

# Adds ISO to Cache
Get-LabAvailableOperatingSystem -Path \\NYANHP-ALPHA\ISOs\Windows_InsiderPreview_Server_vNext_en-us_20292.iso
Get-LabAvailableOperatingSystem -UseOnlyCache

# Still works "normally" on $labsources\ISOs
Get-LabAvailableOperatingSystem

# Cache was extended by the contents of my labsources folder
Get-LabAvailableOperatingSystem -UseOnlyCache

# Removing the file evicts it from the cache, returning only the existing ISOs
Remove-Item -Path \\NYANHP-ALPHA\ISOs\Windows_InsiderPreview_Server_vNext_en-us_20292.iso
Get-LabAvailableOperatingSystem -UseOnlyCache
```