### PR TITLE
Fix issue with missing MacAddress HyperV

### DIFF
--- a/AutomatedLab/AutomatedLabDisks.psm1
+++ b/AutomatedLab/AutomatedLabDisks.psm1
@@ -263,7 +263,7 @@ function New-LabVHDX
         IncludeEqual     = $true
     }
     $referencedDisks = (Compare-Object @param).InputObject
-    if ($createOnlyReferencedDisks)
+    if ($createOnlyReferencedDisks -and $($disks.Count - $referencedDisks.Count) -gt 0)
     {
         Write-ScreenInfo "There are $($disks.Count - $referencedDisks.Count) disks defined that are not referenced by any machine. These disks won't be created." -Type Warning
         $disks = $referencedDisks

--- a/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
@@ -255,8 +255,6 @@ function Remove-LabVirtualNetworkDefinition
 #region New-LabNetworkAdapterDefinition
 function New-LabNetworkAdapterDefinition
 {
-
-
     [CmdletBinding(DefaultParameterSetName = 'manual')]
     param (
         [Parameter(Mandatory)]
@@ -369,6 +367,17 @@ function New-LabNetworkAdapterDefinition
     foreach ($item in $Ipv6DnsServers)
     {
         $adapter.Ipv6DnsServers.Add($item)
+    }
+
+    if ((Get-LabDefinition).DefaultVirtualizationEngine -eq 'HyperV' -and -not $MacAddress)
+    {
+        $macAddressPrefix = Get-LabConfigurationItem -Name MacAddressPrefix
+        [string[]]$macAddressesInUse = (Get-VM | Get-VMNetworkAdapter).MacAddress
+        $macAddressesInUse += (Get-LabMachineDefinition -All).NetworkAdapters.MacAddress
+        if (-not $script:macIdx) { $script:macIdx = 0 }
+        while ("$macAddressPrefix{0:X6}" -f $macIdx -in $macAddressesInUse) { $script:macIdx++ }
+
+        $MacAddress = "$macAddressPrefix{0:X6}" -f $script:macIdx++
     }
 
     if ($Ipv4Gateway) { $adapter.Ipv4Gateway = $Ipv4Gateway }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Adding hidden setting DoNotPrompt as an attempt to not prompt.
   - Does not include prompts that can be turned off like Enable-LabHostRemoting -Force
 - Updated docs
+- Fixing issue with Hyper-V where network adapter MAC address went missing, breaking cmdlets like Repair-LWHyperVNetworkConfig
 
 ### Bugs
 - Fixing issue with Get-LabAzureAvailableRoleSize by filtering earlier.


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

MAC address calculation is done after the definition is exported, which resulted in empty MAC addresses, which in turn disrupted Repair-LWHypervNetworkConfig

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->