### PR TITLE
Added 'DoNotUseCredSsp' as CredSsp might now be ready when this function is called

### DIFF
--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -2447,7 +2447,7 @@ function Copy-LabALCommon
             {
                 'full'
             }
-        } -ComputerName $vm -NoDisplay -IgnoreAzureLabSources -PassThru |
+        } -ComputerName $vm -NoDisplay -IgnoreAzureLabSources -DoNotUseCredSsp -PassThru |
         Add-Member -MemberType NoteProperty -Name ComputerName -Value $vm -Force -PassThru
     }
 
@@ -2457,7 +2457,7 @@ function Copy-LabALCommon
 
     if ($coreChild -and @(Invoke-LabCommand -ScriptBlock{
                 Get-Item -Path '/ALLibraries/core/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
-    } -ComputerName $coreChild.ComputerName -IgnoreAzureLabSources -NoDisplay -PassThru).Count -ne $coreChild.Count)
+    } -ComputerName $coreChild.ComputerName -IgnoreAzureLabSources -NoDisplay -DoNotUseCredSsp -PassThru).Count -ne $coreChild.Count)
     {
         $coreLibraryFolder = Join-Path -Path $libLocation -ChildPath $coreChild[0]
         Copy-LabFileItem -Path $coreLibraryFolder -ComputerName $coreChild.ComputerName -DestinationFolderPath '/ALLibraries' -UseAzureLabSourcesOnAzureVm $false
@@ -2465,7 +2465,7 @@ function Copy-LabALCommon
 
     if ($fullChild -and @(Invoke-LabCommand -ScriptBlock {
                 Get-Item -Path '/ALLibraries/full/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
-    } -ComputerName $fullChild.ComputerName -IgnoreAzureLabSources -NoDisplay -PassThru).Count -ne $fullChild.Count)
+    } -ComputerName $fullChild.ComputerName -IgnoreAzureLabSources -NoDisplay -DoNotUseCredSsp -PassThru).Count -ne $fullChild.Count)
     {
         $fullLibraryFolder = Join-Path -Path $libLocation -ChildPath $fullChild[0]
         Copy-LabFileItem -Path $fullLibraryFolder -ComputerName $fullChild.ComputerName -DestinationFolderPath '/ALLibraries' -UseAzureLabSourcesOnAzureVm $false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bugs
 - Fixing issue with data disks on Azure
+- Fixed a connection bug in 'Copy-LabALCommon' with CredSsp
 
 ## 5.40.0 (2021-10-13)
 


### PR DESCRIPTION
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
DscWorkshop