### PR TITLE
Fixes #1197

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -886,6 +886,8 @@ function Install-Lab
 
         Write-ScreenInfo -Message "Machines with RootDC role to be installed: '$((Get-LabVM -Role RootDC).Name -join ', ')'"
         Install-LabRootDcs -CreateCheckPoints:$CreateCheckPoints
+        
+        New-LabADSubnet
 
         # Set account expiration for builtin account and lab domain account
         foreach ($machine in (Get-LabVM -Role RootDC -ErrorAction SilentlyContinue))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugs
 
 - New-LabADSubnet threw 'Cannot convert this format' when DCs are only connected to an external adapter.
+- New-LabADSubnet was not called if there is only a RootDC defined.
 
 ## 5.39.0 (2021-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bugs
 
+- New-LabADSubnet threw 'Cannot convert this format' when DCs are only connected to an external adapter.
+
 ## 5.39.0 (2021-08-20)
 
 ### Enhancements


### PR DESCRIPTION
## Description

When DCs are connected only to an external interface that gets its IP address by DHCP, AL does not know about the IP details. Added another way to retrieve the data.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
The lab in #1197 and '04 Single domain-joined server.ps1'.