### PR TITLE
Remove Set-LabAutoLogon help as its not a cmdlet

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,7 +139,6 @@ nav:
 - Version history: https://github.com/AutomatedLab/AutomatedLab/blob/master/CHANGELOG.md
 - Module help:
   - AutomatedLab:
-    - Set-LabAutoLogon: AutomatedLab/en-us/Set-LabAutoLogon.md
     - Add-LabAzureSubscription: AutomatedLab/en-us/Add-LabAzureSubscription.md
     - Add-LabCertificate: AutomatedLab/en-us/Add-LabCertificate.md
     - Add-LabVMUserRight: AutomatedLab/en-us/Add-LabVMUserRight.md


### PR DESCRIPTION
## Description

In the menu of the site the cmdlet `Set-LabAutoLogn` is available to click on, however it ends up in a broken page.

I believe the reason for this is that `Set-LabAutoLogon` is not actually a cmdlet but an alias of `Enable-LabAutoLogon` and it therefore doesn't have any help generated for it and therefore this page doesn't render correctly.

The best thing to do is remove the cmdlet.

Please describe your changes in detail, unless the title is already descriptive enough.

- [ ] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [x] Documentation

## How was the change tested?
This change hasn't been tested as I don't have a way to do so. I am hoping that the reviewer will know the implications of removing this line.