### PR TITLE
Custom roles will not pick up configured properties

### DIFF
--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -679,7 +679,7 @@ function Invoke-LabCommand
                 }
 
                 $scriptFullName = Join-Path -Path $param.DependencyFolderPath -ChildPath $param.ScriptFileName
-                if ($item.Properties -and (Test-Path -Path $scriptFullName))
+                if ($item.SerializedProperties -and (Test-Path -Path $scriptFullName))
                 {
                     $script = Get-Command -Name $scriptFullName
                     $temp = Sync-Parameter -Command $script -Parameters ($item.SerializedProperties | ConvertFrom-PSFClixml -ErrorAction SilentlyContinue)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Fixing issue with data disks on Azure
 - Fixed a connection bug in 'Copy-LabALCommon' with CredSsp
 
+- CustomRole does not pick up configured properties
+
 ## 5.40.0 (2021-10-13)
 
 ### Enhancements


### PR DESCRIPTION
## Description

When using a custom role with `Get-LabPostInstallationActivity` and `-PostInstallationActivity` no configured properties are picked up.

I created a very simple lab setup:

**Lab script**
```
New-LabDefinition -Name "TestCR01" -DefaultVirtualizationEngine HyperV

$post = Get-LabPostInstallationActivity -CustomRole CR01 -Properties @{
	p1 = "success" 
}
Add-LabMachineDefinition -Name "TestCR01-win10" -OperatingSystem 'Windows 10 Enterprise Evaluation' -PostInstallationActivity $post

Install-Lab
```

**Custom Role script, placed in `$labSources\CustomRoles\CR01\CR01.ps1`**

```
param(
    [Parameter(Mandatory)]
    [string]$p1
)

echo $p1 > "C:\$((Get-Item $PSCommandPath).Basename).out.txt"
```

Role-script is copied properly but failed to execute since the job waited for interactive input due to the mandatory parameter that AutomatedLab did not send.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

With the above mentioned setup script output file was present after the change and had the correct content.