### PR TITLE
Issue3

### DIFF
--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1072,7 +1072,13 @@ function Export-LabDefinition
                         $roleParentDomain = $firstChildDcRole.Properties.ParentDomain
                         $rootDc = Get-LabMachineDefinition -Role RootDC | Where-Object DomainName -eq $roleParentDomain
 
-                        $networkAdapter.IPv4DnsServers = $rootDc.NetworkAdapters[0].Ipv4Address[0].IpAddress
+                        $networkAdapter.IPv4DnsServers = $machine.NetworkAdapters[0].Ipv4Address[0].IpAddress, $rootDc.NetworkAdapters[0].Ipv4Address[0].IpAddress
+                    }
+                    elseif ($machine.Roles.Name -contains 'DC')
+                    {
+                        $parentDc = Get-LabMachineDefinition -Role RootDC,FirstChildDc | Where-Object DomainName -eq $machine.DomainName | Select-Object -First 1
+
+                        $networkAdapter.IPv4DnsServers = $machine.NetworkAdapters[0].Ipv4Address[0].IpAddress, $parentDc.NetworkAdapters[0].Ipv4Address[0].IpAddress
                     }
                     else #machine is domain joined and not a RootDC or FirstChildDC
                     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Using the 20h2 Windows 10 images in Azure now.
 - Fixing upstream issue with duplicate files in SysInternals archive
 - Removing defunct parameter AzureSubscriptionName from New-LabDefinition (#1079)
+- Adding validator for DNS settings on domain members and domain controllers (#3)
 
 ## 5.33.0 (2021-03-03)
 

--- a/LabXml/Machines/OperatingSystem.cs
+++ b/LabXml/Machines/OperatingSystem.cs
@@ -66,6 +66,8 @@ namespace AutomatedLab
                             return "10.0";
                         case "2019":
                             return "10.0";
+                        case "2022":
+                            return "10.0";
                         case "7":
                             return "6.1";
                         case "8":

--- a/LabXml/Validator/Network/DomainMemberDns.cs
+++ b/LabXml/Validator/Network/DomainMemberDns.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace AutomatedLab
+{
+    /// <summary>
+    /// Validator checks if domain members point to a domain DNS inside the lab
+    /// Domain Controllers point to themselves and to a second Domain Controller
+    /// </summary>
+    public class DomainMemberDns : LabValidator, IValidate
+    {
+        public DomainMemberDns()
+        {
+            messageContainer = RunValidation();
+        }
+
+        public override IEnumerable<ValidationMessage> Validate()
+        {
+            var domainControllers = lab.Machines
+                .Where(m => m.Roles.Select(r => r.Name).Where(r => (AutomatedLab.Roles.ADDS & r) == r).Count() > 0);
+
+            foreach (var domainController in domainControllers)
+            {
+                var dcDns = domainController.NetworkAdapters
+                .SelectMany(n => n.Ipv4DnsServers);
+
+                if (!dcDns.First().AddressAsString.Equals(domainController.IpV4Address))
+                {
+                    yield return new ValidationMessage
+                    {
+                        Message = string.Format("First DNS server {0} of domain controller {1} points to a different IP {2}", domainController.IpV4Address, domainController.Name, dcDns.First().AddressAsString),
+                        TargetObject = domainController.IpV4Address,
+                        Type = MessageType.Error
+                    };
+                }
+            }
+
+            foreach (var machine in lab.Machines.Where(m => m.Roles.Select(r => r.Name).Where(r => (AutomatedLab.Roles.ADDS & r) == r).Count() == 0))
+            {
+                var domainDns = domainControllers.Where(dc => dc.DomainName.Equals(machine.DomainName)).Select(dc => dc.IpV4Address);
+                var machineDns = machine.NetworkAdapters.SelectMany(n => n.Ipv4DnsServers).Where(dns => domainDns.Contains(dns.AddressAsString));
+
+                if (machineDns.Count() != 0)
+                {
+                    yield return new ValidationMessage
+                    {
+                        Message = string.Format("DNS servers of {0} do not point to any of the domain controllers in it's domain", machine.Name),
+                        TargetObject = machine.Name,
+                        Type = MessageType.Error
+                    };
+                }
+            }
+        }
+    }
+}

--- a/LabXml/Validator/Network/DomainMemberDns.cs
+++ b/LabXml/Validator/Network/DomainMemberDns.cs
@@ -35,7 +35,7 @@ namespace AutomatedLab
                 }
             }
 
-            foreach (var machine in lab.Machines.Where(m => m.Roles.Select(r => r.Name).Where(r => (AutomatedLab.Roles.ADDS & r) == r).Count() == 0))
+            foreach (var machine in lab.Machines.Where(m => !string.IsNullOrWhiteSpace(m.DomainName) && m.Roles.Select(r => r.Name).Where(r => (AutomatedLab.Roles.ADDS & r) == r).Count() == 0))
             {
                 var domainDns = domainControllers.Where(dc => dc.DomainName.Equals(machine.DomainName)).Select(dc => dc.IpV4Address);
                 var machineDns = machine.NetworkAdapters.SelectMany(n => n.Ipv4DnsServers).Where(dns => domainDns.Contains(dns.AddressAsString));

--- a/LabXml/Validator/Network/DomainMemberDns.cs
+++ b/LabXml/Validator/Network/DomainMemberDns.cs
@@ -40,7 +40,7 @@ namespace AutomatedLab
                 var domainDns = domainControllers.Where(dc => dc.DomainName.Equals(machine.DomainName)).Select(dc => dc.IpV4Address);
                 var machineDns = machine.NetworkAdapters.SelectMany(n => n.Ipv4DnsServers).Where(dns => domainDns.Contains(dns.AddressAsString));
 
-                if (machineDns.Count() != 0)
+                if (machineDns.Count() == 0)
                 {
                     yield return new ValidationMessage
                     {


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #3, one of our oldest issues. @raandree did I miss something in my tests? It felt too simple

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
```powershell
# Default case: Should not fail
New-LabDefinition -Name DomainValidators -DefaultVirtualizationEngine HyperV

Add-LabDomainDefinition -Name contoso.com -AdminUser Install -AdminPassword Somepass1
Add-LabDomainDefinition -Name a.contoso.com -AdminUser Install -AdminPassword Somepass1

Set-LabInstallationCredential -Username Install -Password Somepass1

Add-LabMachineDefinition -Name DC1 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName contoso.com -Role RootDC
Add-LabMachineDefinition -Name MS1 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName contoso.com
Add-LabMachineDefinition -Name WG1 -OperatingSystem 'Windows Server 2019 Datacenter'
Add-LabMachineDefinition -Name DC2 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName contoso.com -Role DC
Add-LabMachineDefinition -Name DC3 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName a.contoso.com -Role FirstChildDC
Add-LabMachineDefinition -Name DC4 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName a.contoso.com -Role DC

Export-LabDefinition -Force
Test-LabDefinition -Path (Get-LabDefinition).LabFilePath

# Proper direct IP assignment, should not fail
New-LabDefinition -Name DomainValidators -DefaultVirtualizationEngine HyperV

Add-LabDomainDefinition -Name contoso.com -AdminUser Install -AdminPassword Somepass1
Add-LabDomainDefinition -Name a.contoso.com -AdminUser Install -AdminPassword Somepass1

Set-LabInstallationCredential -Username Install -Password Somepass1
Add-LabVirtualNetworkDefinition -Name DomainValidators -AddressSpace 10.0.1.0/24

Add-LabMachineDefinition -Name DC1 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName contoso.com -Role RootDC -IpAddress 10.0.1.10 -DnsServer1 10.0.1.10 -DnsServer2 10.0.1.11
Add-LabMachineDefinition -Name MS1 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName contoso.com -DnsServer1 10.0.1.10
Add-LabMachineDefinition -Name WG1 -OperatingSystem 'Windows Server 2019 Datacenter'
Add-LabMachineDefinition -Name DC2 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName contoso.com -Role DC -IpAddress 10.0.1.11 -DnsServer1 10.0.1.11 -DnsServer2 10.0.1.10
Add-LabMachineDefinition -Name DC3 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName a.contoso.com -Role FirstChildDC -IpAddress 10.0.1.12 -DnsServer1 10.0.1.12 -DnsServer2 10.0.1.13
Add-LabMachineDefinition -Name DC4 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName a.contoso.com -Role DC -IpAddress 10.0.1.13 -DnsServer1 10.0.1.13 -DnsServer2 10.0.1.12

Export-LabDefinition -Force
Test-LabDefinition -Path (Get-LabDefinition).LabFilePath

# Improper direct IP assignment, should fail
New-LabDefinition -Name DomainValidators -DefaultVirtualizationEngine HyperV

Add-LabDomainDefinition -Name contoso.com -AdminUser Install -AdminPassword Somepass1
Add-LabDomainDefinition -Name a.contoso.com -AdminUser Install -AdminPassword Somepass1

Set-LabInstallationCredential -Username Install -Password Somepass1
Add-LabVirtualNetworkDefinition -Name DomainValidators -AddressSpace 10.0.1.0/24

Add-LabMachineDefinition -Name DC1 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName contoso.com -Role RootDC -IpAddress 10.0.1.10 -DnsServer1 10.0.1.10 -DnsServer2 10.0.1.11
Add-LabMachineDefinition -Name MS1 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName contoso.com -DnsServer1 10.0.1.13
Add-LabMachineDefinition -Name WG1 -OperatingSystem 'Windows Server 2019 Datacenter'
Add-LabMachineDefinition -Name DC2 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName contoso.com -Role DC -IpAddress 10.0.1.11 -DnsServer1 10.0.1.10 -DnsServer2 10.0.1.11
Add-LabMachineDefinition -Name DC3 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName a.contoso.com -Role FirstChildDC -IpAddress 10.0.1.12 -DnsServer1 10.0.1.10 -DnsServer2 10.0.1.11
Add-LabMachineDefinition -Name DC4 -OperatingSystem 'Windows Server 2019 Datacenter' -DomainName a.contoso.com -Role DC -IpAddress 10.0.1.13 -DnsServer1 10.0.1.12 -DnsServer2 10.0.1.13

Export-LabDefinition -Force
Test-LabDefinition -Path (Get-LabDefinition).LabFilePath
```