### PR TITLE
Faster Sync-LabAzureLabSources

### DIFF
--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1571,10 +1571,10 @@ function Add-LabIsoImageDefinition
                 if (-not $isoFiles -and $Name)
                 {
                     $filterPath = Split-Path -Path $Path -Leaf
-                    Write-PSFMessage -Message "Syncing $filterPath with Azure lab sources storage in case it does not already exist"
-                    Sync-LabAzureLabSources -Filter $filterPath
+                    Write-ScreenInfo -Message "Syncing $filterPath with Azure lab sources storage as it did not exist"
+                    Sync-LabAzureLabSources -Filter $filterPath -NoDisplay
 
-                    $isoFiles = Get-LabAzureLabSourcesContent -RegexFilter '\.iso' -File -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq (Split-Path -Path $Path -Leaf)}
+                    $isoFiles = Get-LabAzureLabSourcesContent -Path $isoRoot -RegexFilter '\.iso' -File -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq (Split-Path -Path $Path -Leaf)}
                 }
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     - Updated Technical Preview baseline to 2010
   - Using `CM-2002.ps1` with the CM-2002 custom role, you can now specify which roles you want to install, e.g. using `-CMRoles` parameter choose from None, MP, DP, SUP, RSP and EP to install. The default is to install all roles.
 - New SCOM role (thank you @mlinowski !)
+- Add-LabIsoImageDefinition and Sync-LabAzureLabSources is now faster on Azure
 
 ### Fixes
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Using a recursive function, die entire parent hierarchy for a file is created if it does not exist. This has significantly improved the speed of e.g. Add-LabIsoImageDefinition, as we only test the already filtered paths. I have not compared a full sync to be honest. I expect it to be on-par as well, since the New-AzStorageDirectory calls were essentially replaced with Get-AzStorageFile, which is slightly quicker.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Add-LabIsoImageDefinition after deleting one 1GB ISO from the share. Previously took 18 minutes, now only 5, including the upload.

Tested recursive creation by creating a new folder hierarchy inside LabSources and using a single file in that hierarchy for the Filter parameter.