### PR TITLE
Fix AD trust creation where password has single quotes (Fixes #1330)

### DIFF
--- a/AutomatedLab/AutomatedLabADDS.psm1
+++ b/AutomatedLab/AutomatedLabADDS.psm1
@@ -2329,7 +2329,7 @@ function Install-LabADDSTrust
                     [System.DirectoryServices.ActiveDirectory.DirectoryContextType]::Forest,
                     '$($trust.Destination)',
                     '$($domainAdministrator.UserName)',
-                    '$($domainAdministrator.Password)')
+                    '$($domainAdministrator.Password -replace "'","''" )')
                 `$otherForest = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest(`$otherForestCtx)
 
                 Write-Verbose "Creating forest trust between forests '`$(`$thisForest.Name)' and '`$(`$otherForest.Name)'"


### PR DESCRIPTION
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [X ] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [X ] - The PR has a meaningful title.  
- [ X] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ X] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
I installed the module on my local environment and ran with a password which formerly broke the trust creation
