### PR TITLE
Password never expires task error

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -892,7 +892,7 @@ function Install-Lab
             $userName = (Get-Lab).Domains.Where({ $_.Name -eq $machine.DomainName }).Administrator.UserName
             Invoke-LabCommand -ActivityName 'Setting PasswordNeverExpires for deployment accounts in AD' -ComputerName $machine -ScriptBlock {
                 Set-ADUser -Identity $userName -PasswordNeverExpires $true -Confirm:$false
-            } -Variable (Get-Variable userName)
+            } -Variable (Get-Variable userName) -NoDisplay
         }
 
         Write-ScreenInfo -Message 'Done' -TaskEnd

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -961,9 +961,9 @@ function Install-Lab
         {
             $anyDc = $machine.Group | Select -First 1
             $userName = (Get-Lab).Domains.Where({$_.Name -eq $machine.Name}).Administrator.Username
-            Invoke-LabCommand -ComputerName $anyDc -ScriptBlock {
+            Invoke-LabCommand -ActivityName 'Setting PasswordNeverExpires for deployment accounts in AD' -ComputerName $anyDc -ScriptBlock {
                 Set-ADUser -Identity $userName -PasswordNeverExpires $true -Confirm:$false
-            } -Variable (Get-Variable userName)
+            } -Variable (Get-Variable userName) -NoDisplay
         }
 
         Write-ScreenInfo -Message 'Done' -TaskEnd
@@ -1286,7 +1286,7 @@ function Install-Lab
             Invoke-LabCommand -ActivityName 'Setting PasswordNeverExpires for local deployment accounts' -ComputerName $nonDomainControllers -ScriptBlock {
                 # Still supporting ANCIENT server 2008 R2 with it's lack of CIM cmdlets :'(
                 Get-WmiObject -Query "Select * from Win32_UserAccount where name = '$userName' and localaccount='true'" | Set-WmiInstance -Arguments @{ PasswordExpires = $false}
-            } -Variable (Get-Variable userName)
+            } -Variable (Get-Variable userName) -NoDisplay
         }
 
         Write-ScreenInfo -Message 'Done' -TaskEnd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 - Fixing issue when `Install-Lab -BaseImages` or `-NetworkSwitches` was used
 - Azure DevOps installation 'failed' with success code 3010 (reboot required).
-
+- Fixed 'PasswordNeverExpires' when there is only DCs in the lab.
 ## 5.36.0 (2021-04-27)
 
 ### Enhancements


### PR DESCRIPTION
## Description

- The new task that sets the local and domain deployment account's password not to expire threw an error when there are only domain controllers in the lab.
- The code to disable password expiration for domain accounts was invoked when DC are deployed. Moved the code so it is now invoked when the RootDCs are deployed.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Deployed some small labs with only DCs, some with only standalone servers and some with DC and domain-joined machines.