### PR TITLE
Use public Exchange 2019 download

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -297,6 +297,11 @@ Set-PSFConfig -Module AutomatedLab -Name SqlSmo2016 -Value "https://download.mic
 Set-PSFConfig -Module AutomatedLab -Name Dynamics365Uri -Value 'https://download.microsoft.com/download/B/D/0/BD0FA814-9885-422A-BA0E-54CBB98C8A33/CRM9.0-Server-ENU-amd64.exe' -Initialize -Validation String
 #Set-PSFConfig -Module AutomatedLab -Name -Uri 'https://download.microsoft.com/download/6/4/5/645B2661-ABE3-41A4-BC2D-34D9A10DD303/ENU/x64/msodbcsql.msi'
 
+# Exchange Server
+Set-PSFConfig -Module AutomatedLab -Name Exchange2013DownloadUrl -Value 'https://download.microsoft.com/download/7/F/D/7FDCC96C-26C0-4D49-B5DB-5A8B36935903/Exchange2013-x64-cu23.exe'
+Set-PSFConfig -Module AutomatedLab -Name Exchange2016DownloadUrl -Value 'https://download.microsoft.com/download/0/b/7/0b702b8b-03ab-4553-9e2c-c73bb0c8535f/ExchangeServer2016-x64-CU20.ISO'
+Set-PSFConfig -Module AutomatedLab -Name Exchange2019DownloadUrl -Value 'https://download.microsoft.com/download/d/7/b/d7bcf78a-00d2-4a46-a3d2-7d506116bcd2/ExchangeServer2019-x64-CU9.ISO'
+
 # Validation
 Set-PSFConfig -Module AutomatedLab -Name ValidationSettings -Value @{
     ValidRoleProperties     = @{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Update Exchange2019 custom role to use public download.
 
 ### Enhancements
 - New roles to deploy Remote Desktop Services

--- a/LabSources/CustomRoles/Exchange2013/HostStart.ps1
+++ b/LabSources/CustomRoles/Exchange2013/HostStart.ps1
@@ -425,7 +425,7 @@ Function Test-MailboxPath {
 }
 
 $ucmaDownloadLink = 'http://download.microsoft.com/download/2/C/4/2C47A5C1-A1F3-4843-B9FE-84C0032C61EC/UcmaRuntimeSetup.exe'
-$exchangeDownloadLink = 'https://download.microsoft.com/download/7/F/D/7FDCC96C-26C0-4D49-B5DB-5A8B36935903/Exchange2013-x64-cu23.exe'
+$exchangeDownloadLink = Get-LabConfigurationItem -Name Exchange2013DownloadUrl
 $vcRedistDownloadLink = 'http://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe'
 $dotnetDownloadLink = Get-LabConfigurationItem -Name dotnet48DownloadLink
 

--- a/LabSources/CustomRoles/Exchange2016/HostStart.ps1
+++ b/LabSources/CustomRoles/Exchange2016/HostStart.ps1
@@ -285,7 +285,7 @@ function Start-ExchangeInstallation
 }
 
 $ucmaDownloadLink = 'http://download.microsoft.com/download/2/C/4/2C47A5C1-A1F3-4843-B9FE-84C0032C61EC/UcmaRuntimeSetup.exe'
-$exchangeDownloadLink = 'https://download.microsoft.com/download/0/b/7/0b702b8b-03ab-4553-9e2c-c73bb0c8535f/ExchangeServer2016-x64-CU20.ISO'
+$exchangeDownloadLink = Get-LabConfigurationItem -Name Exchange2016DownloadUrl
 $dotnetDownloadLink = Get-LabConfigurationItem -Name dotnet48DownloadLink
 $cppredist642013DownloadLink = Get-LabConfigurationItem -Name cppredist64_2013
 $cppredist322013DownloadLink = Get-LabConfigurationItem -Name cppredist32_2013

--- a/LabSources/CustomRoles/Exchange2019/HostStart.ps1
+++ b/LabSources/CustomRoles/Exchange2019/HostStart.ps1
@@ -2,10 +2,7 @@
     [Parameter(Mandatory)]
     [string]$ComputerName,
 
-    [string]$OrganizationName,
-
-    [Parameter(Mandatory)]
-    [string]$IsoPath
+    [string]$OrganizationName
 )
 
 function Download-ExchangeSources
@@ -13,10 +10,9 @@ function Download-ExchangeSources
 
     Write-ScreenInfo -Message 'Download Exchange 2019 requirements' -TaskStart
 
-    #The image is no longer available publicly
-    #$downloadTargetFolder = "$labSources\ISOs"
-    #Write-ScreenInfo -Message "Adding Exchange 2019 iso from '$exchangeDownloadLink'"
-    #$script:exchangeInstallFile = Get-LabInternetFile -Uri $exchangeDownloadLink -Path $downloadTargetFolder -PassThru -ErrorAction Stop -FileName 'mu_exchange_server_2019-x64-cu2.iso'
+    $downloadTargetFolder = "$labSources\ISOs"
+    Write-ScreenInfo -Message "Downloading Exchange 2019 from '$exchangeDownloadLink'"
+    $script:exchangeInstallFile = Get-LabInternetFile -Uri $exchangeDownloadLink -Path $downloadTargetFolder -PassThru -ErrorAction Stop
 
     $downloadTargetFolder = "$labSources\SoftwarePackages"
     Write-ScreenInfo -Message "Downloading .net Framework 4.8 from '$dotnet48DownloadLink'"
@@ -304,6 +300,7 @@ function Start-ExchangeInstallation
     }
 }
 
+$exchangeDownloadLink = 'https://download.microsoft.com/download/d/7/b/d7bcf78a-00d2-4a46-a3d2-7d506116bcd2/ExchangeServer2019-x64-CU9.ISO'
 $dotnet48DownloadLink = Get-LabConfigurationItem -Name dotnet48DownloadLink
 $VC2013RedristroDownloadLink = Get-LabConfigurationItem -Name cppredist64_2013
 $VC2012RedristroDownloadLink = Get-LabConfigurationItem -Name cppredist64_2012
@@ -317,13 +314,6 @@ if (-not $OrganizationName)
 {
     $OrganizationName = $lab.Name + 'ExOrg'
 }
-
-if (-not (Test-Path -Path $IsoPath))
-{
-    Write-Error "The ISO file '$IsoPath' could not be found."
-    return
-}
-$exchangeInstallFile = Get-Item -Path $IsoPath
 
 Write-ScreenInfo "Intalling Exchange 2019 '$ComputerName'..." -TaskStart
 

--- a/LabSources/CustomRoles/Exchange2019/HostStart.ps1
+++ b/LabSources/CustomRoles/Exchange2019/HostStart.ps1
@@ -300,7 +300,7 @@ function Start-ExchangeInstallation
     }
 }
 
-$exchangeDownloadLink = 'https://download.microsoft.com/download/d/7/b/d7bcf78a-00d2-4a46-a3d2-7d506116bcd2/ExchangeServer2019-x64-CU9.ISO'
+$exchangeDownloadLink = Get-LabConfigurationItem -Name Exchange2019DownloadUrl
 $dotnet48DownloadLink = Get-LabConfigurationItem -Name dotnet48DownloadLink
 $VC2013RedristroDownloadLink = Get-LabConfigurationItem -Name cppredist64_2013
 $VC2012RedristroDownloadLink = Get-LabConfigurationItem -Name cppredist64_2012


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Now that Exchange 2019 has a public download again, the custom role should use it, rather than requiring manual download.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

Built a lab using the updated custom role and confirmed Exchange 2019 CU9 was automatically downloaded and produced a working install.