### PR TITLE
Fixing issue with additional disks on Azure

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -548,7 +548,7 @@ function Import-Lab
         try
         {
             $Script:data.Disks = $importMethodInfo.Invoke($null, $Script:data.DiskDefinitionFiles[0].Path)
-            $Script:data.Disks = Get-LabVHDX -All
+            if ($script:lab.DefaultVirtualizationEngine -eq 'HyperV') { $Script:data.Disks = Get-LabVHDX -All }
 
             if ($Script:data.DiskDefinitionFiles.Count -gt 1)
             {

--- a/AutomatedLab/AutomatedLabDisks.psm1
+++ b/AutomatedLab/AutomatedLabDisks.psm1
@@ -319,6 +319,12 @@ function Get-LabVHDX
     Write-LogFunctionEntry
 
     $lab = Get-Lab
+
+    if ($lab.DefaultVirtualizationEngine -ne 'HyperV') # We should not even be here!
+    {
+        return
+    }
+
     if (-not $lab)
     {
         Write-Error 'No definitions imported, so there is nothing to do. Please use Import-Lab first'

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -1881,11 +1881,11 @@ function Get-LabVM
             $result
         }
         
-        foreach ($machine in $result)
+        foreach ($machine in ($result | Where-Object HostType -eq 'HyperV'))
         {
             if ($machine.Disks.Count -gt 1)
             {
-                $machine.Disks = Get-LabVHDX -Name $machine.Disks.Name
+                $machine.Disks = Get-LabVHDX -Name $machine.Disks.Name -ErrorAction SilentlyContinue
             }
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 ### Bugs
+- Fixing issue with data disks on Azure
 
 ## 5.40.0 (2021-10-13)
 


### PR DESCRIPTION
## Description

On some occasions, Get-LabVHDX was executed in an Azure lab and throwing errors. Now, Get-LabVHDX returns $null when on Azure

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Testing with a colleague, lab deployment containing several disk definitions, always kept going back to Get-LabVhdx.