### PR TITLE
Fixing issue with missing cmdlet on Linux

### DIFF
--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -67,6 +67,7 @@
         'AutomatedLabNotifications',
         @{ModuleName='AutomatedLab.Common'; ModuleVersion='2.0.188'; }
         'PSFramework'
+        'AutomatedLabTest'
     )
 
     CmdletsToExport        = @()

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -105,7 +105,16 @@ function New-LabPSSession
 
             if ($m.HostType -eq 'Azure')
             {
-                if (-not $m.AzureConnectionInfo.DnsName -or -not (Resolve-DnsName -Name $m.AzureConnectionInfo.DnsName -DnsOnly -ErrorAction SilentlyContinue))
+                try
+                {
+                    $azConInfResolved = [System.Net.Dns]::GetHostByName($m.AzureConnectionInfo.DnsName)
+                }
+                catch
+                {
+
+                }
+
+                if (-not $m.AzureConnectionInfo.DnsName -or -not $azConInfResolved)
                 {
                     $m.AzureConnectionInfo = Get-LWAzureVMConnectionInfo -ComputerName $m
                 }
@@ -904,7 +913,16 @@ function New-LabCimSession
 
             if ($m.HostType -eq 'Azure')
             {
-                if (-not $m.AzureConnectionInfo.DnsName -or -not (Resolve-DnsName -Name $m.AzureConnectionInfo.DnsName -DnsOnly -ErrorAction SilentlyContinue))
+                try
+                {
+                    $azConInfResolved = [System.Net.Dns]::GetHostByName($m.AzureConnectionInfo.DnsName)
+                }
+                catch
+                {
+
+                }
+
+                if (-not $m.AzureConnectionInfo.DnsName -or -not $azConInfResolved)
                 {
                     $m.AzureConnectionInfo = Get-LWAzureVMConnectionInfo -ComputerName $m
                 }

--- a/AutomatedLabUnattended/Private/RedHat/Export-UnattendedKickstartFile.ps1
+++ b/AutomatedLabUnattended/Private/RedHat/Export-UnattendedKickstartFile.ps1
@@ -13,7 +13,12 @@ function Export-UnattendedKickstartFile
         $idx = $script:un.IndexOf('%post')
     }
 
-    $repoIp = (Resolve-DnsName -Name packages.microsoft.com -Type A).IP4Address
+    $repoIp = try {
+        ([System.Net.Dns]::GetHostByName('packages.microsoft.com').AddressList | Where-Object AddressFamily -eq InterNetwork).IPAddressToString
+    }
+    catch
+    { }
+
     $repoContent = (Invoke-RestMethod -Method Get -Uri 'https://packages.microsoft.com/config/rhel/7/prod.repo' -ErrorAction SilentlyContinue) -split "`n"
     if ($script:un[$idx + 1] -ne '#start')
     {


### PR DESCRIPTION
Also including Test module

<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Resolve-DnsName does not exist on Linux. Unfortunately, PSScriptAnalyzer did not flag this. Regardless, I have replaced the three calls to that cmdlet with System.Net.Dns

Also added AutomatedLabTest to our dependencies. I never noticed the error as the module was always installed, but it is required during Install-Lab and would fail if AL is installed via the gallery as the only source.

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
