### PR TITLE
Fix DelayBetweenMachines

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1287,7 +1287,7 @@ function Install-Lab
             minutes."
         }
 
-        if (-not $DelayBetweenComputers)
+        if ($null -eq $DelayBetweenComputers)
         {
             $hypervMachineCount = (Get-LabVM -IncludeLinux | Where-Object HostType -eq HyperV).Count
             if ($hypervMachineCount)
@@ -1298,8 +1298,7 @@ function Install-Lab
             else
             {
                 $DelayBetweenComputers = 0
-            }
-            
+            }            
         }
 
         Write-ScreenInfo -Message 'Waiting for machines to start up...' -NoNewLine

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -312,6 +312,17 @@ function Start-LabVM
         if ($hypervVMs)
         {
             Start-LWHypervVM -ComputerName $hypervVMs -DelayBetweenComputers $DelayBetweenComputers -ProgressIndicator $ProgressIndicator -PreDelaySeconds $PreDelaySeconds -PostDelaySeconds $PostDelaySeconds -NoNewLine:$NoNewline
+            
+            foreach ($vm in $hypervVMs)
+            {
+                $machineMetadata = Get-LWHypervVMDescription -ComputerName $vm.ResourceName
+                if (($machineMetadata.InitState -band [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected) -ne [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected)
+                {
+                    Repair-LWHypervNetworkConfig -ComputerName $vm
+                    $machineMetadata.InitState = [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected
+                    Set-LWHypervVMDescription -Hashtable $machineMetadata -ComputerName $vm.ResourceName
+                }
+            }
         }
 
         $azureVms = $vms | Where-Object HostType -eq 'Azure'

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -970,18 +970,9 @@ function Start-LWHypervVM
     {
         $machine = Get-LabVM -ComputerName $Name -IncludeLinux
 
-        $machineMetadata = Get-LWHypervVMDescription -ComputerName $Name.ResourceName
-
         try
         {
             Start-VM -Name $Name.ResourceName -ErrorAction Stop
-
-            if (($machineMetadata.InitState -band [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected) -ne [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected)
-            {
-                Repair-LWHypervNetworkConfig -ComputerName $Name
-                $machineMetadata.InitState = [AutomatedLab.LabVMInitState]::NetworkAdapterBindingCorrected
-                Set-LWHypervVMDescription -Hashtable $machineMetadata -ComputerName $Name.ResourceName
-            }
         }
         catch
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Corrected incorrect HERE string in the PrepareRootDomain script
 - Fixes #1273: Error calling 'Show-LabDeploymentSummary'.
 - Fix bug in New-LabPS/CIMSession where the IP address was not used even though it was preferred
+- DelayBetweenComputers was ignored
 
 ## 5.41.0 (2022-01-31)
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

To actually have a delay between starting the VMs, which was intended to relieve stress on the disk, I have moved Repair-LWHyperVNetworkConfig into Start-LabVm. The time-consuming cmdlet is now called after the start of the VMs, each with their delay, so that all VMs can start at the same time if desired.

We had this at a client who found the starting process for a large lab to be too long.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
`Install-Lab -Delay 0`