### PR TITLE
Cluster awareness

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -140,6 +140,7 @@ Set-PSFConfig -Module 'AutomatedLab' -Name WinRmMaxConnections -Value 300 -Valid
 
 #Hyper-V VM Settings
 Set-PSFConfig -Module 'AutomatedLab' -Name SetLocalIntranetSites -Value 'All'  -Initialize -Validation string  -Description 'All, Forest, Domain, None'
+Set-PSFConfig -Module 'AutomatedLab' -Name DoNotAddVmsToCluster -Value $false -Initialize -Validation bool -Description 'Set to true to skip adding VMs to a cluster if AutomatedLab is being run on a cluster node'
 
 #Hyper-V Network settings
 Set-PSFConfig -Module 'AutomatedLab' -Name MacAddressPrefix -Value '0017FB' -Initialize -Validation string -Description 'The MAC address prefix for Hyper-V labs'

--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -66,7 +66,7 @@
         'HostsFile',
         'AutomatedLabUnattended',
         'AutomatedLabNotifications',
-        @{ModuleName='AutomatedLab.Common'; ModuleVersion='2.0.188'; }
+        @{ModuleName='AutomatedLab.Common'; ModuleVersion='2.1.230'; }
         'PSFramework'
         'AutomatedLabTest'
     )

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1478,7 +1478,7 @@ function Remove-Lab
                 $removeMachines = foreach ($machine in $labMachines)
                 {
                     $machineMetadata = Get-LWHypervVMDescription -ComputerName $machine.ResourceName -ErrorAction SilentlyContinue
-                    $vm = Get-VM -Name $machine.ResourceName -ErrorAction SilentlyContinue
+                    $vm = Get-LWHypervVM -Name $machine.ResourceName -ErrorAction SilentlyContinue
                     if (-not $machineMetadata)
                     {
                         Write-Error -Message "Cannot remove machine '$machine' because lab meta data could not be retrieved"
@@ -2961,8 +2961,8 @@ function Update-LabMemorySettings
 
     if ($machines | Where-Object Memory -lt 32)
     {
-        $totalMemoryAlreadyReservedAndClaimed = ((Get-VM -Name $machines.ResourceName -ErrorAction SilentlyContinue) | Measure-Object -Sum -Property MemoryStartup).Sum
-        $machinesNotCreated = $machines | Where-Object { (-not (Get-VM -Name $_.ResourceName -ErrorAction SilentlyContinue)) }
+        $totalMemoryAlreadyReservedAndClaimed = ((Get-LWHypervVM -Name $machines.ResourceName -ErrorAction SilentlyContinue) | Measure-Object -Sum -Property MemoryStartup).Sum
+        $machinesNotCreated = $machines | Where-Object { (-not (Get-LWHypervVM -Name $_.ResourceName -ErrorAction SilentlyContinue)) }
 
         $totalMemoryAlreadyReserved = ($machines | Where-Object { $_.Memory -ge 128 -and $_.Name -notin $machinesNotCreated.Name } | Measure-Object -Property Memory -Sum).Sum
 
@@ -3031,7 +3031,7 @@ function Update-LabMemorySettings
             }
         }
 
-        ForEach ($machine in $machines | Where-Object { $_.Memory -lt 32 -and -not (Get-VM -Name $_.ResourceName -ErrorAction SilentlyContinue) })
+        ForEach ($machine in $machines | Where-Object { $_.Memory -lt 32 -and -not (Get-LWHypervVM -Name $_.ResourceName -ErrorAction SilentlyContinue) })
         {
             $memoryCalculated = ($totalMemory / $totalMemoryUnits * $machine.Memory / 64) * 64
             if ($memoryUsagePrediction -gt $totalMemory)

--- a/AutomatedLab/AutomatedLabDisks.psm1
+++ b/AutomatedLab/AutomatedLabDisks.psm1
@@ -38,12 +38,12 @@ function New-LabBaseImages
             [int]$legacySize = (Get-Vhd -Path $legacyDiskPath).Size / 1GB
             $newName = Join-Path -Path $lab.Target.Path -ChildPath "BASE_$($os.OperatingSystemName.Replace(' ', ''))_$($os.Version)_$($legacySize).vhdx"
             $affectedDisks = @()
-            $affectedDisks += Get-VM | Get-VMHardDiskDrive | Get-VHD | Where-Object ParentPath -eq $legacyDiskPath
-            $affectedDisks += Get-VM | Get-VMSnapshot | Get-VMHardDiskDrive | Get-VHD | Where-Object ParentPath -eq $legacyDiskPath
+            $affectedDisks += Get-LWHypervVM | Get-VMHardDiskDrive | Get-VHD | Where-Object ParentPath -eq $legacyDiskPath
+            $affectedDisks += Get-LWHypervVM | Get-VMSnapshot | Get-VMHardDiskDrive | Get-VHD | Where-Object ParentPath -eq $legacyDiskPath
             
             if ($affectedDisks)
             {
-                $affectedVms = Get-VM | Where-Object {
+                $affectedVms = Get-LWHypervVM | Where-Object {
                     ($_ | Get-VMHardDiskDrive | Get-VHD | Where-Object { $_.ParentPath -eq $legacyDiskPath -and $_.Attached }) -or
                     ($_ | Get-VMSnapshot | Get-VMHardDiskDrive | Get-VHD | Where-Object { $_.ParentPath -eq $legacyDiskPath -and $_.Attached })                
                 }

--- a/AutomatedLab/AutomatedLabHyperV.psm1
+++ b/AutomatedLab/AutomatedLabHyperV.psm1
@@ -14,11 +14,12 @@ function Install-LabHyperV
     if ($hyperVVms)
     {
         $enableVirt = $vms | Where-Object {-not (Get-VmProcessor -VMName $_.ResourceName).ExposeVirtualizationExtensions}
-        if ($null -ne $enableVirt)
+        $vmObjects = Get-LWHypervVM -Name $enableVirt.ResourceName -ErrorAction SilentlyContinue
+        if ($null -ne $vmObjects)
         {
             Stop-LabVm -Wait -ComputerName $enableVirt
-            Set-VMProcessor -VMName $enableVirt.ResourceName -ExposeVirtualizationExtensions $true
-            Get-VMNetworkAdapter -VMName $enableVirt.ResourceName | Set-VMNetworkAdapter -MacAddressSpoofing On
+            $vmObjects | Set-VMProcessor -ExposeVirtualizationExtensions $true
+            $vmObjects | Get-VMNetworkAdapter | Set-VMNetworkAdapter -MacAddressSpoofing On
         }
     }
 

--- a/AutomatedLab/AutomatedLabInternals.psm1
+++ b/AutomatedLab/AutomatedLabInternals.psm1
@@ -763,7 +763,7 @@ function Set-LabVMDescription
 
     $d.WriteXml($xmlWriter)
 
-    Set-VM -Name $ComputerName -Notes $sb.ToString()
+    Get-LWHypervVm -Name $ComputerName -ErrorAction SilentlyContinue | Set-VM -Notes $sb.ToString()
 
     Write-LogFunctionExit
 }

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -47,6 +47,13 @@ function New-LabVM
         {
             $result = New-LWHypervVM -Machine $machine
 
+            $doNotAddToCluster = Get-LabConfigurationItem -Name DoNotAddVmsToCluster -Default $false
+            if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue))
+            {
+                Write-ScreenInfo -Message "Adding $($machine.Name) ($($machine.ResourceName)) to cluster $((Get-Cluster).Name)"
+                Add-ClusterVirtualMachineRole -VMName $machine.ResourceName -Name $machine.ResourceName
+            }
+
             if ('RootDC' -in $machine.Roles.Name)
             {
                 Start-LabVM -ComputerName $machine.Name -NoNewline

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -51,7 +51,7 @@ function New-LabVM
             if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue))
             {
                 Write-ScreenInfo -Message "Adding $($machine.Name) ($($machine.ResourceName)) to cluster $((Get-Cluster).Name)"
-                Add-ClusterVirtualMachineRole -VMName $machine.ResourceName -Name $machine.ResourceName
+                $null = Add-ClusterVirtualMachineRole -VMName $machine.ResourceName -Name $machine.ResourceName
             }
 
             if ('RootDC' -in $machine.Roles.Name)

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1120,7 +1120,7 @@ function Export-LabDefinition
 
         $spaceNeededBaseDisks = ($hypervUsedOperatingSystems | Measure-Object -Property Size -Sum).Sum
         $spaceBaseDisksAlreadyClaimed = ($hypervUsedOperatingSystems | Measure-Object -Property size -Sum).Sum
-        $spaceNeededData = ($hypervMachines | Where-Object { -not (Get-VM -Name $_.ResourceName -ErrorAction SilentlyContinue) }).Count * 2GB
+        $spaceNeededData = ($hypervMachines | Where-Object { -not (Get-LWHypervVM -Name $_.ResourceName -ErrorAction SilentlyContinue) }).Count * 2GB
 
         $spaceNeeded = $spaceNeededBaseDisks + $spaceNeededData - $spaceBaseDisksAlreadyClaimed
 

--- a/AutomatedLabTest/internal/tests/HyperV.tests.ps1
+++ b/AutomatedLabTest/internal/tests/HyperV.tests.ps1
@@ -10,7 +10,7 @@ Describe "[$($Lab.Name)] HyperV" -Tag HyperV {
             {
                 It "[$vm] should have exposed virtualization extension" -TestCases @{vm = $vm } {
             
-                    (Get-VM -Name $vm.ResourceName| Get-VMProcessor).ExposeVirtualizationExtensions | Should -Be $true
+                    (Get-LWHypervVM -Name $vm.ResourceName| Get-VMProcessor).ExposeVirtualizationExtensions | Should -Be $true
                 }
             }
 

--- a/AutomatedLabWorker/AutomatedLabWorker.psd1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psd1
@@ -27,7 +27,7 @@
         'PSFileTransfer',
         @{
             ModuleName    = "AutomatedLab.Common";
-            ModuleVersion = "1.1.87";
+            ModuleVersion = "2.1.230";
         }
     )
 

--- a/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerDisks.psm1
@@ -327,7 +327,7 @@ function Add-LWVMVHDX
         return
     }
 
-    $vm = Get-VM -Name $VMName -ErrorAction SilentlyContinue
+    $vm = Get-LWHypervVM -Name $VMName -ErrorAction SilentlyContinue
     if (-not $vm)
     {
         Write-Error 'VM cannot be found'

--- a/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
@@ -182,7 +182,7 @@ function Remove-LWNetworkSwitch
         return
     }
 
-    if ((Get-LWHypervVM | Get-VMNetworkAdapter | Where-Object {$_.SwitchName -eq $Name} | Measure-Object).Count -eq 0)
+    if ((Get-LWHypervVM -ErrorAction SilentlyContinue | Get-VMNetworkAdapter | Where-Object {$_.SwitchName -eq $Name} | Measure-Object).Count -eq 0)
     {
         try
         {

--- a/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerNetwork.psm1
@@ -182,7 +182,7 @@ function Remove-LWNetworkSwitch
         return
     }
 
-    if ((Get-VM | Get-VMNetworkAdapter | Where-Object {$_.SwitchName -eq $Name} | Measure-Object).Count -eq 0)
+    if ((Get-LWHypervVM | Get-VMNetworkAdapter | Where-Object {$_.SwitchName -eq $Name} | Measure-Object).Count -eq 0)
     {
         try
         {

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -30,7 +30,7 @@ function New-LWHypervVM
 
     $script:lab = Get-Lab
 
-    if (Get-VM -Name $Machine.ResourceName -ErrorAction SilentlyContinue)
+    if (Get-LWHypervVM -Name $Machine.ResourceName -ErrorAction SilentlyContinue)
     {
         Write-ProgressIndicatorEnd
         Write-ScreenInfo -Message "The machine '$Machine' does already exist" -Type Warning
@@ -739,6 +739,34 @@ Stop-Transcript
 }
 #endregion New-LWHypervVM
 
+function Get-LWHypervVM
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCompatibleCmdlets", "", Justification="Not relevant on Linux")]
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    Write-LogFunctionEntry
+
+    $vm = Get-VM -Name $Name -ErrorAction SilentlyContinue
+
+    $doNotAddToCluster = Get-LabConfigurationItem -Name DoNotAddVmsToCluster -Default $false
+    if (-not $vm -and -not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue))
+    {
+        $vm = Get-VM -Name $Name -CimSession (Get-ClusterGroup -Name $Name).OwnerNode.Name
+    }
+
+    if (-not $vm)
+    {
+        throw "No virtual machine $Name found"
+    }
+
+    $vm
+    Write-LogFunctionExit
+}
+
 #region Remove-LWHypervVM
 function Remove-LWHypervVM
 {
@@ -750,28 +778,34 @@ function Remove-LWHypervVM
 
     Write-LogFunctionEntry
 
-    $vm = Get-VM -Name $Name -ErrorAction SilentlyContinue
-    if ($vm)
+    $vm = Get-LWHypervVM -Name $Name -ErrorAction SilentlyContinue
+
+    if (-not $vm) { Write-LogFunctionExit}
+
+    $vmPath = Split-Path -Path $vm.HardDrives[0].Path -Parent
+
+    if ($vm.State -eq 'Saved')
     {
-        $vmPath = Split-Path -Path $vm.HardDrives[0].Path -Parent
-
-        if ($vm.State -eq 'Saved')
-        {
-            Write-PSFMessage "Deleting saved state of VM '$($Name)'"
-            Remove-VMSavedState -VMName $Name
-        }
-        else
-        {
-            Write-PSFMessage "Stopping VM '$($Name)'"
-            Stop-VM -TurnOff -Name $Name -Force -WarningAction SilentlyContinue
-        }
-
-        Write-PSFMessage "Removing VM '$($Name)'"
-        Remove-VM -Name $Name -Force
-
-        Write-PSFMessage "Removing VM files for '$($Name)'"
-        Remove-Item -Path $vmPath -Force -Confirm:$false -Recurse
+        Write-PSFMessage "Deleting saved state of VM '$($Name)'"
+        $vm | Remove-VMSavedState
     }
+    else
+    {
+        Write-PSFMessage "Stopping VM '$($Name)'"
+        $vm | Stop-VM -TurnOff -Force -WarningAction SilentlyContinue
+    }
+
+    Write-PSFMessage "Removing VM '$($Name)'"
+    $vm | Remove-VM -Force
+
+    $doNotAddToCluster = Get-LabConfigurationItem -Name DoNotAddVmsToCluster -Default $false
+    if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue))
+    {
+        $null = Get-ClusterGroup -Name $machine.ResourceName | Remove-ClusterGroup -RemoveResources -Force
+    }
+
+    Write-PSFMessage "Removing VM files for '$($Name)'"
+    Remove-Item -Path $vmPath -Force -Confirm:$false -Recurse
 
     Write-LogFunctionExit
 }
@@ -804,7 +838,7 @@ function Wait-LWHypervVMRestart
     $machines | Add-Member -Name Uptime -MemberType NoteProperty -Value 0 -Force
     foreach ($machine in $machines)
     {
-        $machine.Uptime = (Get-VM -Name $machine.ResourceName).Uptime.TotalSeconds
+        $machine.Uptime = (Get-LWHypervVM -Name $machine.ResourceName).Uptime.TotalSeconds
     }
 
     $vmDrive = ((Get-Lab).Target.Path)[0]
@@ -879,7 +913,7 @@ function Wait-LWHypervVMRestart
 
         foreach ($machine in $machines)
         {
-            $currentMachineUptime = (Get-VM -Name $machine.ResourceName).Uptime.TotalSeconds
+            $currentMachineUptime = (Get-LWHypervVM -Name $machine.ResourceName).Uptime.TotalSeconds
             Write-Debug -Message "Uptime machine '$($machine.ResourceName)'=$currentMachineUptime, Saved uptime=$($machine.uptime)"
             if ($machine.Uptime -ne 0 -and $currentMachineUptime -lt $machine.Uptime)
             {
@@ -972,7 +1006,7 @@ function Start-LWHypervVM
 
         try
         {
-            Start-VM -Name $Name.ResourceName -ErrorAction Stop
+            Get-LWHypervVm -Name $Name.ResourceName | Start-VM -ErrorAction Stop
         }
         catch
         {
@@ -1065,7 +1099,7 @@ function Stop-LWHypervVM
         if ($stopFailures)
         {
             Write-ScreenInfo -Message "Force-stopping VMs: $($stopFailures -join ',')"
-            Stop-VM -Name $stopFailures -Force
+            Get-LWHypervVm -Name $stopFailures | Stop-VM -Force
         }
     }
     else
@@ -1073,16 +1107,7 @@ function Stop-LWHypervVM
         $jobs = @()
         foreach ($name in (Get-LabVm -ComputerName $ComputerName -IncludeLinux).ResourceName)
         {
-            $job = Start-Job -Name "AL_Shutdown_$name" -ScriptBlock {
-                try
-                {
-                    Stop-VM -Name $using:name -Force -ErrorAction Stop
-                }
-                catch
-                {
-                    Write-Error -Exception $_.Exception -TargetObject $using:name
-                }
-            }
+            $job = Get-LWHypervVm -Name $name -ErrorAction SilentlyContinue | Stop-VM -AsJob -Force -ErrorAction Stop
             $job | Add-Member -Name ComputerName -MemberType NoteProperty -Value $name
             $jobs += $job
         }
@@ -1111,7 +1136,7 @@ function Save-LWHypervVM
             [string]$Name
         )
         Write-LogFunctionEntry
-        Save-VM -Name $Name
+        Get-LWHypervVm -Name $Name | Save-VM
         Write-LogFunctionExit
     }
 
@@ -1145,10 +1170,11 @@ function Checkpoint-LWHypervVM
 
     $step1 = {
         param ($Name)
-        if ((Get-VM -Name $Name -ErrorAction SilentlyContinue).State -eq 'Running' -and -not (Get-VMSnapshot -VMName $Name -Name $SnapshotName -ErrorAction SilentlyContinue))
+        $vm = Get-LWHypervVM -Name $Name -ErrorAction SilentlyContinue
+        if ($vm.State -eq 'Running' -and -not ($vm | Get-VMSnapshot -Name $SnapshotName -ErrorAction SilentlyContinue))
         {
-            Suspend-VM -Name $Name -ErrorAction SilentlyContinue
-            Save-VM -Name $Name -ErrorAction SilentlyContinue
+            $vm | Suspend-VM -ErrorAction SilentlyContinue
+            $vm | Save-VM -ErrorAction SilentlyContinue
 
             Write-Verbose -Message "'$Name' was running"
             $Name
@@ -1156,9 +1182,10 @@ function Checkpoint-LWHypervVM
     }
     $step2 = {
         param ($Name)
-        if (-not (Get-VMSnapshot -VMName $Name -Name $SnapshotName -ErrorAction SilentlyContinue))
+        $vm = Get-LWHypervVM -Name $Name -ErrorAction SilentlyContinue
+        if (-not ($vm | Get-VMSnapshot -Name $SnapshotName -ErrorAction SilentlyContinue))
         {
-            Checkpoint-VM -Name $Name -SnapshotName $SnapshotName
+            $vm | Checkpoint-VM -SnapshotName $SnapshotName
         }
         else
         {
@@ -1170,7 +1197,7 @@ function Checkpoint-LWHypervVM
         if ($Name -in $RunningMachines)
         {
             Write-Verbose -Message "Machine '$Name' was running, starting it."
-            Start-VM -Name $Name -ErrorAction SilentlyContinue
+            Get-LWHypervVM -Name $Name -ErrorAction SilentlyContinue | Start-VM -ErrorAction SilentlyContinue
         }
         else
         {
@@ -1231,15 +1258,16 @@ function Remove-LWHypervVMSnapshot
     {
         Start-RunspaceJob -RunspacePool $pool -Argument $n -ScriptBlock {
             param ($n)
+            $vm = Get-LWHypervVM -Name $n
             if ($SnapshotName)
             {
-                $snapshot = Get-VMSnapshot -VMName $n | Where-Object -FilterScript {
+                $snapshot = $vm | Get-VMSnapshot | Where-Object -FilterScript {
                     $_.Name -eq $SnapshotName
                 }
             }
             else
             {
-                $snapshot = Get-VMSnapshot -VMName $n
+                $snapshot = $vm | Get-VMSnapshot
             }
 
             if (-not $snapshot)
@@ -1248,7 +1276,7 @@ function Remove-LWHypervVMSnapshot
             }
             else
             {
-                Remove-VMSnapshot -VMName $n -Name $snapshot.Name -IncludeAllChildSnapshots -ErrorAction SilentlyContinue
+                $snapshot | Remove-VMSnapshot -IncludeAllChildSnapshots -ErrorAction SilentlyContinue
             }
         }
     }
@@ -1284,7 +1312,7 @@ function Restore-LWHypervVMSnapshot
         Start-RunspaceJob -RunspacePool $pool -Argument $n -ScriptBlock {
             param ($n)
 
-            if ((Get-VM -Name $n -ErrorAction SilentlyContinue).State -eq 'Running')
+            if ((Get-LWHypervVM -Name $n -ErrorAction SilentlyContinue).State -eq 'Running')
             {
                 Write-Verbose -Message "    '$n' was running"
                 $n
@@ -1298,8 +1326,9 @@ function Restore-LWHypervVMSnapshot
     {
         Start-RunspaceJob -RunspacePool $pool -Argument $n -ScriptBlock {
             param ($n)
-            Suspend-VM -Name $n -ErrorAction SilentlyContinue
-            Save-VM -Name $n -ErrorAction SilentlyContinue
+            $vm = Get-LWHypervVM -Name $n
+            $vm | Suspend-VM -ErrorAction SilentlyContinue
+            $vm | Save-VM -ErrorAction SilentlyContinue
             Start-Sleep -Seconds 5
         }
     }
@@ -1313,7 +1342,8 @@ function Restore-LWHypervVMSnapshot
                 [string]$n
             )
 
-            $snapshot = Get-VMSnapshot -VMName $n | Where-Object Name -eq $SnapshotName
+            $vm = Get-LWHypervVM -Name $n
+            $snapshot = $vm | Get-VMSnapshot | Where-Object Name -eq $SnapshotName
 
             if (-not $snapshot)
             {
@@ -1321,8 +1351,8 @@ function Restore-LWHypervVMSnapshot
             }
             else
             {
-                Restore-VMSnapshot -VMName $n -Name $SnapshotName -Confirm:$false
-                Set-VM -Name $n -Notes (Get-VMSnapshot -VMName $n -Name $SnapshotName).Notes
+                $snapshot | Restore-VMSnapshot -Confirm:$false
+                $vm | Set-VM -Notes $snapshot.Notes
 
                 Start-Sleep -Seconds 5
             }
@@ -1397,7 +1427,7 @@ function Get-LWHypervVMStatus
     Write-LogFunctionEntry
 
     $result = @{ }
-    $vms = Get-VM -Name $ComputerName
+    $vms = Get-LWHypervVM -Name $ComputerName -ErrorAction SilentlyContinue
     $vmTable = @{ }
     Get-LabVm -IncludeLinux | Where-Object FriendlyName -in $ComputerName | ForEach-Object {$vmTable[$_.FriendlyName] = $_.Name}
 
@@ -1507,22 +1537,23 @@ function Mount-LWIsoImage
         {
             try
             {
+                $vm = Get-LWHypervVM -Name $machine.ResourceName
                 if ($machine.OperatingSystem.Version -ge '6.2')
                 {
-                    $drive = Add-VMDvdDrive -VMName $machine.ResourceName -Path $IsoPath -ErrorAction Stop -Passthru
+                    $drive = $vm | Add-VMDvdDrive -Path $IsoPath -ErrorAction Stop -Passthru
                 }
                 else
                 {
-                    if (-not (Get-VMDvdDrive -VMName $machine.ResourceName))
+                    if (-not ($vm | Get-VMDvdDrive))
                     {
                         throw "No DVD drive exist for machine '$machine'. Machine is generation 1 and DVD drive needs to be crate in advance (during creation of the machine). Cannot continue."
                     }
-                    $drive = Set-VMDvdDrive -VMName $machine.ResourceName -Path $IsoPath -ErrorAction Stop -Passthru
+                    $drive = $vm | Set-VMDvdDrive -Path $IsoPath -ErrorAction Stop -Passthru
                 }
 
                 Start-Sleep -Seconds $delayBeforeCheck[$delayIndex]
 
-                if ((Get-VMDvdDrive -VMName $machine.ResourceName).Path -contains $IsoPath)
+                if (($vm | Get-VMDvdDrive).Path -contains $IsoPath)
                 {
                     $done = $true
                 }
@@ -1570,15 +1601,16 @@ function Dismount-LWIsoImage
 
     foreach ($machine in $machines)
     {
+        $vm = Get-LWHypervVM -Name $machine.ResourceName -ErrorAction SilentlyContinue
         if ($machine.OperatingSystem.Version -ge [System.Version]'6.2')
         {
             Write-PSFMessage -Message "Removing DVD drive for machine '$machine'"
-            Get-VMDvdDrive -VMName $machine.ResourceName | Remove-VMDvdDrive
+            $vm | Get-VMDvdDrive | Remove-VMDvdDrive
         }
         else
         {
             Write-PSFMessage -Message "Setting DVD drive for machine '$machine' to null"
-            Get-VMDvdDrive -VMName $machine.ResourceName | Set-VMDvdDrive -Path $null
+            $vm | Get-VMDvdDrive | Set-VMDvdDrive -Path $null
         }
     }
 }
@@ -1597,6 +1629,7 @@ function Repair-LWHypervNetworkConfig
     Write-LogFunctionEntry
 
     $machine = Get-LabVM -ComputerName $ComputerName
+    $vm = Get-LWHypervVM -Name $machine.ResourceName
 
     if (-not $machine) { return } # No fixing this on a Linux VM
 
@@ -1686,7 +1719,7 @@ function Repair-LWHypervNetworkConfig
 
     foreach ($adapterInfo in $machine.NetworkAdapters)
     {
-        $vmAdapter = Get-VMNetworkAdapter -VMName $machine.ResourceName -Name $adapterInfo.VirtualSwitch.ResourceName
+        $vmAdapter = $vm | Get-VMNetworkAdapter -Name $adapterInfo.VirtualSwitch.ResourceName
 
         if ($adapterInfo.VirtualSwitch.ResourceName -ne $vmAdapter.SwitchName)
         {
@@ -1717,7 +1750,7 @@ function Set-LWHypervVMDescription
     $suffix = '#>AL#'
     $pattern = '{0}(?<ALNotes>[\s\S]+){1}' -f [regex]::Escape($prefix), [regex]::Escape($suffix)
 
-    $notes = (Get-VM -Name $ComputerName).Notes
+    $notes = (Get-LWHypervVM-Name $ComputerName).Notes
 
     if ($notes -match $pattern) {
         $notes = $notes -replace $pattern, ''
@@ -1733,7 +1766,7 @@ function Set-LWHypervVMDescription
 
     $notes += $prefix + $disctionary.ExportToString() + $suffix
 
-    Set-VM -Name $ComputerName -Notes $notes
+    Get-LWHypervVM-Name $ComputerName | Set-VM -Notes $notes
 
     Write-LogFunctionExit
 }
@@ -1749,7 +1782,7 @@ function Get-LWHypervVMDescription
 
     Write-LogFunctionEntry
     
-    $vm = Get-VM -Name $ComputerName -ErrorAction SilentlyContinue
+    $vm = Get-LWHypervVM -Name $ComputerName -ErrorAction SilentlyContinue
     if (-not $vm)
     {
         return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - New function Install-LabAzureRequiredModule
 - Renamed 'Remove-DeploymentFiles' to 'Remove-LabDeploymentFiles' according to the naming convention and extended
   the function's scope of work.
+- Finally adding cluster-awareness
+  - If AutomatedLab is executed locally on a cluster node, the lab VMs are added to the cluster
 
 ### Bugs
 - Fixing issue with Get-LabAzureAvailableRoleSize by filtering earlier.

--- a/Help/Wiki/Advanced/runoncluster.md
+++ b/Help/Wiki/Advanced/runoncluster.md
@@ -1,0 +1,28 @@
+﻿# Running AutomatedLab on a Hyper-V Cluster
+
+While AutomatedLab was not designed to work with CIM sessions, you can install AutomatedLab on one or more cluster nodes.
+
+To use AutomatedLab on a clustered Hyper-V, e.g. an S2D cluster, go about the configuration like you normally would!
+The main difference is: Your VM path should now be a CSV (cluster-shared volume), and it is probably a good
+idea to store your ISO files either on a network share or in another CSV.
+
+```powershell
+New-LabDefinition -Name IsOnCluster -DefaultVirtualizationEngine HyperV -VmPath C:\ClusterStorage\ALVMS
+
+Add-LabVirtualNetworkDefinition -Name ClusterNet -AddressSpace 172.16.0.0/24 -HyperVProperties @{SwitchType = 'External'; AdapterName = 'eth0'}
+Add-LabMachineDefinition -Name test -Memory 4GB -OperatingSystem 'Windows Server 2019 Datacenter' -Network ClusterNet -IpAddress 172.16.0.199
+Install-Lab
+```
+
+All lab VMs will automatically be added as a cluster role, and removed properly when the lab or the VM is removed.
+To disable this behavior, the setting `DoNotAddVmsToCluster` has been added. To change this setting:
+
+```powershell
+# Disable auto-add
+Set-PSFConfig -FullName AutomatedLab.DoNotAddVmsToCluster -Value $true -PassThru | Register-PSFConfig
+# Enable auto-add - default
+Set-PSFConfig -FullName AutomatedLab.DoNotAddVmsToCluster -Value $false -PassThru | Register-PSFConfig
+```
+
+Activities like live migrations depend on your configuration of course. You will not be able to live-migrate
+a VM that is connected to internal switches - the rules still apply ;)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Exchanging data: Wiki/Basic/exchangedata.md
   - Notification system: Wiki/Advanced/notifications.md
   - Connecting two labs: Wiki/Advanced/connectlabs.md
+  - Running on a Cluster: Wiki/Advanced/runoncluster.md
 - Azure labs:
   - Adding a subscription: Wiki/Basic/addazuresubscription.md
   - Synchronise local lab sources: Wiki/Basic/synclabsources.md


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

IF AutomatedLab is run on a cluster node (Hyper-V) AND the Failover-Clustering cmdlets are available AND the new configuration setting DoNotAddVmsToCluster is `$false`, each VM will be added as a cluster role.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
On my S2D cluster, installed AutomatedLab, created a CSV and then:
```powershell
# Internal switch --> No Live Migrations supported!
New-LabDefinition -NAme S2Test -DefaultVirtualizationEngine HyperV -VmPath C:\ClusterStorage\ALVMS
Add-LabMachineDefinition -Name test -Memory 4GB -OperatingSystem 'Windows Server 2019 Datacenter'
Install-Lab
Remove-LabPSSession
Move-ClusterVirtualMachineRole -MigrationType Quick -Name test -Node S2DHV2 -Wait
New-LabPSSession # Machine still reachable
Get-LWHypervVmDescription -ComputerName test # Still found, even if moved to other node
Remove-Lab -Confirm:$false # Cluster group as well as resources are deleted

# External switch --> Live Migrations work as well
New-LabDefinition -NAme S2Test -DefaultVirtualizationEngine HyperV -VmPath C:\ClusterStorage\ALVMS
Add-LabVirtualNetworkDefinition -Name S2Test -AddressSpace 172.16.0.0/24 -HyperVProperties @{SwitchType = 'External'; AdapterName = 'eth0'}
Add-LabMachineDefinition -Name test -Memory 4GB -OperatingSystem 'Windows Server 2019 Datacenter' -Network S2Test -IpAddress 172.16.0.199
Install-Lab
Remove-LabPSSession
Move-ClusterVirtualMachineRole -MigrationType Live -Name test -Node S2DHV2 -Wait
New-LabPSSession # Machine still reachable
Get-LWHypervVmDescription -ComputerName test # Still found, even if moved to other node
Remove-Lab -Confirm:$false
```
After install was done, migrated the VM to another node and verified that without changing the node, AutomatedLab would still be able to access the VMs using CIM-Sessions