### PR TITLE
Custom netbios support for Ca inst

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -116,6 +116,7 @@ else
     '/'
 }
 Set-PSFConfig -Module 'AutomatedLab' -Name OsRoot -Value $osroot -Initialize -Validation string
+Set-PSFConfig -Module 'AutomatedLab' -Name OverridePowerPlan -Value $true -Initialize -Validation bool -Description 'On Windows: Indicates that power settings will be set to High Power during lab deployment'
 
 #PSSession settings
 Set-PSFConfig -Module 'AutomatedLab' -Name InvokeLabCommandRetries -Value 3 -Initialize -Validation integer -Description 'Number of retries for Invoke-LabCommand'

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -571,7 +571,7 @@ function Import-Lab
             -Credential ([System.Management.Automation.PSSerializer]::Deserialize($Script:data.VMWareSettings.Credential))
         }
 
-        if (-not ($IsLinux -or $IsMacOs))
+        if (-not ($IsLinux -or $IsMacOs) -and (Get-LabConfigurationItem -Name OverridePowerPlan))
         {
             $powerSchemeBackup = (powercfg.exe -GETACTIVESCHEME).Split(':')[1].Trim().Split()[0]
             powercfg.exe -setactive 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c

--- a/AutomatedLab/AutomatedLabADCS.psm1
+++ b/AutomatedLab/AutomatedLabADCS.psm1
@@ -1826,6 +1826,12 @@ function Install-LabCAMachine
             $rootDc = Get-LabVM -Role RootDC | Where-Object DomainName -eq $rootDomain
         }
 
+        $rdcProperties = $rootDc.Roles | Where-Object Name -eq 'RootDc'
+        if ($rdcProperties -and $rdcProperties.Properties.ContainsKey('NetBiosDomainName'))
+        {
+            $rootDomainNetBIOSName = $rdcProperties.Properties['NetBiosDomainName']
+        }
+
         $param.Add('ForestAdminUserName', ('{0}\{1}' -f $rootDomainNetBIOSName, $rootDomain.Administrator.UserName))
         $param.Add('ForestAdminPassword', $rootDomain.Administrator.Password)
 

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -3671,7 +3671,7 @@ function Import-LabDefinition
             -Credential ([System.Management.Automation.PSSerializer]::Deserialize($Script:lab.VMWareSettings.Credential))
         }
 
-        if (-not ($IsLinux -or $IsMacOs))
+        if (-not ($IsLinux -or $IsMacOs) -and (Get-LabConfigurationItem -Name OverridePowerPlan))
         {
             $powerSchemeBackup = (powercfg.exe -GETACTIVESCHEME).Split(':')[1].Trim().Split()[0]
             powercfg.exe -setactive 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Enhancements
+
+### Bugs
+
+- Fixed bug in CA deployment: NETBIOS domain name was disregarded if one was explicitly configured
+
 ## 5.37.0 (2021-05-31)
 
 ### Enhancements


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Additionally I made the Power Plan settings optional. I had severe hardware issues on my device. The balanced plan in current releases has a slider that can be set to high power instead. Making it configurable seemed like an easy solution.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
```powershell
New-LabDefinition -Name tst -DefaultVirtualizationEngine HyperV

Add-LabMachineDefinition -Name DC -Roles (Get-LabMachineRoleDefinition -Role RootDC -Properties @{NetBiosDomainName = 'yolo'}) -DomainName contoso.com -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)' -Memory 4gb
Add-LabMachineDefinition -Name CA -Roles CaRoot -DomainName contoso.com -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)' -Memory 4gb
Install-Lab
Remove-Lab -Confirm:$false

New-LabDefinition -Name tst -DefaultVirtualizationEngine HyperV

Add-LabMachineDefinition -Name DC -Roles RootDC -DomainName contoso.com -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)' -Memory 4gb
Add-LabMachineDefinition -Name CA -Roles CaRoot -DomainName contoso.com -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)' -Memory 4gb
Install-Lab
Remove-Lab -Confirm:$false
```