### PR TITLE
add new columns to TaggingData table and view of DSC Pullserver database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Performance improvements of DSC Pullserver reports from DscWorkshop
   - precalculation of values from JSON based status reports at insert time 
 - Added 2022 and Win11 to Azure image name table
+- Add new columns to TaggingData table and view of DSC Pullserver database.
 
 ### Bugs
 - Fixing issue with data disks on Azure

--- a/LabSources/PostInstallationActivities/SetupDscPullServer/CreateDscSqlDatabase.ps1
+++ b/LabSources/PostInstallationActivities/SetupDscPullServer/CreateDscSqlDatabase.ps1
@@ -238,7 +238,9 @@ CREATE TABLE [dbo].[TaggingData](
 	[AgentId] [nvarchar](255) NOT NULL,
 	[Environment] [nvarchar](255) NULL,
 	[BuildNumber] [int] NOT NULL,
-	[GitCommitId] [nvarchar](255) NOT NULL,
+	[GitCommitId] [nvarchar](255) NULL,
+	[NodeVersion] [nvarchar](50) NULL,
+	[NodeRole] [nvarchar](50) NULL,
 	[Version] [nvarchar](50) NOT NULL,
 	[BuildDate] [datetime] NOT NULL,
 	[Timestamp] [datetime] NOT NULL,
@@ -573,6 +575,8 @@ SELECT rg.NodeName
       ,tg.[Environment]
       ,tg.[BuildNumber]
       ,tg.[GitCommitId]
+      ,tg.[NodeVersion]
+      ,tg.[NodeRole]
       ,tg.[Version]
       ,tg.[BuildDate]
       ,tg.[Timestamp]


### PR DESCRIPTION
## Description

Add new columns to TaggingData table and view of DSC Pullserver database.
All columns are nullable and so the change is backward compatible.
The change is required to support additional attributes in DscTagging from CommonTasks (see PullRequest at https://github.com/dsccommunity/CommonTasks/pull/130)

- [X] - I have tested my changes.  
- [X] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [X] - The PR has a meaningful title.  
- [X] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [X] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

The change was tested in our AutomatedLab environment with 10 VMs.
