### PR TITLE
Fix wrong path output in Get-LabVhdx

### DIFF
--- a/AutomatedLab/AutomatedLabDisks.psm1
+++ b/AutomatedLab/AutomatedLabDisks.psm1
@@ -335,6 +335,12 @@ function Get-LabVHDX
         $disks = $lab.Disks
     }
 
+    if (-not (Get-LabMachineDefinition -ErrorAction SilentlyContinue))
+    {
+        Import-LabDefinition -Name $lab.Name
+        Import-Lab -Name $lab.Name -NoDisplay -NoValidation
+    }
+
     if ($disks)
     {
         foreach ($disk in $disks)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - New-LabADSubnet was not called if there is only a RootDC defined.
 - Handling SQL inis when on Azure now actually working by referring to
 - Fixed typos and added SkipDeployment to the filter
+- Output of Get-LabVhdx fixed, was reporting wrong path
 
 ## 5.39.0 (2021-08-20)
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Get-LabVhdx now imports definition in case Get-LabMachineDefinition comes up emtpy (i.e. after importing an already deployed lab)

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
