### PR TITLE
Fixes error handline in 'Set-DscLocalConfigurationManagerConfiguration'

### DIFF
--- a/AutomatedLab/AutomatedLabDsc.psm1
+++ b/AutomatedLab/AutomatedLabDsc.psm1
@@ -799,12 +799,12 @@ function Set-LabDscLocalConfigurationManagerConfiguration
 
         try
         {
-            Test-DscConfiguration -ErrorAction Stop
-            Write-Error 'There was a problem resetting the Local Configuration Manger configuration'
+            Test-DscConfiguration -ErrorAction Stop | Out-Null
+            Write-Host 'DSC Local Configuration Manger was set to the new values'
         }
         catch
         {
-            Write-Host 'DSC Local Configuration Manger was set to the new values'
+            Write-Error 'There was a problem resetting the Local Configuration Manger configuration'
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 - Corrected various issues in the SharePoint role installation script.
 - Corrected incorrect HERE string in the PrepareRootDomain script
 - Fixes #1273: Error calling 'Show-LabDeploymentSummary'.
-- Fix bug in New-LabPS/CIMSession where the IP address was not used even though it was preferred
+- Fix bug in New-LabPS/CIMSession where the IP address was not used even though it was preferred.
+- Fixes #1293: Set-DscLocalConfigurationManagerConfiguration throws error when successful.
 
 ## 5.41.0 (2022-01-31)
 


### PR DESCRIPTION
## Description

Fixes #1293: Set-DscLocalConfigurationManagerConfiguration throws error when successful.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Tested `Set-DscLocalConfigurationManagerConfiguration` with local LCM config.
