### PR TITLE
Simple FunctionsToExport fix for HostsFile module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixing the (once again) updated kickstart file content - we now carry around three different flavors.
 - NIC order now preserved, specification of default NIC possible as well for connections
 - Fixed issue with cluster resources being added a second time
+- Fixed function importing for the HostsFile module
 
 ## 5.42.0 (2022-05-05)
 

--- a/HostsFile/HostsFile.psd1
+++ b/HostsFile/HostsFile.psd1
@@ -21,7 +21,7 @@
 
     ModuleList             = @('HostsFile')
 
-    FunctionsToExport      = 'Add-HostEntry', 'Clear-HostFile', 'Get-HostEntry', 'Open-HostFile', 'Remove-HostEntry', 'Save-HostFile'
+    FunctionsToExport      = 'Add-HostEntry', 'Clear-HostFile', 'Get-HostEntry', 'Get-HostFile', 'Remove-HostEntry'
 
     FileList               = @('HostsFile.psm1', 'HostsFile.psd1')
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

I updated the `FunctionsToExport` in the `HostsFile.psd1` to reflect the functions present in `HostsFile.psm1`.

I initially noticed this issue after trying to use the module to list out all the hosts in my `hosts` file and couldn't find a command for it even though one was present in the `HostsFile.psm1` file.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

Since this is a simple change, I imported the module:

```powershell
Import-Module .\HostsFile
```

And then first ensured that all the expected commands were present:

```powershell
Get-Command -Module HostsFile
```

The expected output was seen:

```text
CommandType Name             Version Source
----------- ----             ------- ------
Function    Add-HostEntry    1.0.0   HostsFile
Function    Clear-HostFile   1.0.0   HostsFile
Function    Get-HostEntry    1.0.0   HostsFile
Function    Get-HostFile     1.0.0   HostsFile
Function    Remove-HostEntry 1.0.0   HostsFile
```

I tested the now present `Get-HostFile` command and found it to be working. It output my hosts file and parsed the addresses and host names as I would expect.
