### PR TITLE
Added support for multiple FailoverStorage roles

### DIFF
--- a/AutomatedLab/AutomatedLabFailover.psm1
+++ b/AutomatedLab/AutomatedLabFailover.psm1
@@ -239,7 +239,14 @@ function Install-LabFailoverStorage
     
         $role = $failoverNode.Roles | Where-Object Name -eq 'FailoverNode'
         $name = $role.Properties['ClusterName']
-        $storageMapping."$($failoverNode.Name)" = $role.Properties['StorageTarget']
+        $storageMapping."$($failoverNode.Name)" = if ($role.Properties.ContainsKey('StorageTarget'))
+        {
+            $role.Properties['StorageTarget']
+        }
+        else
+        {
+            $storageNodes.Name
+        }
 
         if (-not $name)
         {

--- a/AutomatedLab/AutomatedLabFailover.psm1
+++ b/AutomatedLab/AutomatedLabFailover.psm1
@@ -99,20 +99,20 @@ function Install-LabFailoverCluster
                     if ($line -match 'Disk (?<DiskNumber>\d) \s+(Offline)\s+(?<Size>\d+) GB\s+(?<Free>\d+) GB')
                     {
                         $nextDriveLetter = [char[]](67..90) |
-                            Where-Object { (Get-WmiObject -Class Win32_LogicalDisk |
-                                    Select-Object -ExpandProperty DeviceID) -notcontains "$($_):"} |
-                            Select-Object -First 1
+                        Where-Object { (Get-WmiObject -Class Win32_LogicalDisk |
+                        Select-Object -ExpandProperty DeviceID) -notcontains "$($_):"} |
+                        Select-Object -First 1
 
                         $diskNumber = $Matches.DiskNumber
 
                         $diskpartCmd = "@
-                        SELECT DISK $diskNumber
-                        ATTRIBUTES DISK CLEAR READONLY
-                        ONLINE DISK
-                        CREATE PARTITION PRIMARY
-                        ASSIGN LETTER=$nextDriveLetter
-                        EXIT
-                    @"
+                            SELECT DISK $diskNumber
+                            ATTRIBUTES DISK CLEAR READONLY
+                            ONLINE DISK
+                            CREATE PARTITION PRIMARY
+                            ASSIGN LETTER=$nextDriveLetter
+                            EXIT
+                        @"
                         $diskpartCmd | diskpart.exe | Out-Null
 
                         Start-Sleep -Seconds 2
@@ -217,15 +217,30 @@ function Install-LabFailoverStorage
     param
     ( )
 
-    $storageNode = Get-LabVM -Role FailoverStorage -ErrorAction SilentlyContinue
+    $storageNodes = Get-LabVM -Role FailoverStorage -ErrorAction SilentlyContinue
     $failoverNodes = Get-LabVM -Role FailoverNode -ErrorAction SilentlyContinue
-    Start-LabVm -ComputerName (Get-LabVm -Role FailoverStorage,FailoverNode) -Wait
+    if ($storageNodes.Count -gt 1)
+    {
+        foreach ($failoverNode in $failoverNodes)
+        {
+            $role = $failoverNode.Roles | Where-Object Name -eq 'FailoverNode'
+            if (-not $role.Properties.ContainsKey('StorageTarget'))
+            {
+                Write-Error "There are $($storageNodes.Count) VMs with the 'FailoverStorage' role and the storage target is not defined for '$failoverNode'. Please define the property 'StorageTarget' with the 'FailoverStorage' role." -ErrorAction Stop
+            }
+        }
+    }
+    Start-LabVM -ComputerName (Get-LabVM -Role FailoverStorage, FailoverNode) -Wait
     
     $clusters = @{}
+    $storageMapping = @{}
     
     foreach ($failoverNode in $failoverNodes) {
     
-        $name = ($failoverNode.Roles | Where-Object Name -eq 'FailoverNode').Properties['ClusterName']
+        $role = $failoverNode.Roles | Where-Object Name -eq 'FailoverNode'
+        $name = $role.Properties['ClusterName']
+        $storageMapping."$($failoverNode.Name)" = $role.Properties['StorageTarget']
+
         if (-not $name)
         {
             $name = 'ALCluster'
@@ -251,77 +266,77 @@ function Install-LabFailoverStorage
         $clusters[$clusterName] = $initiatorIds
     }
     
-    Install-LabWindowsFeature -ComputerName $storageNode -FeatureName FS-iSCSITarget-Server
+    Install-LabWindowsFeature -ComputerName $storageNodes -FeatureName FS-iSCSITarget-Server
 
-    foreach ($disk in $storageNode.Disks)
+    foreach ($storageNode in $storageNodes)
     {
-        Write-ScreenInfo "Working on $($disk.name)"
-        #$lunDrive = $role.Properties['LunDrive'][0] # Select drive letter only
-        $driveLetter = $disk.DriveLetter
+        foreach ($disk in $storageNode.Disks)
+        {
+            Write-ScreenInfo "Working on $($disk.name)"
+            #$lunDrive = $role.Properties['LunDrive'][0] # Select drive letter only
+            $driveLetter = $disk.DriveLetter
 
-        Invoke-LabCommand -ActivityName "Creating iSCSI target for $($disk.name)" -ComputerName $storageNode -ScriptBlock {
-            # assign drive letter if not provided
-            if (-not $driveLetter)
-            {
-                # http://vcloud-lab.com/entries/windows-2016-server-r2/find-next-available-free-drive-letter-using-powershell-
-                #$driveLetter = (68..90 | % {$L = [char]$_; if ((gdr).Name -notContains $L) {$L}})[0]
-                $driveLetter = $env:SystemDrive[0]
-            }
-
-            $driveInfo = [System.IO.DriveInfo] [string] $driveLetter
-
-            if (-not (Test-Path $driveInfo))
-            {
-                $offlineDisk = Get-Disk | Where-Object -Property OperationalStatus -eq Offline | Select-Object -First 1
-                if ($offlineDisk)
+            Invoke-LabCommand -ActivityName "Creating iSCSI target for $($disk.name) on '$storageNode'" -ComputerName $storageNode -ScriptBlock {
+                # assign drive letter if not provided
+                if (-not $driveLetter)
                 {
-                    $offlineDisk | Set-Disk -IsOffline $false
-                    $offlineDisk | Set-Disk -IsReadOnly $false
+                    # http://vcloud-lab.com/entries/windows-2016-server-r2/find-next-available-free-drive-letter-using-powershell-
+                    #$driveLetter = (68..90 | % {$L = [char]$_; if ((gdr).Name -notContains $L) {$L}})[0]
+                    $driveLetter = $env:SystemDrive[0]
                 }
 
-                if (-not ($offlineDisk | Get-Partition | Get-Volume))
+                $driveInfo = [System.IO.DriveInfo] [string] $driveLetter
+
+                if (-not (Test-Path $driveInfo))
                 {
-                    $offlineDisk | New-Volume -FriendlyName $disk -FileSystem ReFS -DriveLetter $driveLetter
+                    $offlineDisk = Get-Disk | Where-Object -Property OperationalStatus -eq Offline | Select-Object -First 1
+                    if ($offlineDisk)
+                    {
+                        $offlineDisk | Set-Disk -IsOffline $false
+                        $offlineDisk | Set-Disk -IsReadOnly $false
+                    }
+
+                    if (-not ($offlineDisk | Get-Partition | Get-Volume))
+                    {
+                        $offlineDisk | New-Volume -FriendlyName $disk -FileSystem ReFS -DriveLetter $driveLetter
+                    }
                 }
-            }
 
-            $folderPath = Join-Path -Path $driveInfo -ChildPath $disk.Name
-            $folder = New-Item -ItemType Directory -Path $folderPath -ErrorAction SilentlyContinue
-            $folder = Get-Item -Path $folderPath -ErrorAction Stop
+                $folderPath = Join-Path -Path $driveInfo -ChildPath $disk.Name
+                $folder = New-Item -ItemType Directory -Path $folderPath -ErrorAction SilentlyContinue
+                $folder = Get-Item -Path $folderPath -ErrorAction Stop
 
-            foreach ($clu in $clusters.GetEnumerator())
-            {
-                if (-not (Get-IscsiServerTarget -TargetName $clu.Key -ErrorAction SilentlyContinue))
+                foreach ($clu in $clusters.GetEnumerator())
                 {
-                    New-IscsiServerTarget -TargetName $clu.Key -InitiatorIds $clu.Value
+                    if (-not (Get-IscsiServerTarget -TargetName $clu.Key -ErrorAction SilentlyContinue))
+                    {
+                        New-IscsiServerTarget -TargetName $clu.Key -InitiatorIds $clu.Value
+                    }
+                    $diskTarget = (Join-Path -Path $folder.FullName -ChildPath "$($disk.name).vhdx")
+                    $diskSize = [uint64]$disk.DiskSize*1GB
+                    if (-not (Get-IscsiVirtualDisk -Path $diskTarget -ErrorAction SilentlyContinue))
+                    {
+                        New-IscsiVirtualDisk -Path $diskTarget -Size $diskSize
+                    }
+                    Add-IscsiVirtualDiskTargetMapping -TargetName $clu.Key -Path $diskTarget
                 }
-                $diskTarget = (Join-Path -Path $folder.FullName -ChildPath "$($disk.name).vhdx")
-                $diskSize = [uint64]$disk.DiskSize*1GB
-                if (-not (Get-IscsiVirtualDisk -Path $diskTarget -ErrorAction SilentlyContinue))
+            } -Variable (Get-Variable -Name clusters, disk, driveletter) -ErrorAction Stop
+
+            Invoke-LabCommand -ActivityName 'Connecting iSCSI target' -ComputerName (Get-LabVM -Role FailoverNode) -ScriptBlock {
+                $targetAddress = $storageMapping[$env:COMPUTERNAME]
+                if (-not (Get-Command New-IscsiTargetPortal -ErrorAction SilentlyContinue))
                 {
-                    New-IscsiVirtualDisk -Path $diskTarget -Size $diskSize
+                    iscsicli.exe QAddTargetPortal $targetAddress
+                    $target = ((iscsicli.exe ListTargets) -match 'iqn.+target')[0].Trim()
+                    iscsicli.exe QLoginTarget $target
                 }
-                Add-IscsiVirtualDiskTargetMapping -TargetName $clu.Key -Path $diskTarget
-            }
-        } -Variable (Get-Variable -Name clusters, disk, driveletter) -ErrorAction Stop
-
-        $targetAddress = $storageNode.IpV4Address
-
-        Invoke-LabCommand -ActivityName 'Connecting iSCSI target' -ComputerName (Get-LabVM -Role FailoverNode) -ScriptBlock {
-            if (-not (Get-Command New-IscsiTargetPortal -ErrorAction SilentlyContinue))
-            {
-                iscsicli.exe QAddTargetPortal $targetAddress
-                $target = ((iscsicli.exe ListTargets) -match 'iqn.+target')[0].Trim()
-                iscsicli.exe QLoginTarget $target
-            }
-            else
-            {
-                New-IscsiTargetPortal -TargetPortalAddress $targetAddress
-                Get-IscsiTarget | Where-Object {-not $_.IsConnected} | Connect-IscsiTarget -IsPersistent $true
-            }
-
-
-        } -Variable (Get-Variable targetAddress) -ErrorAction Stop
+                else
+                {
+                    New-IscsiTargetPortal -TargetPortalAddress $targetAddress
+                    Get-IscsiTarget | Where-Object {-not $_.IsConnected} | Connect-IscsiTarget -IsPersistent $true
+                }
+            } -Variable (Get-Variable storageMapping) -ErrorAction Stop
+        }
     }
 }
 #endregion

--- a/AutomatedLab/AutomatedLabFailover.psm1
+++ b/AutomatedLab/AutomatedLabFailover.psm1
@@ -5,9 +5,9 @@ function Install-LabFailoverCluster
     param ( )
 
     $failoverNodes = Get-LabVm -Role FailoverNode -ErrorAction SilentlyContinue
-    $clusters = $failoverNodes | Group-Object { ($PSItem.Roles | Where-Object -Property Name -eq 'FailoverNode').Properties['ClusterName'] }
+    $clusters = $failoverNodes | Group-Object { ($_.Roles | Where-Object -Property Name -eq 'FailoverNode').Properties['ClusterName'] }
     $useDiskWitness = $false
-    Start-LabVm -Wait -ComputerName $failoverNodes
+    Start-LabVM -Wait -ComputerName $failoverNodes
 
     Install-LabWindowsFeature -ComputerName $failoverNodes -FeatureName Failover-Clustering, RSAT-Clustering -IncludeAllSubFeature
 
@@ -322,7 +322,7 @@ function Install-LabFailoverStorage
                 }
             } -Variable (Get-Variable -Name clusters, disk, driveletter) -ErrorAction Stop
 
-            Invoke-LabCommand -ActivityName 'Connecting iSCSI target' -ComputerName (Get-LabVM -Role FailoverNode) -ScriptBlock {
+            Invoke-LabCommand -ActivityName "Connecting iSCSI target - storage node '$storageNode' - disk '$disk'" -ComputerName (Get-LabVM -Role FailoverNode) -ScriptBlock {
                 $targetAddress = $storageMapping[$env:COMPUTERNAME]
                 if (-not (Get-Command New-IscsiTargetPortal -ErrorAction SilentlyContinue))
                 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Exchange links updated
 - NuGet custom role distributes nuget.exe on lab VMs and registers repository
 - No more validating non-deployed roles
+- Support for multiple storage nodes, controlled by new role property
+  'StorageTarget' for role 'FailoverNode'
 
 ### Bugs
 


### PR DESCRIPTION
## Description

So far the AL supported only one VM having the FailoverStorage role. All FailoverNodes got connected to the one FailoverStorage role in the lab. Now, multiple FailoverStorage can be added. If there are multiple storage nodes defined, the FailoverNode role must know which FailoverStorage VM to target. This is controlled using the 'StorageTarget' property of the FailoverNode role:

```powershell
$cluster = Get-LabMachineRoleDefinition -Role FailoverNode -Properties @{
    ClusterName = 'Clu1'
    ClusterIp = '192.168.50.200'
    StorageTarget = 'x1foCLS1'
}
```

- [x] - I have tested my changes.  
- [x]  - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
```powershell
<#
This demo creates a failover cluster with 2 nodes, and 2 shared disks
that can be added to cluster roles.
#>

$labname = 'FailOverLab2'
New-LabDefinition -Name $labname -DefaultVirtualizationEngine HyperV

Add-LabDomainDefinition -Name contoso.com -AdminUser Install -AdminPassword Somepass1

Set-LabInstallationCredential -Username Install -Password Somepass1

Add-LabVirtualNetworkDefinition -Name $labname -AddressSpace 192.168.50.0/24

$PSDefaultParameterValues = @{
    'Add-LabMachineDefinition:OperatingSystem' = 'Windows Server 2019 Datacenter (Desktop Experience)'
    'Add-LabMachineDefinition:Network'         = $labname
    'Add-LabMachineDefinition:DomainName'      = 'contoso.com'
    'Add-LabMachineDefinition:Memory'          = 1GB
}

Add-LabMachineDefinition -Name foDC1 -Roles RootDC

# Integrate an iSCSI Target into your machines
$storageRole = Get-LabMachineRoleDefinition -Role FailoverStorage
Add-LabDiskDefinition -Name x1LunDrive -DiskSizeInGb 26 -DriveLetter D
Add-LabDiskDefinition -Name x1SqlDataDrive -DiskSizeInGb 10 -DriveLetter E
Add-LabDiskDefinition -Name x1SqlLogDrive -DiskSizeInGb 10 -DriveLetter F
Add-LabMachineDefinition -Name x1foCLS1 -Roles $storageRole -DiskName x1LunDrive, x1SqlDataDrive, x1SqlLogDrive

$storageRole = Get-LabMachineRoleDefinition -Role FailoverStorage
Add-LabDiskDefinition -Name x2LunDrive -DiskSizeInGb 35 -DriveLetter D
Add-LabDiskDefinition -Name x2SqlDataDrive -DiskSizeInGb 15 -DriveLetter E
Add-LabDiskDefinition -Name x2SqlLogDrive -DiskSizeInGb 15 -DriveLetter F
Add-LabMachineDefinition -Name x2foCLS1 -Roles $storageRole -DiskName x2LunDrive, x2SqlDataDrive, x2SqlLogDrive

$cluster = Get-LabMachineRoleDefinition -Role FailoverNode -Properties @{ ClusterName = 'Clu1'; ClusterIp = '192.168.50.200'; StorageTarget = 'x1foCLS1' }
Add-LabMachineDefinition -name x1foCLN1 -Roles $cluster
Add-LabMachineDefinition -name x1foCLN2 -Roles $cluster

$cluster = Get-LabMachineRoleDefinition -Role FailoverNode -Properties @{ ClusterName = 'Clu2'; ClusterIp = '192.168.50.210'; StorageTarget = 'x2foCLS1' }
Add-LabMachineDefinition -name x2foCLN1 -Roles $cluster
Add-LabMachineDefinition -name x2foCLN2 -Roles $cluster

Install-Lab

Show-LabDeploymentSummary
```