### PR TITLE
Added 'Restart-LabVM'

### DIFF
--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -125,7 +125,7 @@ function Install-LabTeamFoundationServer
 
     $installationJobs = @()
     $count = 0
-    foreach ( $machine in $tfsMachines)
+    foreach ($machine in $tfsMachines)
     {
         if (Get-LabIssuingCA)
         {
@@ -201,8 +201,10 @@ function Install-LabTeamFoundationServer
         if ((Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
         {
             # For good luck, disable the firewall again - in case Invoke-AzVmRunCommand failed to do its job.
-            Invoke-LabCommand -ComputerName $machine,$sqlServer -NoDisplay -ScriptBlock {Set-NetFirewallProfile -All -Enabled False -PolicyStore PersistentStore}
+            Invoke-LabCommand -ComputerName $machine, $sqlServer -NoDisplay -ScriptBlock { Set-NetFirewallProfile -All -Enabled False -PolicyStore PersistentStore }
         }
+
+        Restart-LabVM -ComputerName $machine -Wait -NoDisplay
 
         $installationJobs += Invoke-LabCommand -ComputerName $machine -ScriptBlock {
             $tfsConfigPath = (Get-ChildItem -Path $env:ProgramFiles -Filter tfsconfig.exe -Recurse | Select-Object -First 1).FullName

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Fixing issue when `Install-Lab -BaseImages` or `-NetworkSwitches` was used
+- Azure DevOps installation 'failed' with success code 3010 (reboot required).
 
 ## 5.36.0 (2021-04-27)
 


### PR DESCRIPTION
## Description

I am not sure when I have seen this first. Maybe the ADO version '2020.0.1' brings in this new requirement. The change requires a bit more time but does not hurt also for older versions of ADO.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
DscWorkshop Deployment