### PR TITLE
Fixes 1273, 'Show-LabDeploymentSummary' throws if no lab data present

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -3259,6 +3259,12 @@ function Show-LabDeploymentSummary
         [switch]$Detailed
     )
 
+    if (-not (Get-Lab -ErrorAction SilentlyContinue))
+    {
+        Write-ScreenInfo "There is no lab information available in the current PowerShell session. Deploy a lab with AutomatedLab or import an already deployed lab with the 'Import-Lab' cmdlet."
+        return
+    }
+
     $ts = New-TimeSpan -Start $Global:AL_DeploymentStart -End (Get-Date)
     $hoursPlural = ''
     $minutesPlural = ''
@@ -3268,7 +3274,6 @@ function Show-LabDeploymentSummary
     if ($ts.minutes -gt 1) { $minutesPlural = 's' }
     if ($ts.Seconds -gt 1) { $secondsPlural = 's' }
 
-    $lab = Get-Lab
     $machines = Get-LabVM -IncludeLinux
 
     Write-ScreenInfo -Message '---------------------------------------------------------------------------'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixing issue with Get-LabAzureAvailableRoleSize by filtering earlier
 - Corrected various issues in the SharePoint role installation script.
 - Corrected incorrect HERE string in the PrepareRootDomain script
+- Fixes #1273: Error calling 'Show-LabDeploymentSummary'.
 
 ## 5.41.0 (2022-01-31)
 


### PR DESCRIPTION
## Description

Fixes #1273.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Called cmdlet in various scenarios.