### PR TITLE
Stop sorting NICs

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -145,6 +145,7 @@ Set-PSFConfig -Module 'AutomatedLab' -Name DoNotAddVmsToCluster -Value $false -I
 
 #Hyper-V Network settings
 Set-PSFConfig -Module 'AutomatedLab' -Name MacAddressPrefix -Value '0017FB' -Initialize -Validation string -Description 'The MAC address prefix for Hyper-V labs' -Handler { if ($args[0].Length -eq 0 -or $args[0].Length -gt 11){Write-PSFMessage -Level Error -Message "Invalid prefix length for MacAddressPrefix! $($args[0]) needs to be at least one character and at most 11 characters"; throw "Invalid prefix length for MacAddressPrefix! $($args[0]) needs to be at least one character and at most 11 characters"} }
+Set-PSFConfig -Module 'AutomatedLab' -Name DisableDeviceNaming -Value $false -Validation bool -Initialize -Description 'Disables Device Naming for VM NICs. Enabled by default for Hosts > 2016 and Gen 2 Guests > 2016'
 
 #Hyper-V Disk Settings
 Set-PSFConfig -Module 'AutomatedLab' -Name CreateOnlyReferencedDisks -Value $true -Initialize -Validation bool -Description 'Disks that are not references by a VM will not be created'

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -876,8 +876,8 @@ function Install-Lab
 
                 if (-not $address) { continue }
 
-                $hostFileAddedEntries += Add-HostEntry -HostName $machine.Name -IpAddress $machine.IpV4Address -Section $Script:data.Name
-                $hostFileAddedEntries += Add-HostEntry -HostName $machine.FQDN -IpAddress $machine.IpV4Address -Section $Script:data.Name
+                $hostFileAddedEntries += Add-HostEntry -HostName $machine.Name -IpAddress $address -Section $Script:data.Name
+                $hostFileAddedEntries += Add-HostEntry -HostName $machine.FQDN -IpAddress $address -Section $Script:data.Name
             }
 
             if ($hostFileAddedEntries)

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1384,7 +1384,7 @@ function Install-Lab
 
     if (-not $NoValidation -and ($performAll -or $PostDeploymentTests))
     {
-        if (Get-InstalledModule -Name Pester -MinimumVersion 5.0 -ErrorAction SilentlyContinue)
+        if ((Get-Module -ListAvailable -Name Pester -ErrorAction SilentlyContinue).Version -ge [version]'5.0')
         {    
             Write-ScreenInfo -Type Verbose -Message "Testing deployment with Pester"
             $result = Invoke-LabPester -Lab (Get-Lab) -Show Normal -PassThru

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -867,11 +867,17 @@ function Install-Lab
             $hostFileAddedEntries = 0
             foreach ($machine in ($Script:data.Machines | Where-Object {[string]::IsNullOrEmpty($_.FriendlyName)}))
             {
-                if ($machine.Hosttype -eq 'HyperV' -and $machine.NetworkAdapters[0].Ipv4Address -and -not (Get-LabConfigurationItem -Name SkipHostFileModification))
+                if ($machine.HostType -ne 'HyperV' -or (Get-LabConfigurationItem -Name SkipHostFileModification)) { continue }
+                $address = ($machine.NetworkAdapters | Where-Object Default)[0].Ipv4Address
+                if (-not $address)
                 {
-                    $hostFileAddedEntries += Add-HostEntry -HostName $machine.Name -IpAddress $machine.IpV4Address -Section $Script:data.Name
-                    $hostFileAddedEntries += Add-HostEntry -HostName $machine.FQDN -IpAddress $machine.IpV4Address -Section $Script:data.Name
+                    $address = $machine.NetworkAdapters[0].Ipv4Address
                 }
+
+                if (-not $address) { continue }
+
+                $hostFileAddedEntries += Add-HostEntry -HostName $machine.Name -IpAddress $machine.IpV4Address -Section $Script:data.Name
+                $hostFileAddedEntries += Add-HostEntry -HostName $machine.FQDN -IpAddress $machine.IpV4Address -Section $Script:data.Name
             }
 
             if ($hostFileAddedEntries)

--- a/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinitionNetwork.psm1
@@ -307,7 +307,10 @@ function New-LabNetworkAdapterDefinition
         [boolean]$ManagementAdapter = $false,
 
         [string]
-        $MacAddress
+        $MacAddress,
+
+        [bool]
+        $Default
     )
 
     Write-LogFunctionEntry
@@ -318,6 +321,7 @@ function New-LabNetworkAdapterDefinition
     }
 
     $adapter = New-Object -TypeName AutomatedLab.NetworkAdapter
+    $adapter.Default = $Default
     $MacAddress = $MacAddress -replace '[\.\-\:]'
 
     #If the defined interface is flagged as being a Management interface, ignore the virtual switch check as it will not exist yet

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -507,12 +507,12 @@ function New-LWHypervVM
             PassThru         = $true
         }
 
-        if ((Get-Command Add-VMNetworkAdapter).Parameters.Values.Name -contains 'DeviceNaming' -and $vm.Generation -eq 2 -and $Machine.OperatingSystem.Version -ge 10.0)
+        if (-not (Get-LabConfigurationItem -Name DisableDeviceNaming -Default $false) -and (Get-Command Add-VMNetworkAdapter).Parameters.Values.Name -contains 'DeviceNaming' -and $vm.Generation -eq 2 -and $Machine.OperatingSystem.Version -ge 10.0)
         {
-            $parameters['DeviceNaming']
+            $parameters['DeviceNaming'] = 'On'
         }
 
-        $newAdapter = Add-VMNetworkAdapter 
+        $newAdapter = Add-VMNetworkAdapter @parameters
 
         if (-not $adapter.AccessVLANID -eq 0) {
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed issue with cluster roles not being cleaned up properly (thanks @Trentent !)
 - Fixed issue with Get-LWHyperVVm and clusters (thanks @Trentent !)
 - Fixing the (once again) updated kickstart file content - we now carry around three different flavors.
+- NIC order now preserved, specification of default NIC possible as well for connections
 
 ## 5.42.0 (2022-05-05)
 

--- a/LabXml/Machines/NetworkAdapter.cs
+++ b/LabXml/Machines/NetworkAdapter.cs
@@ -132,6 +132,8 @@ namespace AutomatedLab
             set { accessVLANID = value; }
         }
 
+        public bool Default {get; set;}
+
         public NetworkAdapter()
         {
             ipv4Address = new List<IPNetwork>();


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Default IP address to connect was taken from first NIC, after sorting by IP. This can mean unusable IP addresses.

Enables Device Naming on Hyper-V if available, can be deactivated using config system

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [ ] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
