### PR TITLE
Fixes #1087

### DIFF
--- a/AutomatedLab/AutomatedLabDiskImageWindows.psm1
+++ b/AutomatedLab/AutomatedLabDiskImageWindows.psm1
@@ -12,7 +12,7 @@
     )
 
     $dismPattern = 'Index : (?<Index>\d{1,2})(\r)?\nName : (?<Name>.+)'
-    $standardImagePath = Get-Item -Path "$DriveLetter`:\Sources\Install.*" | Where-Object Name -Match '.*\.(esd|wim)'
+    $standardImagePath = Get-Item -Path "$DriveLetter`:\Sources\install.*" | Where-Object Name -Match '.*\.(esd|wim)'
     $doNotSkipNonNonEnglishIso = Get-LabConfigurationItem -Name DoNotSkipNonNonEnglishIso
     
     if (Test-Path -Path $standardImagePath)

--- a/AutomatedLab/AutomatedLabDiskImageWindows.psm1
+++ b/AutomatedLab/AutomatedLabDiskImageWindows.psm1
@@ -12,7 +12,7 @@
     )
 
     $dismPattern = 'Index : (?<Index>\d{1,2})(\r)?\nName : (?<Name>.+)'
-    $standardImagePath = "$DriveLetter`:\Sources\Install.wim"
+    $standardImagePath = Get-Item -Path "$DriveLetter`:\Sources\Install.*" | Where-Object Name -Match '.*\.(esd|wim)'
     $doNotSkipNonNonEnglishIso = Get-LabConfigurationItem -Name DoNotSkipNonNonEnglishIso
     
     if (Test-Path -Path $standardImagePath)

--- a/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
@@ -127,9 +127,10 @@ exit
 
         Write-PSFMessage 'Applying image to the volume...'
 
-        $wimPath = "$isoDrive\Sources\install.wim"
+        $installFilePath = Get-Item -Path "$isoDrive\Sources\install.*" | Where-Object Name -Match '.*\.(esd|wim)'
+
         $job = Start-Job -ScriptBlock {
-            $output = Dism.exe /English /apply-Image /ImageFile:$using:wimPath /index:$using:imageIndex /ApplyDir:$using:vhdWindowsVolume\
+            $output = Dism.exe /English /apply-Image /ImageFile:$using:installFilePath /index:$using:imageIndex /ApplyDir:$using:vhdWindowsVolume\
             New-Object PSObject -Property @{
                 Outout = $output
                 LastExitCode = $LASTEXITCODE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 ### Fixes
+- Fixed #1087. AL now supports WIM and ESD files in Windows ISOs.
 
 ## 5.33.0 (2021-03-03)
 


### PR DESCRIPTION
## Description

This PR fixes #1087. AL now also supports ESD files. Luckily the way to deal with ESD files is the same like dealing with WIM files.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Used '01 Single Win10 Client.ps1' script.