### PR TITLE
Various small fixes

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -118,6 +118,7 @@ else
 Set-PSFConfig -Module 'AutomatedLab' -Name OsRoot -Value $osroot -Initialize -Validation string
 Set-PSFConfig -Module 'AutomatedLab' -Name OverridePowerPlan -Value $true -Initialize -Validation bool -Description 'On Windows: Indicates that power settings will be set to High Power during lab deployment'
 Set-PSFConfig -Module 'AutomatedLab' -Name SendFunctionTelemetry -Value $false -Initialize -Validation bool -Description 'Indicates if function call telemetry is sent' -Hidden
+Set-PSFConfig -Module 'AutomatedLab' -Name DoNotPrompt -Value $false -Initialize -Validation bool -Description 'Indicates that AutomatedLab should not display prompts. Workaround for environments that register as interactive, even if they are not' -Hidden
 
 #PSSession settings
 Set-PSFConfig -Module 'AutomatedLab' -Name InvokeLabCommandRetries -Value 3 -Initialize -Validation integer -Description 'Number of retries for Invoke-LabCommand'

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -513,7 +513,11 @@ function Import-Lab
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath 'Unattended2012.xml'
                     }
-                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat')
+                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.Version -lt 8.0)
+                    {
+                        $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath ks_defaultLegacy.cfg
+                    }
+                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.Version -ge 8.0)
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath ks_default.cfg
                     }

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -393,7 +393,7 @@ function Add-LabAzureSubscription
     $syncMaxSize = Get-LabConfigurationItem -Name LabSourcesMaxFileSizeMb
     $syncIntervalDays = Get-LabConfigurationItem -Name LabSourcesSyncIntervalDays
 
-    if (-not $lastchecked)
+    if (-not (Get-LabConfigurationItem -Name DoNotPrompt -Default $false) -and -not $lastchecked)
     {
         $lastchecked = [datetime]0
         $syncText = @"

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -1240,9 +1240,10 @@ function Connect-LabVM
 
         if ($machine.OperatingSystemType -eq 'Linux')
         {
-            $sshBinary = Get-ChildItem $labsources\Tools\OpenSSH -Filter ssh.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+            $sshBinary = Get-Command ssh.exe -ErrorAction SilentlyContinue
+            if (-not $sshBinary) { Get-ChildItem $labsources\Tools\OpenSSH -Filter ssh.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 }
 
-            if (-not $sshBinary)
+            if (-not $sshBinary -and -not (Get-LabConfigurationItem -Name DoNotPrompt))
             {
                 $download = Read-Choice -ChoiceList 'No','Yes' -Caption 'Download Win32-OpenSSH' -Message 'OpenSSH is necessary to connect to Linux VMs. Would you like us to download Win32-OpenSSH for you?' -Default 1
 

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1245,6 +1245,7 @@ function Export-LabDefinition
             if ($Script:machines | Where-Object LinuxType -eq 'RedHat')
             {
                 $kickstartContent | Out-File -FilePath (Join-Path -Path $script:lab.Sources.UnattendedXml.Value -ChildPath ks_default.cfg) -Encoding unicode
+                $kickstartContent.Replace(' --non-interactive','') | Out-File -FilePath (Join-Path -Path $script:lab.Sources.UnattendedXml.Value -ChildPath ks_defaultLegacy.cfg) -Encoding unicode                
             }
             if ($Script:machines | Where-Object LinuxType -eq 'Suse')
             {
@@ -3626,7 +3627,11 @@ function Import-LabDefinition
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath 'Unattended2012.xml'
                     }
-                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat')
+                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.Version -lt 8.0)
+                    {
+                        $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath ks_defaultLegacy.cfg
+                    }
+                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.Version -ge 8.0)
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath ks_default.cfg
                     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   the function's scope of work.
 - Finally adding cluster-awareness
   - If AutomatedLab is executed locally on a cluster node, the lab VMs are added to the cluster
+- Adding hidden setting DoNotPrompt as an attempt to not prompt.
+  - Does not include prompts that can be turned off like Enable-LabHostRemoting -Force
+- Updated docs
 
 ### Bugs
 - Fixing issue with Get-LabAzureAvailableRoleSize by filtering earlier.
@@ -22,6 +25,7 @@
 - Fixes #1293: Set-DscLocalConfigurationManagerConfiguration throws error when successful.
 - DelayBetweenComputers was ignored
 - Fixed lab location. Sometimes the 'Lab.xml' was stored in 'C:\ProgramData\AutomatedLab' directly.
+- Removing unsupported kickstart parameter for old CentOS versions
 
 ## 5.41.0 (2022-01-31)
 

--- a/Help/AutomatedLab/en-us/Test-LabPathIsOnLabAzureLabSourcesStorage.md
+++ b/Help/AutomatedLab/en-us/Test-LabPathIsOnLabAzureLabSourcesStorage.md
@@ -23,10 +23,14 @@ Tests if a given path is inside the Azure lab source storage share
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Test-LabPathIsOnLabAzureLabSourcesStorage -Path "$labSources\Tools\SomeTool.exe"
 ```
 
-{{ Add example description here }}
+Test if the path "$labSources\Tools\SomeTool.exe" is actually located on an Azure
+lab sources share.
+
+The dynamic $labSources variable may either point to a local path or an Azure
+file share depending on the Hypervisor that is used.
 
 ## PARAMETERS
 

--- a/Help/Wiki/Roles/dscpull.md
+++ b/Help/Wiki/Roles/dscpull.md
@@ -15,7 +15,7 @@ Add-LabMachineDefinition -Name Pulli -Roles DscPullServer
 You can optionally specify parameters by using the role definition:
 
 ```powershell
-$role = Get-LabMachineRoleDefinition -Role DscPullServer -RoleProperties @{
+$role = Get-LabMachineRoleDefinition -Role DscPullServer -Properties @{
     DatabaseEngine = 'mdb'
     DatabaseName = 'DSC'
     DatabaseServer = 'SQL01'

--- a/Help/Wiki/Roles/hyperv.md
+++ b/Help/Wiki/Roles/hyperv.md
@@ -13,7 +13,7 @@ Add-LabMachineDefinition -Name HV01 -Roles HyperV
 You can also customize many relevant settings by creating the role definition reference:
 
 ```powershell
-$role = Get-LabMachineRoleDefinition -Role HyperV -RoleProperties @{EnableEnhancedSessionMode = 'true'}
+$role = Get-LabMachineRoleDefinition -Role HyperV -Properties @{EnableEnhancedSessionMode = 'true'}
 Add-LabMachineDefinition -Name HV01 -Roles $role
 ```
 ## Role properties

--- a/Help/Wiki/Roles/sql.md
+++ b/Help/Wiki/Roles/sql.md
@@ -17,7 +17,7 @@ Add-LabMachineDefinition -Name SQL01 -Roles SQLServer2017
 If you need a little more control, simply use the role properties. The following example only installs the engine and tools:
 
 ```powershell
-$role = Get-LabMachineRoleDefinition -Role SQLServer2017 -RoleProperties @{Features = 'SQL,Tools'}
+$role = Get-LabMachineRoleDefinition -Role SQLServer2017 -Properties @{Features = 'SQL,Tools'}
 
 Add-LabMachineDefinition -Name SQL01 -Roles $role
 ```


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

- Adding hidden setting DoNotPrompt as an attempt to not prompt.
  - Does not include prompts that can be turned off like Enable-LabHostRemoting -Force
- Updated docs
- Removing unsupported kickstart parameter for old CentOS versions

Fixes #1290 
Fixes #1275
Fixes #1304 

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [x] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

#1290
```powershell
Clear-LabCache
Set-PSFConfig -FullName AutomatedLab.DoNotPrompt -Value $true -PassThru | Register-PSFConfig

New-LabDefinition -Name 20220409jhp -DefaultVirtualizationEngine Azure
Add-LabAzureSubscription -DefaultLocationName 'West Europe'

Clear-LabCache
Set-PSFConfig -FullName AutomatedLab.DoNotPrompt -Value $false -PassThru | Register-PSFConfig

New-LabDefinition -Name 20220409jhp -DefaultVirtualizationEngine Azure
Add-LabAzureSubscription -DefaultLocationName 'West Europe' # Prompts
```

#1304 
```powershell
$labName = 'ALLovesLinux'

New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV

Add-LabVirtualNetworkDefinition -Name 'USBternet' -HyperVProperties @{ SwitchType = 'External'; AdapterName = 'Ethernet' }

$na = New-LabNetworkAdapterDefinition -VirtualSwitch 'USBternet' -UseDhcp
Add-LabMachineDefinition -Name LINCN1 -OperatingSystem 'CentOS-7' -Memory 8GB -NetworkAdapter $na
Add-LabMachineDefinition -Name LINCN2 -OperatingSystem 'CentOS 8' -Memory 8GB -NetworkAdapter $na

Install-Lab
```