### PR TITLE
Network Interface name now considered even if there is only one interface

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -976,8 +976,7 @@ function Start-LWHypervVM
         {
             Start-VM -Name $Name.ResourceName -ErrorAction Stop
 
-            if ($machine.NetworkAdapters.Count -gt 1 -and
-            ($machineMetadata.InitState -band [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected) -ne [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected)
+            if (($machineMetadata.InitState -band [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected) -ne [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected)
             {
                 Repair-LWHypervNetworkConfig -ComputerName $Name
                 $machineMetadata.InitState = [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - When Az credentials were expired, lab resources were not removed
 - When calculating the required free space on disk for labs on Hyper-V, also VMs
   that are enabled for SkipDeployment were taken into account. This is now fixed.
+- The network interface name was not assigned if there is only one interface defined for a VM.
 
 ## 5.38.0 (2021-07-14)
 


### PR DESCRIPTION
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
The following small lab and more complex stuff.

```powershell
New-LabDefinition -Name xWin10 -DefaultVirtualizationEngine HyperV
Add-LabVirtualNetworkDefinition -Name xWin10 -AddressSpace 192.168.67.1/24

$netAdapter = New-LabNetworkAdapterDefinition -Ipv4Address 192.168.67.11 -VirtualSwitch xWin10 -Ipv4Gateway 19.168.67.1 -InterfaceName xxx
Add-LabMachineDefinition -Name xClient1 -Memory 1GB -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)' -NetworkAdapter $netAdapter
Install-Lab
```
