### PR TITLE
Increase timeout for SQL Install job

### DIFF
--- a/AutomatedLab/AutomatedLabSQL.psm1
+++ b/AutomatedLab/AutomatedLabSQL.psm1
@@ -330,7 +330,7 @@ GO
                 }
 
                 $installMachines = $machinesBatch | Where-Object { -not $_.SqlAlreadyInstalled }
-                Wait-LWLabJob -Job $jobs -Timeout 20 -NoDisplay -ProgressIndicator 15 -NoNewLine
+                Wait-LWLabJob -Job $jobs -Timeout 40 -NoDisplay -ProgressIndicator 15 -NoNewLine
                 Dismount-LabIsoImage -ComputerName $machinesBatch -SupressOutput
                 Restart-LabVM -ComputerName $installMachines -NoDisplay
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

I experienced the following error while attempting to install SQL 2012 SP1. Here is where I found the timeout was having issues:
```
Wait-LWLabJob : Timeout while waiting for job 203
At C:\Program Files\WindowsPowerShell\Modules\AutomatedLab\5.39.0\AutomatedLabSQL.psm1:322 char:17
+ ...             Wait-LWLabJob -Job $jobs -Timeout 20 -NoDisplay -Progress ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Wait-LWLabJob
Wait-LWLabJob : Timeout while waiting for job 203
At C:\Program Files\WindowsPowerShell\Modules\AutomatedLab\5.39.0\AutomatedLabSQL.psm1:322 char:17
+ ...             Wait-LWLabJob -Job $jobs -Timeout 20 -NoDisplay -Progress ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Wait-LWLabJob
```

After extending the timeout to **_40_** from **_20_**, the installation **succeeded** and I was not shown any error for exceeding the timeout.

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
As shown in the following picture, there is no longer an error when installing SQL 2012 SP1:
![no_more_error](https://user-images.githubusercontent.com/63755224/134779848-96121f3a-817a-4b93-a313-d766d9369273.png)

