### PR TITLE
SQL ini handling Azure

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -798,6 +798,7 @@ Register-PSFTeppArgumentCompleter -Command Add-LabAzureSubscription -Parameter S
 Register-PSFTeppArgumentCompleter -Command Get-LabPostInstallationActivity -Parameter CustomRole -Name 'AutomatedLab-CustomRole'
 Register-PSFTeppArgumentCompleter -Command Add-LabMachineDefinition -Parameter AzureRoleSize -Name 'AutomatedLab-AzureRoleSize'
 Register-PSFTeppArgumentCompleter -Command Add-LabMachineDefinition, Enable-LabMachineAutoShutdown -Parameter TimeZone -Name 'AutomatedLab-TimeZone'
+Register-PSFTeppArgumentCompleter -Command Add-LabAzureSubscription -Parameter AutoShutdownTimeZone -Name 'AutomatedLab-TimeZone'
 Register-PSFTeppArgumentCompleter -Command Add-LabMachineDefinition -Parameter RhelPackage -Name 'AutomatedLab-RhelPackage'
 Register-PSFTeppArgumentCompleter -Command Add-LabMachineDefinition -Parameter SusePackage -Name 'AutomatedLab-SusePackage'
 #endregion

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -615,7 +615,19 @@ function Export-Lab
     Remove-Item -Path $lab.DiskDefinitionFiles[0].Path
 
     $lab.Machines.Export($lab.MachineDefinitionFiles[0].Path)
-    $lab.Disks.Export($lab.DiskDefinitionFiles[0].Path)
+    try
+    {
+        $lab.Disks.Export($lab.DiskDefinitionFiles[0].Path)
+    }
+    catch
+    {
+        $tmpList = [AutomatedLab.ListXmlStore[AutomatedLab.Disk]]::new()
+        foreach ($d in $lab.Disks)
+        {
+            $tmpList.Add($d)
+        }
+        $tmpList.Export($lab.DiskDefinitionFiles[0].Path)
+    }
     $lab.Machines.Clear()
     $lab.Disks.Clear()
 

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -88,7 +88,7 @@ function Add-LabAzureSubscription
         [timespan]
         $AutoShutdownTime,
 
-        [TimeZoneInfo]
+        [string]
         $AutoShutdownTimeZone,
 
         [switch]$PassThru,

--- a/AutomatedLab/AutomatedLabSQL.psm1
+++ b/AutomatedLab/AutomatedLabSQL.psm1
@@ -171,7 +171,18 @@ GO
                 {
                     $global:setupArguments = ''
                     $fileName = Join-Path -Path 'C:\' -ChildPath (Split-Path -Path $role.Properties.ConfigurationFile -Leaf)
-                    $configurationFileContent = Get-Content $role.Properties.ConfigurationFile | ConvertFrom-String -Delimiter = -PropertyNames Key, Value
+                    $confPath = if ($lab.DefaultVirtualizationEngine -eq 'Azure' -and (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $role.Properties.ConfigurationFile))
+                    {
+                        $blob = Get-LabAzureLabSourcesContent -Path $role.Properties.ConfigurationFile.Replace($labSources,'')
+                        $null = Get-AzStorageFileContent -File $blob -Destination (Join-Path $env:TEMP azsql.ini) -Force
+                        Join-Path $env:TEMP azsql.ini
+                    }
+                    elseif ($lab.DefaultVirtualizationEngine -ne 'Azure' -or ($lab.DefaultVirtualizationEngine -eq 'Azure' -and -not (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $role.Properties.ConfigurationFile)))
+                    {
+                        $role.Properties.ConfigurationFile
+                    }
+
+                    $configurationFileContent = Get-Content $confPath | ConvertFrom-String -Delimiter = -PropertyNames Key, Value
                     Write-PSFMessage -Message ($configurationFileContent | Out-String)
                     try
                     {
@@ -703,9 +714,19 @@ function New-LabSqlAccount
     }
 
     if ($RoleProperties.ContainsKey('ConfigurationFile'))
-    {
-        $config = Get-Content -Path $RoleProperties.ConfigurationFile | Where-Object -FilterScript {-not $_.StartsWith('#') -and $_.Contains('=')}
-        $config = $config -replace '\\', '\\' | ConvertFrom-StringData
+    {        
+        $confPath = if ($lab.DefaultVirtualizationEngine -eq 'Azure' -and (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $RoleProperties.ConfigurationFile))
+        {
+            $blob = Get-LabAzureLabSourcesContent -Path $RoleProperties.ConfigurationFile.Replace($labSources,'')
+            $null = Get-AzStorageFileContent -File $blob -Destination (Join-Path $env:TEMP azsql.ini) -Force
+            Join-Path $env:TEMP azsql.ini
+        }
+        elseif ($lab.DefaultVirtualizationEngine -ne 'Azure' -or ($lab.DefaultVirtualizationEngine -eq 'Azure' -and -not (Test-LabPathIsOnLabAzureLabSourcesStorage -Path $RoleProperties.ConfigurationFile)))
+        {
+            $RoleProperties.ConfigurationFile
+        }
+
+        $config = (Get-Content -Path $confPath) -replace '\\', '\\' | ConvertFrom-String -Delimiter = -PropertyNames Key, Value
 
         if (($config | Where-Object Key -eq SQLSvcAccount) -and ($config | Where-Object Key -eq SQLSvcPassword))
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Enhancements
 
+- Restart-LabVm stability on Azure improved
+  - Does not check event log any longer but uses CIM instead to check if the reboot was successfully executed
+
 ### Bugs
 
 - Enable/Disable-LabMachineAutoShutdown now work more intuitively
@@ -12,6 +15,7 @@
 - Fixed a display bug. When no IP address space was added to a virtual network, 0.0.0.0 was shown instead of the actual IP.
 - New-LabADSubnet threw 'Cannot convert this format' when DCs are only connected to an external adapter.
 - New-LabADSubnet was not called if there is only a RootDC defined.
+- Handling SQL inis when on Azure now actually working by referring to
 
 ## 5.39.0 (2021-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Restart-LabVm stability on Azure improved
   - Does not check event log any longer but uses CIM instead to check if the reboot was successfully executed
+- Azure managed disks now actually support all the parameters that Add-LabDiskDefinition exposes
 
 ### Bugs
 

--- a/LabXml/Disks/Disk.cs
+++ b/LabXml/Disks/Disk.cs
@@ -18,6 +18,9 @@
 
         public char DriveLetter { get; set; }
 
+        // Specifically used on Azure to properly assign drive letters and partition/format
+        public int Lun { get; set; }
+
         public string FileName
         {
             get


### PR DESCRIPTION
## Description

When installing SQL with an ini file, and the file is stored on labsources share, setup failed. Now we check if the file is supposed to come from cloud lab sources and get the content using `Get-AzStorageFileContent`. 🍸 

The reboot checking on Azure was streamlined by checking for LastBootupTime via CIM. The event log method previously used was sometimes running into timeouts. 🚀 

Fixed the parameter type for the auto shutdown parameters of `Add-LabAzureSubscription` 🕙 

Assigning anything to an Azure managed disk now actually works 🎉 

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
CM-2103 lab on Azure. SQL was installed with the correct ini file

Disks:
```powershell
ipmo automatedlab,automatedlabworker -force
new-labdefinition -name tst260821jhp -defaultvirt azure
Add-LabAzureSubscription -SubscriptionName JHPaaS -DefaultLocationName 'West Europe'
Add-LabDiskDefinition -Name DS1 -DiskSizeInGb 20 -DriveLetter O
Add-LabDiskDefinition -Name DS2 -DiskSizeInGb 20 -DriveLetter U
Add-LabDiskDefinition -Name DS3 -DiskSizeInGb 20 -DriveLetter P -AllocationUnitSize 64kb -UseLargeFRS
Add-LabDiskDefinition -Name DS4 -DiskSizeInGb 20 -SkipInit
Add-LabMachineDefinition -Name Disker -DiskName DS1, DS2, DS3, DS4 -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'
Install-Lab
```