### PR TITLE
AL does no longer use the Hyper-V VM's notes field exclusively (Fixes #1135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@
   - Thanks to the awesomeness that is @friedrichweinmann and his PSFramework, we now have Variables and Functions that can be passed to Get-LabInstallationActivity
 - Adding SQL Server 2019 to Azure DevOps Server deployment ode and validators.
 - Added product keys for 'Windows 10 Education' and 'Windows 10 Pro Education'.
-- Setting lab administrative accounts to never expire
-- MAC addresses are now configurable
+- Setting lab administrative accounts to never expire.
+- MAC addresses are now configurable.
 
 ### Fixes
 - Fixed #1033, NonExistingDnsServerAssigned is now only called if domain controllers are defined in the lab.
-- Fixed issue with SharePoint servers not being deployed when they had other roles applied to them
-- Adding alias Disable-LabHostRemoting for increased visibility (Fixes #1137)
+- Fixed issue with SharePoint servers not being deployed when they had other roles applied to them.
+- Adding alias Disable-LabHostRemoting for increased visibility (Fixes #1137).
+- AL does no longer use the Hyper-V VM's notes field exclusively (Fixes #1135).
 
 ## 5.34.0 (2021-03-30)
 


### PR DESCRIPTION
## Description

Fixes #1135.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Some lab deployments and tests with previously deployed ones. The following code reads the notes old style notes and adds them back using the prefix and suffix. From then on, the old style notes will have no effect and a smooth transition is possible.