### PR TITLE
Moving additional disk location to VM path

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -144,6 +144,9 @@ Set-PSFConfig -Module 'AutomatedLab' -Name SetLocalIntranetSites -Value 'All'  -
 #Hyper-V Network settings
 Set-PSFConfig -Module 'AutomatedLab' -Name MacAddressPrefix -Value '0017FB' -Initialize -Validation string -Description 'The MAC address prefix for Hyper-V labs'
 
+#Hyper-V Disk Settings
+Set-PSFConfig -Module 'AutomatedLab' -Name CreateOnlyReferencedDisks -Value $true -Initialize -Validation bool -Description 'Disks that are not references by a VM will not be created'
+
 #Admin Center
 Set-PSFConfig -Module 'AutomatedLab' -Name WacDownloadUrl -Value 'http://aka.ms/WACDownload' -Validation string -Initialize -Description 'Windows Admin Center Download URL'
 
@@ -767,7 +770,7 @@ Register-PSFTeppScriptblock -Name 'AutomatedLab-Subscription' -ScriptBlock {
 }
 
 Register-PSFTeppScriptblock -Name 'AutomatedLab-CustomRole' -ScriptBlock {
-(Get-ChildItem -Path (Join-Path -Path (Get-LabSourcesLocationInternal -Local) -ChildPath 'CustomRoles' -ErrorAction SilentlyContinue) -Directory -ErrorAction SilentlyContinue).Name
+    (Get-ChildItem -Path (Join-Path -Path (Get-LabSourcesLocationInternal -Local) -ChildPath 'CustomRoles' -ErrorAction SilentlyContinue) -Directory -ErrorAction SilentlyContinue).Name
 }
 
 Register-PSFTeppScriptblock -Name 'AutomatedLab-AzureRoleSize' -ScriptBlock {

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -548,6 +548,7 @@ function Import-Lab
         try
         {
             $Script:data.Disks = $importMethodInfo.Invoke($null, $Script:data.DiskDefinitionFiles[0].Path)
+            $Script:data.Disks = Get-LabVHDX -All
 
             if ($Script:data.DiskDefinitionFiles.Count -gt 1)
             {
@@ -1486,7 +1487,7 @@ function Remove-Lab
                         }
                         else
                         {
-                            Write-ScreenInfo "Disk '$($disk.Path)' does not exist"
+                            Write-ScreenInfo "Disk '$($disk.Path)' does not exist" -Type Verbose
                         }
                     }
                 }

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -1880,6 +1880,14 @@ function Get-LabVM
         {
             $result
         }
+        
+        foreach ($machine in $result)
+        {
+            if ($machine.Disks.Count -gt 1)
+            {
+                $machine.Disks = Get-LabVHDX -Name $machine.Disks.Name
+            }
+        }
 
         if ($Filter)
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Exchange links updated
 - NuGet custom role distributes nuget.exe on lab VMs and registers repository
 - No more validating non-deployed roles
-- The VHDx files for additional disks are not stored in the VM's path and no longer in the
+- The VHDx files for additional disks are now stored in the VM's path and no longer in the
   disks folder.
 
 ### Bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Exchange links updated
 - NuGet custom role distributes nuget.exe on lab VMs and registers repository
 - No more validating non-deployed roles
+- The VHDx files for additional disks are not stored in the VM's path and no longer in the
+  disks folder.
 
 ### Bugs
 


### PR DESCRIPTION
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
```powershell
#Here AL installs a lab with one domain controller and one client. The OS can be configured quite easily as well as
#the domain name or memory. AL takes care about network settings like in the previous samples.

New-LabDefinition -Name Lab1 -DefaultVirtualizationEngine HyperV

Add-LabMachineDefinition -Name xzDC1 -Memory 1GB -OperatingSystem 'Windows Server 2016 Datacenter (Desktop Experience)' -Roles RootDC -DomainName contoso.com

Add-LabDiskDefinition -Name xzT1 -DiskSizeInGb 20
Add-LabMachineDefinition -Name xzClient1 -Memory 1GB -OperatingSystem 'Windows 10 Pro' -DomainName contoso.com -DiskName xzT1

Add-LabDiskDefinition -Name xzT2 -DiskSizeInGb 20

Install-Lab

Show-LabDeploymentSummary -Detailed
```