### PR TITLE
Docs tidy up - clarify, fix typos and fix formatting

### DIFF
--- a/Help/Wiki/Basic/createnewlab.md
+++ b/Help/Wiki/Basic/createnewlab.md
@@ -13,11 +13,11 @@ New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV -VmPath D:\
 
 During the lab deployment, AL exports your definitions into XML files. By default these are stored in 'C:\Users\<username>\Documents\AutomatedLab-Labs'. If you close the PowerShell session after the lab deployment, you can import the lab again using the Import-Lab cmdlet.
 
-!https://cloud.githubusercontent.com/assets/11280760/20555110/6f12f9a8-b160-11e6-863a-bac119eac71b.png!
+![Lab Definition Files](https://cloud.githubusercontent.com/assets/11280760/20555110/6f12f9a8-b160-11e6-863a-bac119eac71b.png)
 
 The virtual machines are stored in a different folder. AL tries to determine the fastest drive and uses the cmdlet Get-DiskSpeed for this. AL tries to avoid using the system drive. The speed test runs only once and results are cached. However if you plug in a new drive, AL takes it into consideration and measure its speed.
 
-!https://cloud.githubusercontent.com/assets/11280760/20642671/252e839a-b415-11e6-8c80-307f7662d64a.JPG!
+![VM Folder](https://cloud.githubusercontent.com/assets/11280760/20642671/252e839a-b415-11e6-8c80-307f7662d64a.JPG)
 
 Starting with version 5.23, each lab deployment will not only be validated before the deployment but also
 when the installation is finished. To enable the deployment validation, you need to install Pester 5.0.1+.

--- a/Help/Wiki/Basic/createnewlab.md
+++ b/Help/Wiki/Basic/createnewlab.md
@@ -3,7 +3,7 @@ Creating your lab starts with New-LabDefinition. This cmdlet creates a container
 It is mandatory to define the name of the lab and the virtualization engine. So far AL supports Hyper-V and Azure.
 
 ``` powershell
-New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV -Path D:\AutomatedLabs -VmPath D:\AutomatedLab-VMs
+New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV -VmPath D:\AutomatedLab-VMs
 ```
 
 - **New-LabDefinition** Parameters

--- a/Help/Wiki/Basic/createnewlab.md
+++ b/Help/Wiki/Basic/createnewlab.md
@@ -9,7 +9,6 @@ New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV -Path D:\Au
 - **New-LabDefinition** Parameters
   - **Name**: The name if the lab to create. The name must be unique.
   - **DefaultVirtualizationEngine**: HyperV for local deployments or Azure to deploy into the cloud.
-  - **Path**: This is the path were the lab files will go (screenshot 1). If not defined the labs will be stored in "C:\Users\<username>\Documents\AutomatedLab-Labs".
   - **VmPath**: This is where AL creates the virtual machines. If this path is not defined AL will choose the fastest drive by trying not to use the system drive and create a folder there names "AutomatedLab-VMs".
 
 During the lab deployment, AL exports your definitions into XML files. By default these are stored in 'C:\Users\<username>\Documents\AutomatedLab-Labs'. If you close the PowerShell session after the lab deployment, you can import the lab again using the Import-Lab cmdlet.

--- a/Help/Wiki/Basic/exchangedata.md
+++ b/Help/Wiki/Basic/exchangedata.md
@@ -17,7 +17,7 @@ The following command copies a file to the specified machine trying SMB first an
 Copy-LabFileItem -Path 'D:\170630 AL' -ComputerName wServer1 -DestinationFolderPath C:\Temp
 ```
 
-The following samples are Using the PSFileTransfer cmdlets directly. These do not support SMB and send the files over the PSSession right away. The Force switch creates the target folder if not already existing.
+The following samples are using the PSFileTransfer cmdlets directly. These do not support SMB and send the files over the PSSession right away. The Force switch creates the target folder if not already existing.
 ```
 Note: It is recommended to use Copy-LabFileItem as SMB is much faster
 then sending a byte array over WinRM.
@@ -41,7 +41,7 @@ Receive-Directory -SourceFolderPath 'C:\Program Files\Wireshark' -DestinationFol
 ## Internals
 Hyper-V machines are usually reachable from the host by SMB. However, it is not sure or pretty unlikely if the other way works as well, accessing the host machines from the VM.
 
-Copy-LabFileItem always tries SMB first. If this does not work, it uses the PowerShell session and transfers the file as a Byte[]. Reading and writing a file as a byte array, serializing the by byte array and sending it over the network is much slower than SMB but totally sufficient for most scenarios. If you transfer large files, make sure SMB works from the host to the VMs.
+Copy-LabFileItem always tries SMB first. If this does not work, it uses the PowerShell session and transfers the file as a Byte[]. Reading and writing a file as a byte array, serializing the byte array and sending it over the network is much slower than SMB but totally sufficient for most scenarios. If you transfer large files, make sure SMB works from the host to the VMs.
 
 ```
 Note: All the functions of the module PSFileTransfer do not rely on other modules

--- a/Help/Wiki/Basic/gettingstarted.md
+++ b/Help/Wiki/Basic/gettingstarted.md
@@ -39,11 +39,13 @@ The just press the run button or hit F5 to start the deployment.
 
 This is what is going to happen. Many things happen automatically but can be customized:
 * AutomatedLab starts a new lab named "GettingStarted". The lab defininition will be stored in C:\ProgramData\AutomatedLab\Labs\GettingStarted. The location can be customized ["Advanced AutomatedLab Configurations"](../Advanced/automatedlabconfig.md) with the setting LabAppDataRoot.
-* AL will update download the SysInternals tools and put them into the LabSources folder.
-* AL looks for an ISO file that contains the specified OS. If the ISO file cannot be found, the deployment stops.
-* AL adds the one and only machine to the lab and recognizes that no network was defined. In this case, AL creates a virtual switch automatically and uses an free IP range.
-* The AL measures the disk speed and chooses the fastet drive for the lab, as no location is defined in the call to "New-LabDefinition". In my case, it chooses D. Measuring is done only once and the result is cached.
-* Then the actual deployment starts. AL creates  
+
+  * AL will update download the SysInternals tools and put them into the LabSources folder.
+  * AL looks for an ISO file that contains the specified OS. If the ISO file cannot be found, the deployment stops.
+  * AL adds the one and only machine to the lab and recognizes that no network was defined. In this case, AL creates a virtual switch automatically and uses an free IP range.
+  * The AL measures the disk speed and chooses the fastet drive for the lab, as no location is defined in the call to "New-LabDefinition". In my case, it chooses D. Measuring is done only once and the result is cached.
+  * Then the actual deployment starts. AL creates
+
     1. The virtual switch
     2. Then it creates the a base image for the operating system that is shared among all machines with the same OS.
     3. Afterwards the VM is created and started

--- a/Help/Wiki/Basic/install.md
+++ b/Help/Wiki/Basic/install.md
@@ -18,7 +18,7 @@ Set-PSFConfig -Module AutomatedLab -Name LabAppDataRoot -Value /home/youruser/.a
 # Prepare sample content - modify to your needs
 
 # Windows
-New-LabSourcesFolder -Drive C
+New-LabSourcesFolder -DriveLetter C
 
 # Linux
 Set-PSFConfig -Module AutomatedLab -Name LabSourcesLocation -Value /home/youruser/labsources -PassThru | Register-PSFConfig

--- a/Help/Wiki/Basic/installsoftware.md
+++ b/Help/Wiki/Basic/installsoftware.md
@@ -1,14 +1,14 @@
 ## Summary
-Installing software on lab machines is almost as easy as installing <TODO Windows Features>.  And there are similar challenges. But additionally, there to the challenges some installers have an extra demand, like the .net 4.5.2 package that cannot be installed remotely. Like for installing Windows Features AutomatedLab tries to provide a solution that makes this task as simple as possible. It does not matter if the **installation file is already on the VM or on your host machine**. And you do not have to care whether it is a **.exe, .msi or .msu** file, AL will handle the complexity for you. And there is also a very convenient way to work **install stuff from ISOs** mounted to the lab VMs.
+Installing software on lab machines is almost as easy as installing Windows Features.  And there are similar challenges. But additional to the challenges, some installers have an extra demand, like the .NET 4.5.2 package that cannot be installed remotely. Like when installing Windows Features, AutomatedLab tries to provide a solution that makes this task as simple as possible. It does not matter if the **installation file is already on the VM or on your host machine**. And you do not have to care whether it is a **.exe, .msi or .msu** file, AL will handle the complexity for you. And there is also a very convenient way to **install stuff from ISOs** mounted to the lab VMs.
 
 ### Install-LabSoftwarePackage Introduction
 The cmdlet that handles the installation is Install-LabSoftwarePackage. It is designed to work in various scenarios that will be discussed in this article.
 Internally, it uses Invoke-LabCommand again to connect to the lab VMs by using the credentials known to the lab. The files are copied to the lab VMs using Copy-LabFileItem.
 
 ### Install-LabSoftwarePackage Usage
-#### Installing an package that is on the host machine
+#### Installing a package that is on the host machine
 A very simple demonstration of how the cmdlet can help, is installing Notepad++ on a lab VM. Note that $labSources always points to the LabSources folder that is created by AL, so you do not have to provide the full path. This also works on Azure. A lab VM hosted on Azure accesses the share hosted on Azure by default. The Azure LabSources share can be synced with the local one.
-The next command copes the Notepad++.exe file to the VM and invokes the installer. The package must support a silent installation. For Notepad++, you can switch to the silent mode by providing the argument “/S” (case-sensitive).
+The next command copies the Notepad++.exe file to the VM and invokes the installer. The package must support a silent installation. For Notepad++, you can switch to the silent mode by providing the argument “/S” (case-sensitive).
 ``` PowerShell
 Install-LabSoftwarePackage -ComputerName Server1 -Path $labSources\SoftwarePackages\Notepad++.exe -CommandLine /S
 ```
@@ -17,7 +17,7 @@ If you want to install the same package to all machines in a lab, regardless if 
 Install-LabSoftwarePackage -ComputerName (Get-LabVM) -Path $labSources\SoftwarePackages\Notepad++.exe -CommandLine /S
 ```
 #### Installing a package that is on the host machine as scheduled job
-Some software packages are creating headaches, like the .net Framework 4.5.2. The package calls the Windows Update Service which checks if it is called from remote by checking the token for the NETWORK RID, and cancels the installation if that’s the case.
+Some software packages are creating headaches, like the .NET Framework 4.5.2. The package calls the Windows Update Service which checks if it is called remotely by checking the token for the NETWORK RID, and cancels the installation if that’s the case.
 Install-LabSoftwarePackage offers the switch AsScheduledJob to be able to start the installation remotely which then actually runs locally.
 The next example shows how to install .net 4.5.2 on a VM, restart the VM and then install the Windows Management Framework 5.1.
 

--- a/Help/Wiki/Basic/invokelabcommand.md
+++ b/Help/Wiki/Basic/invokelabcommand.md
@@ -19,7 +19,7 @@ Invoke-LabCommand -ScriptBlock { Get-Date } -ComputerName (Get-LabVM)
 ```
 ### Making local variables and functions available remotely
 If you have functions and variables defined locally, they are not available in the remote session. With the using scope (PowerShell 3+) you can access local variables in the remote session but it requires changing the code by adding “$using:” to each variable you want to retrieve from the local scope. Hence this code will no longer work locally which makes debugging your code locally on the VM much harder.
-Invoke-LabCommand provides the two parameters “Variable” and “Function”. All the variables and functions given here are pushed to the remove session making them available there.
+Invoke-LabCommand provides the two parameters “Variable” and “Function”. All the variables and functions given here are pushed to the remote session making them available there.
 The following sample demonstrates this by having a local function that just returns the value of a local variable. Invoke-LabCommand runs the same code on a remote machine without changing anything.
 The code you may run locally:
 ``` PowerShell

--- a/Help/Wiki/Basic/mountazureisos.md
+++ b/Help/Wiki/Basic/mountazureisos.md
@@ -1,13 +1,12 @@
-Mounting ISO files on Azure is as simple as calling the existing cmdlet ``Mount-LabIsoImage``. The only difference is, that the ISO image file path lies on Azure. To find out which images are accessible in your AutomatedLab storage account you can do the following:  
-``
+Mounting ISO files on Azure is as simple as calling the existing cmdlet ``Mount-LabIsoImage``. The only difference is that the ISO image file path lies on Azure. To find out which images are accessible in your AutomatedLab storage account you can do the following:
+
     Login-AzureRmAccount
     (Get-LabAzureLabSourcesContent -RegexFilter \.iso).FullName
-``
 
-When mounting the ISO file, be sure to specify -PassThru to be able to use the drive letter that was used to mount the ISO in later commands:  
+When mounting the ISO file, be sure to specify `-PassThru` to be able to use the drive letter that was used to mount the ISO in later commands:
 
     $mountedVolume = Mount-LabIsoImage -IsoPath https://some/azure/path.iso -ComputerName DC1 -PassThru
-    
+
     Invoke-LabCommand DC1 -ScriptBlock {
     param
     (

--- a/Help/Wiki/Basic/networksandaddresses.md
+++ b/Help/Wiki/Basic/networksandaddresses.md
@@ -18,6 +18,7 @@ To manually create network definitions in order to have specific network address
 ```
 
 Additionally, the parameters AzureProperties and HyperVProperties can be used to pass parameter hashtables. The following are valid keys that can be used as properties for AzureProperties:
+
 * SubnetName: The name of the subnet to create in the virtual network. AL does not segment virtual networks into subnets. One virtual network per network definition will be created
 * SubnetAddressPrefix: The address prefix (e.g. 24) of the subnet that will be created.
 * LocationName: The Azure location name (e.g. westeurope). Bear in mind that this should not differ from your lab's default location.
@@ -25,6 +26,7 @@ Additionally, the parameters AzureProperties and HyperVProperties can be used to
 * ConnectToVnets: Connections to other VNETs by leveraging VNET peering. When connecting two or more lab networks through this parameter, please also specifiy this for all additional network definitions
 
 For HyperV, the following properties are valid:
+
 * SwitchType: Internal or External. Defaults to internal. If External is specified, AdapterName needs to be set as well
 * AdapterName: The network adapter of the OS that will bridge the connection to the external network
 

--- a/Help/Wiki/Basic/synclabsources.md
+++ b/Help/Wiki/Basic/synclabsources.md
@@ -1,18 +1,16 @@
-While creating an Azure-based lab is very easy and only requires to set the default virtualization engine to Azure instead of HyperV not all features are readily available from the start. To fully make use of Azure, you should also synch your lab sources with Azure.  
-Doing so only requires a single line of code:  
-`
-Sync-LabAzureLabSources
-`
+While creating an Azure-based lab is very easy and only requires to set the default virtualization engine to Azure instead of HyperV. Not all features are readily available from the start. To fully make use of Azure, you should also synch your lab sources with Azure. Doing so only requires a single line of code: `Sync-LabAzureLabSources`.
 
 This by default will synchronize your entire local lab sources folder with a pre-created Azure file share called labsources in the resource group AutomatedLabSources and the lab's randomly-named storage account. This file share will automatically be mapped on each virtual machine.  
 Operating system images are automatically skipped in the synchronization process as they are readily available on Azure and are not being used.
 
-During the lab initialization the builtin variable $labsources will be automatically updated to point to your Azure lab sources location if you are deploying an Azure-based lab. There is no need to declare the variable in any script, as it is dynamically calculated to match the default virtualization engine.
+During the lab initialization the builtin variable $labSources will be automatically updated to point to your Azure lab sources location if you are deploying an Azure-based lab. There is no need to declare the variable in any script, as it is dynamically calculated to match the default virtualization engine.
 
 To skip large files or entire ISOs for certain products like e.g. Exchange or Skype for Business the following parameters are available:
+
 * SkipIsos: This switch parameter indicates that all ISO files should be skipped.
 * MaxFileSizeInMb: This parameter takes an integer value indicating the maximum size of the files to synch.
 
-Now you can simply use the other cmdlets provided by AutomatedLab to access files from the file share:  
+Now you can simply use the other cmdlets provided by AutomatedLab to access files from the file share:
+
 * `$postInstallActivity = Get-LabPostInstallationActivity -ScriptFileName PrepareRootDomain.ps1 -DependencyFolder $labSources\PostInstallationActivities\PrepareRootDomain`
 * `Install-LabSoftwarePackage -ComputerName $machines -Path $labSources\SoftwarePackages\Notepad++.exe -CommandLine /S -AsJob`

--- a/Help/Wiki/Roles/roles.md
+++ b/Help/Wiki/Roles/roles.md
@@ -8,7 +8,7 @@ Add-LabMachineDefinition -Name CA1 -Roles CaRoot, Routing
 Add-LabMachineDefinition -Name Web1 -Roles WebServer
 ```
 
-Many roles offer options for customization. The options are documented in the role documentation. If you want to define a customized role, use the cmdlet Get-LabMachineRoleDefinition which takes two parameters, the role and properties. The properties parameter takes a hashtabe.
+Many roles offer options for customization. The options are documented in the role documentation. If you want to define a customized role, use the cmdlet Get-LabMachineRoleDefinition which takes two parameters, the role and properties. The properties parameter takes a hashtable.
 If you want to define the role FirstChildDC, you can leave everything to default / automatics or go with your own definition.
 ```powershell
 $role = Get-LabMachineRoleDefinition -Role FirstChildDC -Properties @{ ParentDomain = 'vm.net'; NewDomain = 'a'; DomainFunctionalLevel = 'Win2012R2' }


### PR DESCRIPTION
## Description

This is my first time using AutomatedLab, so I was going through the [docs](https://automatedlab.org/en/latest/) from the start to the end and noticed some things that are incorrect, some typos and formatting errors I wanted to fix.

There are a number of commits in this PR as I did them as I went along. I'm happy to squash and force push if that would make it easier. However, this [commit](https://github.com/AutomatedLab/AutomatedLab/commit/e23691c8f51515ac7077cd1fa7e661ce3f518965) and this [one](https://github.com/AutomatedLab/AutomatedLab/commit/78356c1846f6d2e54a339ff1684082b78ba82730) have a fuller description of why I made the changes that would be useful to have for context.

Please describe your changes in detail, unless the title is already descriptive enough.

- [ ] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [x] Documentation

## How was the change tested?

The only changes that needed testing were the formatting ones - to make sure they worked. I tested this using the markdown preview in VS Code. Although to be fair, the doc rendered properly before my changes in VS Code. So, I'm assuming the process to get it to ReadTheDocs is messing things up OR ReadTheDocs is stricter than VS Code. Regardless, it renders as it should.