### PR TITLE
PreInstallActivity added

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -878,6 +878,9 @@ function Install-Lab
     {
         Write-ScreenInfo -Message 'Installing Root Domain Controllers' -TaskStart
 
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role RootDC | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
+
         Write-ScreenInfo -Message "Machines with RootDC role to be installed: '$((Get-LabVM -Role RootDC).Name -join ', ')'"
         Install-LabRootDcs -CreateCheckPoints:$CreateCheckPoints
 
@@ -888,6 +891,8 @@ function Install-Lab
     {
         Write-ScreenInfo -Message 'Configuring routing' -TaskStart
 
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role Routing | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Install-LabRouting
 
         Write-ScreenInfo -Message 'Done' -TaskEnd
@@ -907,6 +912,8 @@ function Install-Lab
     {
         Write-ScreenInfo -Message 'Installing Child Domain Controllers' -TaskStart
 
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role FirstChildDC | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Write-ScreenInfo -Message "Machines with FirstChildDC role to be installed: '$((Get-LabVM -Role FirstChildDC).Name -join ', ')'"
         Install-LabFirstChildDcs -CreateCheckPoints:$CreateCheckPoints
 
@@ -929,6 +936,8 @@ function Install-Lab
     {
         Write-ScreenInfo -Message 'Installing Additional Domain Controllers' -TaskStart
 
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role DC | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Write-ScreenInfo -Message "Machines with DC role to be installed: '$((Get-LabVM -Role DC).Name -join ', ')'"
         Install-LabDcs -CreateCheckPoints:$CreateCheckPoints
 
@@ -957,6 +966,8 @@ function Install-Lab
     if (($FileServer -or $performAll) -and (Get-LabVM -Role FileServer))
     {
         Write-ScreenInfo -Message 'Installing File Servers' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role FileServer | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Install-LabFileServers -CreateCheckPoints:$CreateCheckPoints
 
         Write-ScreenInfo -Message 'Done' -TaskEnd
@@ -965,6 +976,8 @@ function Install-Lab
     if (($CA -or $performAll) -and (Get-LabVM -Role CaRoot, CaSubordinate))
     {
         Write-ScreenInfo -Message 'Installing Certificate Servers' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role CaRoot,CaSubordinate | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Install-LabCA -CreateCheckPoints:$CreateCheckPoints
 
         Write-ScreenInfo -Message 'Done' -TaskEnd
@@ -973,6 +986,8 @@ function Install-Lab
     if(($HyperV -or $performAll) -and (Get-LabVm -Role HyperV | Where-Object {-not $_.SkipDeployment}))
     {
         Write-ScreenInfo -Message 'Installing HyperV servers' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role HyperV | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         Install-LabHyperV
 
@@ -983,6 +998,8 @@ function Install-Lab
     {
         Write-ScreenInfo -Message 'Installing Failover Storage' -TaskStart
 
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role FailoverStorage | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Start-LabVM -RoleName FailoverStorage -ProgressIndicator 15 -PostDelaySeconds 5 -Wait
         Install-LabFailoverStorage
 
@@ -992,6 +1009,8 @@ function Install-Lab
     if (($FailoverCluster -or $performAll) -and (Get-LabVM -Role FailoverNode, FailoverStorage | Where-Object { -not $_.SkipDeployment }))
     {
         Write-ScreenInfo -Message 'Installing Failover Cluster' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role FailoverNode, FailoverStorage | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         Start-LabVM -RoleName FailoverNode,FailoverStorage -ProgressIndicator 15 -PostDelaySeconds 5 -Wait
         Install-LabFailoverCluster
@@ -1002,6 +1021,8 @@ function Install-Lab
     if (($SQLServers -or $performAll) -and (Get-LabVM -Role SQLServer2008, SQLServer2008R2, SQLServer2012, SQLServer2014, SQLServer2016, SQLServer2017, SQLServer2019 | Where-Object { -not $_.SkipDeployment }))
     {
         Write-ScreenInfo -Message 'Installing SQL Servers' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role SQLServer | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         if (Get-LabVM -Role SQLServer2008)   { Write-ScreenInfo -Message "Machines to have SQL Server 2008 installed: '$((Get-LabVM -Role SQLServer2008).Name -join ', ')'" }
         if (Get-LabVM -Role SQLServer2008R2) { Write-ScreenInfo -Message "Machines to have SQL Server 2008 R2 installed: '$((Get-LabVM -Role SQLServer2008R2).Name -join ', ')'" }
         if (Get-LabVM -Role SQLServer2012)   { Write-ScreenInfo -Message "Machines to have SQL Server 2012 installed: '$((Get-LabVM -Role SQLServer2012).Name -join ', ')'" }
@@ -1014,9 +1035,11 @@ function Install-Lab
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }
 
-    if (($RemoteDesktop -or $performAll) -and (Get-LabVm -Role RemoteDesktopConnectionBroker,RemoteDesktopGateway,RemoteDesktopLicensing,RemoteDesktopSessionHost,RemoteDesktopVirtualizationHost,RemoteDesktopWebAccess -Filter {-not $_.SkipDeployment}))
+    if (($RemoteDesktop -or $performAll) -and (Get-LabVm -Role RDS -Filter {-not $_.SkipDeployment}))
     {
         Write-ScreenInfo -Message 'Deploying Remote Desktop Services' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role RDS | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Install-LabRemoteDesktopServices
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }
@@ -1024,6 +1047,8 @@ function Install-Lab
     if (($Dynamics -or $performAll) -and (Get-LabVm -Role Dynamics | Where-Object { -not $_.SkipDeployment }))
     {
         Write-ScreenInfo -Message 'Installing Dynamics' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role Dynamics | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Install-LabDynamics -CreateCheckPoints:$CreateCheckPoints
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }
@@ -1031,6 +1056,8 @@ function Install-Lab
     if (($DSCPullServer -or $performAll) -and (Get-LabVM -Role DSCPullServer | Where-Object { -not $_.SkipDeployment }))
     {
         Start-LabVM -RoleName DSCPullServer -ProgressIndicator 15 -PostDelaySeconds 5 -Wait
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role DSCPullServer | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         Write-ScreenInfo -Message 'Installing DSC Pull Servers' -TaskStart
         Install-LabDscPullServer
@@ -1041,6 +1068,8 @@ function Install-Lab
     if (($ADFS -or $performAll) -and (Get-LabVM -Role ADFS))
     {
         Write-ScreenInfo -Message 'Configuring ADFS' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role ADFS | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         Install-LabAdfs
 
@@ -1056,6 +1085,8 @@ function Install-Lab
     if (($WebServers -or $performAll) -and (Get-LabVM -Role WebServer | Where-Object { -not $_.SkipDeployment }))
     {
         Write-ScreenInfo -Message 'Installing Web Servers' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role WebServer | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Write-ScreenInfo -Message "Machines to have Web Server role installed: '$((Get-LabVM -Role WebServer | Where-Object { -not $_.SkipDeployment }).Name -join ', ')'"
         Install-LabWebServers -CreateCheckPoints:$CreateCheckPoints
 
@@ -1065,6 +1096,8 @@ function Install-Lab
     if (($WindowsAdminCenter -or $performAll) -and (Get-LabVm -Role WindowsAdminCenter))
     {
         Write-ScreenInfo -Message 'Installing Windows Admin Center Servers' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role WindowsAdminCenter | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Write-ScreenInfo -Message "Machines to have Windows Admin Center installed: '$((Get-LabVM -Role WindowsAdminCenter | Where-Object { -not $_.SkipDeployment }).Name -join ', ')'"
         Install-LabWindowsAdminCenter
 
@@ -1074,6 +1107,8 @@ function Install-Lab
     if (($Orchestrator2012 -or $performAll) -and (Get-LabVM -Role Orchestrator2012))
     {
         Write-ScreenInfo -Message 'Installing Orchestrator Servers' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role Orchestrator2012 | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Install-LabOrchestrator2012
 
         Write-ScreenInfo -Message 'Done' -TaskEnd
@@ -1083,6 +1118,8 @@ function Install-Lab
     {
         Write-ScreenInfo -Message 'Installing SharePoint Servers' -TaskStart
 
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role SharePoint | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Install-LabSharePoint
 
         Write-ScreenInfo -Message 'Done' -TaskEnd
@@ -1091,6 +1128,8 @@ function Install-Lab
     if (($VisualStudio -or $performAll) -and (Get-LabVM -Role VisualStudio2013))
     {
         Write-ScreenInfo -Message 'Installing Visual Studio 2013' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role VisualStudio2013 | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         Write-ScreenInfo -Message "Machines to have Visual Studio 2013 installed: '$((Get-LabVM -Role VisualStudio2013).Name -join ', ')'"
         Install-VisualStudio2013
@@ -1101,6 +1140,8 @@ function Install-Lab
     if (($VisualStudio -or $performAll) -and (Get-LabVM -Role VisualStudio2015))
     {
         Write-ScreenInfo -Message 'Installing Visual Studio 2015' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role VisualStudio2015 | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         Write-ScreenInfo -Message "Machines to have Visual Studio 2015 installed: '$((Get-LabVM -Role VisualStudio2015).Name -join ', ')'"
         Install-VisualStudio2015
@@ -1111,6 +1152,8 @@ function Install-Lab
     if (($Office2013 -or $performAll) -and (Get-LabVM -Role Office2013))
     {
         Write-ScreenInfo -Message 'Installing Office 2013' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role Office2013 | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         Write-ScreenInfo -Message "Machines to have Office 2013 installed: '$((Get-LabVM -Role Office2013).Name -join ', ')'"
         Install-LabOffice2013
@@ -1121,6 +1164,8 @@ function Install-Lab
     if (($Office2016 -or $performAll) -and (Get-LabVM -Role Office2016))
     {
         Write-ScreenInfo -Message 'Installing Office 2016' -TaskStart
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role Office2016 | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         Write-ScreenInfo -Message "Machines to have Office 2016 installed: '$((Get-LabVM -Role Office2016).Name -join ', ')'"
         Install-LabOffice2016
@@ -1131,6 +1176,8 @@ function Install-Lab
     if (($TeamFoundation -or $performAll) -and (Get-LabVM -Role Tfs2015,Tfs2017,Tfs2018,TfsBuildWorker,AzDevOps))
     {
         Write-ScreenInfo -Message 'Installing Team Foundation Server environment'
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role Tfs2015,Tfs2017,Tfs2018,TfsBuildWorker,AzDevOps | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
         Write-ScreenInfo -Message "Machines to have TFS or the build agent installed: '$((Get-LabVM -Role Tfs2015,Tfs2017,Tfs2018,TfsBuildWorker,AzDevOps).Name -join ', ')'"
 
         $machinesToStart = Get-LabVM -Role Tfs2015,Tfs2017,Tfs2018,TfsBuildWorker,AzDevOps | Where-Object -Property SkipDeployment -eq $false
@@ -1147,6 +1194,8 @@ function Install-Lab
     {
         Write-ScreenInfo -Message 'Installing SCVMM'
         Write-ScreenInfo -Message "Machines to have SCVMM Management or Console installed: '$((Get-LabVM -Role SCVMM).Name -join ', ')'"
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role SCVMM | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         $machinesToStart = Get-LabVM -Role SCVMM | Where-Object -Property SkipDeployment -eq $false
         if ($machinesToStart)
@@ -1162,6 +1211,8 @@ function Install-Lab
     {
         Write-ScreenInfo -Message 'Installing SCOM'
         Write-ScreenInfo -Message "Machines to have SCOM components installed: '$((Get-LabVM -Role SCOM).Name -join ', ')'"
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName $(Get-LabVM -Role SCOM | Where-Object { -not $_.SkipDeployment }) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
 
         $machinesToStart = Get-LabVM -Role SCOM | Where-Object -Property SkipDeployment -eq $false
         if ($machinesToStart)

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -962,6 +962,12 @@ function Install-Lab
         Install-LabADDSTrust
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }
+
+    if ((Get-LabVm -Filter {-not $_.SkipDeployment -and $_.Roles.Count -eq 0}))
+    {
+        $jobs = Invoke-LabCommand -PreInstallationActivity -ActivityName 'Pre-installation' -ComputerName (Get-LabVm -Filter {-not $_.SkipDeployment -and $_.Roles.Count -eq 0}) -PassThru -NoDisplay
+        $jobs | Where-Object { $_ -is [System.Management.Automation.Job] } | Wait-Job | Out-Null
+    }
     
     if (($FileServer -or $performAll) -and (Get-LabVM -Role FileServer))
     {

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -704,7 +704,7 @@ function Invoke-LabCommand
             }
         }
 
-        Write-ScreenInfo -Message 'Post-installations done' -TaskEnd -OverrideNoDisplay
+        Write-ScreenInfo -Message 'Pre/Post-installations done' -TaskEnd -OverrideNoDisplay
     }
     else
     {

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psd1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psd1
@@ -52,7 +52,7 @@
         'Get-LabIsoImageDefinition'
         'Get-LabMachineDefinition'
         'Get-LabMachineRoleDefinition'
-        'Get-LabPostInstallationActivity'
+        'Get-LabInstallationActivity'
         'Get-LabVirtualNetwork'
         'Get-LabVirtualNetworkDefinition'
         'Get-LabVolumesOnPhysicalDisks'
@@ -66,5 +66,9 @@
         'Set-LabDefinition'
         'Set-LabLocalVirtualMachineDiskAuto'
         'Test-LabDefinition'
+    )
+
+    AliasesToExport = @(
+        'Get-LabPostInstallationActivity'
     )
 }

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1879,7 +1879,9 @@ function Add-LabMachineDefinition
         [ValidateScript( { $_ -in @([System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures).Name) })]
         [string]$UserLocale,
 
-        [AutomatedLab.PostInstallationActivity[]]$PostInstallationActivity,
+        [AutomatedLab.InstallationActivity[]]$PostInstallationActivity,
+
+        [AutomatedLab.InstallationActivity[]]$PreInstallationActivity,
 
         [string]$ToolsPath,
 
@@ -2795,6 +2797,7 @@ function Add-LabMachineDefinition
 
         $machine.Roles = $Roles
         $machine.PostInstallationActivity = $PostInstallationActivity
+        $machine.PreInstallationActivity = $PreInstallationActivity
 
         if ($HypervProperties)
         {
@@ -3010,7 +3013,7 @@ function Get-LabMachineRoleDefinition
 #endregion Get-LabMachineRoleDefinition
 
 #region Get-LabPostInstallationActivity
-function Get-LabPostInstallationActivity
+function Get-LabInstallationActivity
 {
     [CmdletBinding()]
     param (
@@ -3046,7 +3049,7 @@ function Get-LabPostInstallationActivity
     begin
     {
         Write-LogFunctionEntry
-        $activity = New-Object -TypeName AutomatedLab.PostInstallationActivity
+        $activity = New-Object -TypeName AutomatedLab.InstallationActivity
         if (-not $Properties)
         {
             $Properties = @{ } 
@@ -3726,3 +3729,5 @@ function Get-OnlineAdapterHardwareAddress
     }
 }
 #endregion Internal
+
+if (-not (Test-Path "alias:Get-LabPostInstallationActivity")) { New-Alias -Name Get-LabPostInstallationActivity -Value Get-LabInstallationActivity -Description "Alias so that scripts keep working" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Enhancements
+- New PreInstallationActivity parameter for Add-LabMachineDefinition
+  - Immediately before a role is deployed, the PreInstallationActivity is executed
+  - Machines without roles will get their PreInstallActivity executed after all domains are deployed
+  - For both pre and post, Get-LabInstallationActivity can be used, and can even include custom roles
 
 ### Fixes
 

--- a/LabXml/Machines/InstallationActivity.cs
+++ b/LabXml/Machines/InstallationActivity.cs
@@ -5,7 +5,7 @@ using System.Xml.Serialization;
 namespace AutomatedLab
 {
     [Serializable]
-    public class PostInstallationActivity
+    public class InstallationActivity
     {
         private Path dependencyFolder;
         private string scriptFileName;
@@ -94,7 +94,7 @@ namespace AutomatedLab
             set { asJob = value; }
         }
 
-        public PostInstallationActivity()
+        public InstallationActivity()
         {
             properties = new SerializableDictionary<string, List<object>>();
         }

--- a/LabXml/Machines/Machine.cs
+++ b/LabXml/Machines/Machine.cs
@@ -26,7 +26,7 @@ namespace AutomatedLab
         private User installationUser;
         private string userLocale;
         private string timeZone;
-        private List<PostInstallationActivity> postInstallationActivity;
+        private List<InstallationActivity> postInstallationActivity;
         private string productKey;
         private Path toolsPath;
         private string toolsPathDestination;
@@ -144,6 +144,8 @@ namespace AutomatedLab
             get { return memory; }
             set { memory = value; }
         }
+
+        public List<InstallationActivity> PreInstallationActivity { get; set; }
 
         public long MinMemory
         {
@@ -275,7 +277,7 @@ namespace AutomatedLab
         }
 
         [XmlElement("PostInstallation")]
-        public List<PostInstallationActivity> PostInstallationActivity
+        public List<InstallationActivity> PostInstallationActivity
         {
             get { return postInstallationActivity; }
             set { postInstallationActivity = value; }
@@ -385,7 +387,8 @@ namespace AutomatedLab
         {
             roles = new List<Role>();
             LinuxPackageGroup = new List<string>();
-            postInstallationActivity = new List<PostInstallationActivity>();
+            postInstallationActivity = new List<InstallationActivity>();            
+            PreInstallationActivity = new List<InstallationActivity>();
             networkAdapters = new List<NetworkAdapter>();
             internalNotes = new SerializableDictionary<string, string>();
             notes = new SerializableDictionary<string, string>();

--- a/TestClient/Program.cs
+++ b/TestClient/Program.cs
@@ -235,7 +235,7 @@ namespace TestClient
             m.DomainName = "vm.net";
             m.HostType = VirtualizationHost.HyperV;
             m.PostInstallationActivity.Add(
-                new PostInstallationActivity()
+                new InstallationActivity()
                 {
                     DependencyFolder = new AutomatedLab.Path() { Value = @"c:\test" },
                     IsoImage = new AutomatedLab.Path() { Value = @"c:\test\windows.iso" },


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #511 and allows a pre-installation activity. Pre-installation activities are executed before each individual role deployment so that the activities can rely on whatever was deployed before, e.g. the Domain environment or SQL instance before Azure DevOps is deployed.

The machines without any assigned role get their pre-installs executed after all domain-components have been deployed.

Renamed PostInstallationActivity to just InstallationActivity. Cmdlet Get-LabInstallationActivity exports the alias Get-LabPostInstallationActivity so that existing scripts do not break.

@GlennJC I know that issue is *quite* dated, but if you still require this functionality, I'd be happy to get feedback on this implementation. You can try out the new feature using the dev build from <https://ci.appveyor.com/project/nyanhp/automatedlab/build/job/3h9ijge4oyrr59ne/artifacts>

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

```powershell
$labName = 'POSH'

New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV

#make the network definition
Add-LabVirtualNetworkDefinition -Name $labName -AddressSpace 192.168.30.0/24

#and the domain definition with the domain admin account
Add-LabDomainDefinition -Name contoso.com -AdminUser Install -AdminPassword Somepass1

#these credentials are used for connecting to the machines. As this is a lab we use clear-text passwords
Set-LabInstallationCredential -Username Install -Password Somepass1

#defining default parameter values, as these ones are the same for all the machines
$PSDefaultParameterValues = @{
    'Add-LabMachineDefinition:Network' = $labName
    'Add-LabMachineDefinition:ToolsPath'= "$labSources\Tools"
    'Add-LabMachineDefinition:DomainName' = 'contoso.com'
    'Add-LabMachineDefinition:DnsServer1' = '192.168.30.10'
    'Add-LabMachineDefinition:OperatingSystem' = 'Windows Server 2016 Datacenter (Desktop Experience)'
}

#The PostInstallationActivity is just creating some users
$postInstallActivity = @()
$postInstallActivity += Get-LabPostInstallationActivity -ScriptFileName 'New-ADLabAccounts 2.0.ps1' -DependencyFolder $labSources\PostInstallationActivities\PrepareFirstChildDomain
$postInstallActivity += Get-LabPostInstallationActivity -ScriptFileName PrepareRootDomain.ps1 -DependencyFolder $labSources\PostInstallationActivities\PrepareRootDomain
Add-LabMachineDefinition -Name POSHDC1 -Memory 5GB -Roles RootDC -IpAddress 192.168.30.10 -PostInstallationActivity $postInstallActivity


#file server
$pre = @(Get-LabInstallationActivity -ScriptFileName Hello.ps1 -DependencyFolder "$labsources\PostInstallationActivities\Hello")
Add-LabMachineDefinition -Name POSHFS1 -Memory 5GB -Roles FileServer -IpAddress 192.168.30.50 -PreInstallationActivity $pre


$pre = @(Get-LabInstallationActivity -ScriptFileName Hello.ps1 -DependencyFolder "$labsources\PostInstallationActivities\Hello")
Add-LabMachineDefinition -Name POSHFS2 -Memory 5GB -IpAddress 192.168.30.51 -PreInstallationActivity $pre


Install-Lab
```