### PR TITLE
CentOS Stream 9, SSH Remoting

### DIFF
--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -260,7 +260,8 @@
         'Enable-LabAzureJitAccess',
         'Get-LWAzureVm',
         'Install-LabSshKnownHost',
-        'UnInstall-LabSshKnownHost'
+        'UnInstall-LabSshKnownHost',
+        'Get-LabSshKnownHost'
     )
 
     AliasesToExport        = @(

--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -258,7 +258,9 @@
         'Enable-LabInternalRouting',
         'Request-LabAzureJitAccess',
         'Enable-LabAzureJitAccess',
-        'Get-LWAzureVm'
+        'Get-LWAzureVm',
+        'Install-LabSshKnownHost',
+        'UnInstall-LabSshKnownHost'
     )
 
     AliasesToExport        = @(

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -741,6 +741,7 @@ function Install-Lab
         [switch]$StartRemainingMachines,
         [switch]$CreateCheckPoints,
         [switch]$InstallRdsCertificates,
+        [switch]$InstallSshKnownHosts,
         [switch]$PostDeploymentTests,
         [switch]$NoValidation,
         [int]$DelayBetweenComputers
@@ -1352,6 +1353,15 @@ function Install-Lab
         Write-ScreenInfo -Message 'Installing RDS certificates of lab machines' -TaskStart
         
         Install-LabRdsCertificate
+        
+        Write-ScreenInfo -Message 'Done' -TaskEnd
+    }
+
+    if ($InstallSshKnownHosts -or $performAll)
+    {
+        Write-ScreenInfo -Message "Adding lab machines to $home/.ssh/known_hosts" -TaskStart
+        
+        Install-LabSshKnownHost
         
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -513,11 +513,11 @@ function Import-Lab
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath 'Unattended2012.xml'
                     }
-                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.Version -lt 8.0)
+                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.OperatingSystem.Version -lt 8.0)
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath ks_defaultLegacy.cfg
                     }
-                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.Version -ge 8.0)
+                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.OperatingSystem.Version -ge 8.0)
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath ks_default.cfg
                     }

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -166,16 +166,17 @@ function New-LabPSSession
                 $param.Add('Port', 5985)
             }
 
-            if (((Get-Command New-PSSession).Parameters.Values.Name -notcontains 'HostName') -and $m.OperatingSystemType -eq 'Linux' -and -not [string]::IsNullOrWhiteSpace($m.SshPublicKeyPath))
+            if (((Get-Command New-PSSession).Parameters.Values.Name -notcontains 'HostName') -and $m.OperatingSystemType -eq 'Linux' -and -not [string]::IsNullOrWhiteSpace($m.SshPrivateKeyPath))
             {
                 Write-ScreenInfo -Type Warning -Message "SSH Transport is not available from within Windows PowerShell."
             }
-            if (((Get-Command New-PSSession).Parameters.Values.Name -contains 'HostName') -and $m.OperatingSystemType -eq 'Linux' -and -not [string]::IsNullOrWhiteSpace($m.SshPublicKeyPath))
+            if (((Get-Command New-PSSession).Parameters.Values.Name -contains 'HostName') -and $m.OperatingSystemType -eq 'Linux' -and -not [string]::IsNullOrWhiteSpace($m.SshPrivateKeyPath))
             {
                 $param.Clear()
                 $param['HostName'] = $m.Name
-                $param['KeyFilePath'] = $m.SshPublicKeyPath
+                $param['KeyFilePath'] = $m.SshPrivateKeyPath
                 $param['Port'] = 22
+                $param['UserName'] = $cred.UserName
                 $connectionName = $m.Name
             }
             elseif ($m.OperatingSystemType -eq 'Linux')
@@ -187,7 +188,7 @@ function New-LabPSSession
                 $param['Authentication'] = 'Basic'
             }
 
-            if (($IsLinux -or $IsMacOs) -and [string]::IsNullOrWhiteSpace($m.SshPublicKeyPath))
+            if (($IsLinux -or $IsMacOs) -and [string]::IsNullOrWhiteSpace($m.SshPrivateKeyPath))
             {
                 $param['Authentication'] = 'Negotiate'
             }

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -719,7 +719,11 @@ function Wait-LabVM
 
     end
     {
-        $sshHosts = (Get-LabSshKnownHost -ErrorAction SilentlyContinue).ComputerName
+        if ((Get-Command -ErrorAction SilentlyContinue -Name New-PSSession).Parameters.Values.Name -contains 'HostName' )
+        {
+            # Quicker than reading in the file on unsupported configurations
+            $sshHosts = (Get-LabSshKnownHost -ErrorAction SilentlyContinue).ComputerName
+        }
         $jobs = foreach ($vm in $vms)
         {
             $session = $null

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -719,10 +719,16 @@ function Wait-LabVM
 
     end
     {
+        $sshHosts = (Get-LabSshKnownHost -ErrorAction SilentlyContinue).ComputerName
         $jobs = foreach ($vm in $vms)
         {
             $session = $null
             #remove the existing sessions to ensure a new one is created and the existing one not reused.
+            if ((Get-Command -ErrorAction SilentlyContinue -Name New-PSSession).Parameters.Values.Name -contains 'HostName' -and $sshHosts -and $vm.Name -notin $sshHosts)
+            {
+                Install-LabSshKnownHost
+                $sshHosts = (Get-LabSshKnownHost -ErrorAction SilentlyContinue).ComputerName
+            }
             Remove-LabPSSession -ComputerName $vm
 
             if (-not ($IsLinux -or $IsMacOs)) { netsh.exe interface ip delete arpcache | Out-Null }

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2020,7 +2020,7 @@ function Add-LabMachineDefinition
             Write-ScreenInfo -Type Warning -Message "SSH Transport is not available from within Windows PowerShell. Please use PowerShell 6+ if you want to use remoting-cmdlets."
         }
 
-        if (-not [string]::IsNullOrWhiteSpace($SshPublicKeyPath) -or -not [string]::IsNullOrWhiteSpace($SshPrivateKeyPath) -and -not ([string]::IsNullOrWhiteSpace($SshPublicKeyPath) -and [string]::IsNullOrWhiteSpace($SshPrivateKeyPath)))
+        if ((-not [string]::IsNullOrWhiteSpace($SshPublicKeyPath) -and [string]::IsNullOrWhiteSpace($SshPrivateKeyPath)) -or ([string]::IsNullOrWhiteSpace($SshPublicKeyPath) -and -not [string]::IsNullOrWhiteSpace($SshPrivateKeyPath)))
         {
             Write-ScreenInfo -Type Warning -Message "Both SshPublicKeyPath and SshPrivateKeyPath need to be used to successfully remote to Linux VMs"
         }

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1242,7 +1242,12 @@ function Export-LabDefinition
             {
                 $unattendedXmlDefaultContent2012 | Out-File -FilePath (Join-Path -Path $script:lab.Sources.UnattendedXml.Value -ChildPath Unattended2012.xml) -Encoding unicode
             }
-            if ($Script:machines | Where-Object LinuxType -eq 'RedHat')
+            if ($Script:machines | Where-Object {$_.LinuxType -eq 'RedHat' -and $_.OperatingSystem.Version -ge 9.0})
+            {
+                $kickstartContent.Replace('install','').Trim() | Out-File -FilePath (Join-Path -Path $script:lab.Sources.UnattendedXml.Value -ChildPath ks_default.cfg) -Encoding unicode
+                $kickstartContent.Replace(' --non-interactive','') | Out-File -FilePath (Join-Path -Path $script:lab.Sources.UnattendedXml.Value -ChildPath ks_defaultLegacy.cfg) -Encoding unicode                
+            }
+            elseif ($Script:machines | Where-Object LinuxType -eq 'RedHat')
             {
                 $kickstartContent | Out-File -FilePath (Join-Path -Path $script:lab.Sources.UnattendedXml.Value -ChildPath ks_default.cfg) -Encoding unicode
                 $kickstartContent.Replace(' --non-interactive','') | Out-File -FilePath (Join-Path -Path $script:lab.Sources.UnattendedXml.Value -ChildPath ks_defaultLegacy.cfg) -Encoding unicode                
@@ -1932,7 +1937,9 @@ function Add-LabMachineDefinition
 
         [string[]]$RhelPackage,
 
-        [string[]]$SusePackage
+        [string[]]$SusePackage,
+
+        [string]$SshPublicKeyPath
     )
 
     begin
@@ -2006,6 +2013,11 @@ function Add-LabMachineDefinition
             }
         }
 
+        if (((Get-Command New-PSSession).Parameters.Values.Name -notcontains 'HostName') -and $OperatingSystem.OperatingSystemType -eq 'Linux' -and -not [string]::IsNullOrWhiteSpace($SshPublicKeyPath))
+        {
+            Write-ScreenInfo -Type Warning -Message "SSH Transport is not available from within Windows PowerShell. Please use PowerShell 6+ if you want to use remoting-cmdlets."
+        }
+
         if ($AzureProperties)
         {
             $illegalKeys = Compare-Object -ReferenceObject $azurePropertiesValidKeys -DifferenceObject ($AzureProperties.Keys | Sort-Object -Unique) |
@@ -2067,6 +2079,20 @@ function Add-LabMachineDefinition
         $machine.Name = $Name
         $machine.FriendlyName = $ResourceName
         $script:machines.Add($machine)
+
+        if ($OperatingSystem.OperatingSystemType -eq 'Windows' -and $SshPublicKeyPath)
+        {
+            Write-ScreenInfo -Message "SSH Keys are ignored on Windows for the time being. Why not contribute to AutomatedLab and add the configuration of an ssh server?"
+        }
+        elseif ($OperatingSystem.OperatingSystemType -eq 'Linux' -and $SshPublicKeyPath -and -not (Test-Path -Path $SshPublicKeyPath))
+        {
+            throw "$SshPublicKeyPath does not exist. Rethink your decision."
+        }
+        elseif ($OperatingSystem.OperatingSystemType -eq 'Linux' -and $SshPublicKeyPath)
+        {
+            $machine.SshPublicKeyPath = $SshPublicKeyPath
+            $machine.SshPublicKey = Get-Content -Raw -Path $SshPublicKeyPath
+        }
 
         if ((Get-LabDefinition).DefaultVirtualizationEngine -and (-not $PSBoundParameters.ContainsKey('VirtualizationHost')))
         {
@@ -3631,11 +3657,11 @@ function Import-LabDefinition
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath 'Unattended2012.xml'
                     }
-                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.Version -lt 8.0)
+                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.OperatingSystem.Version -lt 8.0)
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath ks_defaultLegacy.cfg
                     }
-                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.Version -ge 8.0)
+                    if ($this.OperatingSystemType -eq 'Linux' -and $this.LinuxType -eq 'RedHat' -and $this.OperatingSystem.Version -ge 8.0)
                     {
                         $Path = Join-Path -Path (Get-Lab).Sources.UnattendedXml.Value -ChildPath ks_default.cfg
                     }

--- a/AutomatedLabUnattended/Private/RedHat/Export-UnattendedKickstartFile.ps1
+++ b/AutomatedLabUnattended/Private/RedHat/Export-UnattendedKickstartFile.ps1
@@ -29,7 +29,7 @@ function Export-UnattendedKickstartFile
             {
                 if (-not $line) { continue }
                 if ($line -like '*gpgcheck*') {$line = 'gpgcheck=0'}
-                'echo "{0}" >> /etc/yum.repos.d/microsoft.repo' -f $line.Replace('https://packages.microsoft.com/rhel/7/prod', 'https://packages.microsoft.com/rhel/$VERSION/prod')
+                'echo "{0}" >> /etc/yum.repos.d/microsoft.repo' -f $line
             }
             'echo "{0} packages.microsoft.com" >> /etc/hosts' -f $repoIp
             'yum install -y openssl'

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -233,15 +233,16 @@ function New-LWHypervVM
     
     if ($Machine.OperatingSystemType -eq 'Linux' -and -not [string]::IsNullOrEmpty($Machine.SshPublicKey))
     {
-        Add-UnattendedSynchronousCommand "mkdir -p /home/$($Machine.InstallationUser.UserName)/.ssh" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "mkdir -p /.ssh" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /home/$($Machine.InstallationUser.UserName)/.ssh/authorized_keys" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /.ssh/authorized_keys" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "chmod 700 /home/$($Machine.InstallationUser.UserName)/.ssh && chmod 600 /home/$($Machine.InstallationUser.UserName)/.ssh/authorized_keys" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "chmod 700 /.ssh && chmod 600 /.ssh/authorized_keys" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "chown -R $($Machine.InstallationUser.UserName):$($Machine.InstallationUser.UserName) /home/$($Machine.InstallationUser.UserName)/.ssh" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "chown -R root:root /.ssh" -Description 'SSH'
         Add-UnattendedSynchronousCommand "sed -i 's|[#]*PubkeyAuthentication yes|PubkeyAuthentication yes|g' /etc/ssh/sshd_config" -Description 'PowerShell is so much better.'
+        Add-UnattendedSynchronousCommand "sed -i 's|[#]*PasswordAuthentication yes|PasswordAuthentication no|g' /etc/ssh/sshd_config" -Description 'PowerShell is so much better.'
+        Add-UnattendedSynchronousCommand "chmod 700 /home/$($Machine.InstallationUser.UserName)/.ssh && chmod 600 /home/$($Machine.InstallationUser.UserName)/.ssh/authorized_keys" -Description 'SSH'
+        Add-UnattendedSynchronousCommand "chmod 700 /root/.ssh && chmod 600 /root/.ssh/authorized_keys" -Description 'SSH'
+        Add-UnattendedSynchronousCommand "chown -R $($Machine.InstallationUser.UserName):$($Machine.InstallationUser.UserName) /home/$($Machine.InstallationUser.UserName)/.ssh" -Description 'SSH'
+        Add-UnattendedSynchronousCommand "chown -R root:root /root/.ssh" -Description 'SSH'        
+        Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /home/$($Machine.InstallationUser.UserName)/.ssh/authorized_keys" -Description 'SSH'
+        Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /root/.ssh/authorized_keys" -Description 'SSH'
+        Add-UnattendedSynchronousCommand "mkdir -p /home/$($Machine.InstallationUser.UserName)/.ssh" -Description 'SSH'
+        Add-UnattendedSynchronousCommand "mkdir -p /root/.ssh" -Description 'SSH'
     }
 
     if ($Machine.Roles.Name -contains 'RootDC' -or
@@ -285,10 +286,10 @@ function New-LWHypervVM
 
                 if (-not [string]::IsNullOrEmpty($Machine.SshPublicKey))
                 {
-                    Add-UnattendedSynchronousCommand "mkdir -p /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh" -Description 'SSH'
                     Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh/authorized_keys" -Description 'SSH'
                     Add-UnattendedSynchronousCommand "chmod 700 /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh && chmod 600 /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh/authorized_keys" -Description 'SSH'
                     Add-UnattendedSynchronousCommand "chown -R $($Machine.InstallationUser.UserName)@$($Machine.DomainName):$($Machine.InstallationUser.UserName)@$($Machine.DomainName) /home/$($Machine.InstallationUser.UserName)@$($Machine.DomainName)/.ssh" -Description 'SSH'
+                    Add-UnattendedSynchronousCommand "mkdir -p /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh" -Description 'SSH'
                 }
             }
         }
@@ -843,6 +844,10 @@ function Remove-LWHypervVM
     {
         Write-PSFMessage "Removing Clustered Resource: $Name"
         $null = Get-ClusterGroup -Name $Name | Remove-ClusterGroup -RemoveResources -Force
+    }
+    else
+    {
+        $vm | Remove-VM -Force
     }
 
     Write-PSFMessage "Removing VM files for '$($Name)'"

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -241,7 +241,7 @@ function New-LWHypervVM
         Add-UnattendedSynchronousCommand "chmod 700 /.ssh && chmod 600 /.ssh/authorized_keys" -Description 'SSH'
         Add-UnattendedSynchronousCommand "chown -R $($Machine.InstallationUser.UserName):$($Machine.InstallationUser.UserName) /home/$($Machine.InstallationUser.UserName)/.ssh" -Description 'SSH'
         Add-UnattendedSynchronousCommand "chown -R root:root /.ssh" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "sed -i 's|[#]*PubkeyAuthentication yes|PubkeyAuthentication yes|g' /etc/ssh/sshd_config" -Default 'PowerShell is so much better.'
+        Add-UnattendedSynchronousCommand "sed -i 's|[#]*PubkeyAuthentication yes|PubkeyAuthentication yes|g' /etc/ssh/sshd_config" -Description 'PowerShell is so much better.'
     }
 
     if ($Machine.Roles.Name -contains 'RootDC' -or

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -235,12 +235,13 @@ function New-LWHypervVM
     {
         Add-UnattendedSynchronousCommand "mkdir -p /home/$($Machine.InstallationUser.UserName)/.ssh" -Description 'SSH'
         Add-UnattendedSynchronousCommand "mkdir -p /.ssh" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /home/$($Machine.InstallationUser.UserName)/.ssh" -Description 'SSH'
-        Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /.ssh" -Description 'SSH'
+        Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /home/$($Machine.InstallationUser.UserName)/.ssh/authorized_keys" -Description 'SSH'
+        Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /.ssh/authorized_keys" -Description 'SSH'
         Add-UnattendedSynchronousCommand "chmod 700 /home/$($Machine.InstallationUser.UserName)/.ssh && chmod 600 /home/$($Machine.InstallationUser.UserName)/.ssh/authorized_keys" -Description 'SSH'
         Add-UnattendedSynchronousCommand "chmod 700 /.ssh && chmod 600 /.ssh/authorized_keys" -Description 'SSH'
         Add-UnattendedSynchronousCommand "chown -R $($Machine.InstallationUser.UserName):$($Machine.InstallationUser.UserName) /home/$($Machine.InstallationUser.UserName)/.ssh" -Description 'SSH'
         Add-UnattendedSynchronousCommand "chown -R root:root /.ssh" -Description 'SSH'
+        Add-UnattendedSynchronousCommand "sed -i 's|[#]*PubkeyAuthentication yes|PubkeyAuthentication yes|g' /etc/ssh/sshd_config" -Default 'PowerShell is so much better.'
     }
 
     if ($Machine.Roles.Name -contains 'RootDC' -or
@@ -285,7 +286,7 @@ function New-LWHypervVM
                 if (-not [string]::IsNullOrEmpty($Machine.SshPublicKey))
                 {
                     Add-UnattendedSynchronousCommand "mkdir -p /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh" -Description 'SSH'
-                    Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh" -Description 'SSH'
+                    Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh/authorized_keys" -Description 'SSH'
                     Add-UnattendedSynchronousCommand "chmod 700 /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh && chmod 600 /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh/authorized_keys" -Description 'SSH'
                     Add-UnattendedSynchronousCommand "chown -R $($Machine.InstallationUser.UserName)@$($Machine.DomainName):$($Machine.InstallationUser.UserName)@$($Machine.DomainName) /home/$($Machine.InstallationUser.UserName)@$($Machine.DomainName)/.ssh" -Description 'SSH'
                 }

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -233,6 +233,8 @@ function New-LWHypervVM
     
     if ($Machine.OperatingSystemType -eq 'Linux' -and -not [string]::IsNullOrEmpty($Machine.SshPublicKey))
     {
+        Add-UnattendedSynchronousCommand "restorecon -R /root/.ssh/" -Description 'Restore SELinux context'
+        Add-UnattendedSynchronousCommand "restorecon -R /$($Machine.InstallationUser.UserName)/.ssh/" -Description 'Restore SELinux context'
         Add-UnattendedSynchronousCommand "sed -i 's|[#]*PubkeyAuthentication yes|PubkeyAuthentication yes|g' /etc/ssh/sshd_config" -Description 'PowerShell is so much better.'
         Add-UnattendedSynchronousCommand "sed -i 's|[#]*PasswordAuthentication yes|PasswordAuthentication no|g' /etc/ssh/sshd_config" -Description 'PowerShell is so much better.'
         Add-UnattendedSynchronousCommand "chmod 700 /home/$($Machine.InstallationUser.UserName)/.ssh && chmod 600 /home/$($Machine.InstallationUser.UserName)/.ssh/authorized_keys" -Description 'SSH'
@@ -286,6 +288,7 @@ function New-LWHypervVM
 
                 if (-not [string]::IsNullOrEmpty($Machine.SshPublicKey))
                 {
+                    Add-UnattendedSynchronousCommand "restorecon -R /$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh/" -Description 'Restore SELinux context'
                     Add-UnattendedSynchronousCommand "echo `"$($Machine.SshPublicKey)`" > /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh/authorized_keys" -Description 'SSH'
                     Add-UnattendedSynchronousCommand "chmod 700 /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh && chmod 600 /home/$($domain.Administrator.UserName)@$($Machine.DomainName)/.ssh/authorized_keys" -Description 'SSH'
                     Add-UnattendedSynchronousCommand "chown -R $($Machine.InstallationUser.UserName)@$($Machine.DomainName):$($Machine.InstallationUser.UserName)@$($Machine.DomainName) /home/$($Machine.InstallationUser.UserName)@$($Machine.DomainName)/.ssh" -Description 'SSH'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed issue with cluster roles not being cleaned up properly (thanks @Trentent !)
 - Fixed issue with Get-LWHyperVVm and clusters (thanks @Trentent !)
+- Fixing the (once again) updated kickstart file content - we now carry around three different flavors.
 
 ## 5.42.0 (2022-05-05)
 

--- a/LabXml/Machines/Machine.cs
+++ b/LabXml/Machines/Machine.cs
@@ -85,6 +85,8 @@ namespace AutomatedLab
         public int LoadBalancerWinrmHttpsPort { get; set; }
 
         public List<string> LinuxPackageGroup { get; set; }
+        public string SshPublicKey {get; set; }
+        public string SshPublicKeyPath {get; set; }
 
         public OperatingSystemType OperatingSystemType
         {

--- a/LabXml/Machines/Machine.cs
+++ b/LabXml/Machines/Machine.cs
@@ -87,6 +87,7 @@ namespace AutomatedLab
         public List<string> LinuxPackageGroup { get; set; }
         public string SshPublicKey {get; set; }
         public string SshPublicKeyPath {get; set; }
+        public string SshPrivateKeyPath {get; set; }
 
         public OperatingSystemType OperatingSystemType
         {


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

CentOS Stream 9 works (Fixes #1319 )
Had to add SSH remoting (PS 6+ only!) to make the connection possible since OMI-PSRP-Server is a catastrophe. SSH remoting currently experimental: If the private key is password protected (as it should be), there is no quick way to pass this password on the command line. If protection is only ensured through ACLs it largely works. Another issue is: With labs the fingerprints of machines change. A lot. This also breaks remoting, as there seems to be no way of ignoring the different fingerprint

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
```powershell
$labName = 'ALLovesLinux'
New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV
Add-LabVirtualNetworkDefinition -Name 'USBternet' -HyperVProperties @{ SwitchType = 'External'; AdapterName = 'Ethernet' }
Set-LabInstallationCredential -Username Install -Password Somepass1
$netAdapter = @()
$netAdapter += New-LabNetworkAdapterDefinition -VirtualSwitch 'USBternet' -UseDhcp
Add-LabMachineDefinition -Name LINCN1 -OperatingSystem 'CentOS Stream 9' -NetworkAdapter $netAdapter -Memory 8GB -SshPublicKeyPath $home\.ssh\AzurePubKey.pub -SshPrivateKeyPath $home\.ssh\AzurePrivKey
Install-Lab -nova
Remove-Lab

# Testing missing private key - warning is displayed but lab is installed (as it will still work in general)
$labName = 'ALLovesLinux'
New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV
Add-LabVirtualNetworkDefinition -Name 'USBternet' -HyperVProperties @{ SwitchType = 'External'; AdapterName = 'Ethernet' }
Set-LabInstallationCredential -Username Install -Password Somepass1
$netAdapter = @()
$netAdapter += New-LabNetworkAdapterDefinition -VirtualSwitch 'USBternet' -UseDhcp
Add-LabMachineDefinition -Name LINCN1 -OperatingSystem 'CentOS Stream 9' -NetworkAdapter $netAdapter -Memory 8GB -SshPublicKeyPath $home\.ssh\AzurePubKey.pub
Install-Lab -nova

# Tested lab on Windows, noticed that warning is displayed if SSH parameters are used (SSH remoting not possible with Windows PowerShell)
# Ran our benchmark DSC lab on PS 7.2.3 and noticed no odd behavior
```