### PR TITLE
Fixes #1333

### DIFF
--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -1400,7 +1400,7 @@ function Get-LabAzureAvailableRoleSize
     foreach ($vms in Get-AzVMSize -Location $azLocation.Location | Where-Object -Property Name -in $availableRoleSizes.Name)
     {
         $rsInfo = $availableRoleSizes | Where-Object Name -eq $vms.Name
-        $vms | Add-Member -NotePropertyName Generation -NotePropertyValue (($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -split ',')
+        $vms | Add-Member -NotePropertyName Generation -NotePropertyValue (($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -split ',') -PassThru
     }
 }
 

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -323,7 +323,8 @@ function Add-LabAzureSubscription
     {
         throw "No available role sizes in region '$DefaultLocationName'! Cannot continue."
     }
-    $script:lab.AzureSettings.RoleSizes = [AutomatedLab.Azure.AzureRmVmSize]::Create($roleSizes)
+
+    $script:lab.AzureSettings.RoleSizes = $rolesizes
 
     # Add LabSources storage
     New-LabAzureLabSourcesStorage
@@ -428,6 +429,16 @@ Get/Set/Register/Unregister-PSFConfig -Module AutomatedLab -Name AutoSyncLabSour
         elseif ($choice -eq 1)
         {
             Set-PSFConfig -Module AutomatedLab -Name AutoSyncLabSources -Value $false -PassThru | Register-PSFConfig
+        }
+
+        $timestamps.LabSourcesSynced = Get-Date
+        if ($IsLinux -or $IsMacOs)
+        {
+            $timestamps.Export((Join-Path -Path (Get-LabConfigurationItem -Name LabAppDataRoot) -ChildPath 'Stores/Timestamps.xml'))
+        }
+        else
+        {
+            $timestamps.ExportToRegistry('Cache', 'Timestamps')
         }
     }
 
@@ -1397,10 +1408,20 @@ function Get-LabAzureAvailableRoleSize
         $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription'
     }
 
-    foreach ($vms in Get-AzVMSize -Location $azLocation.Location | Where-Object -Property Name -in $availableRoleSizes.Name)
+    foreach ($vms in (Get-AzVMSize -Location $azLocation.Location | Where-Object -Property Name -in $availableRoleSizes.Name))
     {
         $rsInfo = $availableRoleSizes | Where-Object Name -eq $vms.Name
-        $vms | Add-Member -NotePropertyName Generation -NotePropertyValue (($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -split ',') -PassThru
+
+            [AutomatedLab.Azure.AzureRmVmSize]@{
+                NumberOfCores = $vms.NumberOfCores
+                MemoryInMB = $vms.MemoryInMB
+                Name = $vms.Name
+                MaxDataDiskCount = $vms.MaxDataDiskCount
+                ResourceDiskSizeInMB = $vms.ResourceDiskSizeInMB
+                OSDiskSizeInMB = $vms.OSDiskSizeInMB
+                Gen1Supported = ($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -like '*v1*'
+                Gen2Supported = ($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -like '*v2*'
+            }
     }
 }
 

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -1395,9 +1395,13 @@ function Get-LabAzureAvailableRoleSize
 
     $availableRoleSizes = Get-AzComputeResourceSku -Location $azLocation.Location | Where-Object {
         $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription'
-    } | Select-Object -ExpandProperty Name
+    }
 
-    Get-AzVMSize -Location $azLocation.Location | Where-Object -Property Name -in $availableRoleSizes
+    foreach ($vms in Get-AzVMSize -Location $azLocation.Location | Where-Object -Property Name -in $availableRoleSizes.Name)
+    {
+        $rsInfo = $availableRoleSizes | Where-Object Name -eq $vms.Name
+        $vms | Add-Member -NotePropertyName Generation -NotePropertyValue (($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -split ',')
+    }
 }
 
 function Get-LabAzureAvailableSku

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1572,7 +1572,7 @@ function Add-LabIsoImageDefinition
 
                 if (-not $isoFiles -and $Name)
                 {
-                    $filterPath = Split-Path -Path $Path -Leaf
+                    $filterPath = (Split-Path -Path $Path -Leaf) -replace '\\','/' # Due to breaking changes introduced in Az.Storage 4.7.0
                     Write-ScreenInfo -Message "Syncing $filterPath with Azure lab sources storage as it did not exist"
                     Sync-LabAzureLabSources -Filter $filterPath -NoDisplay
 

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -606,14 +606,15 @@
 
         Write-ScreenInfo -Type Verbose -Message ('Adding machine template')
         $vmSize = Get-LWAzureVmSize -Machine $Machine
-        $imageRef = (Get-LWAzureSku -Machine $machine).sku
+        $imageRef = Get-LWAzureSku -Machine $machine
+
         if ($vmSize.Generation -contains 'v2')
         {
-            $pattern = '{0}(-g2$|gen2|-gensecond$)' -f $imageRef # Yes, why should the image names be consistent? Also of course we don't need a damn VMGeneration property...
-            $newImage = ($lab.AzureSettings.VMImages | Where-Object Skus -match $pattern).Skus
+            $pattern = '{0}(-g2$|gen2|-gensecond$)' -f $imageRef.sku # Yes, why should the image names be consistent? Also of course we don't need a damn VMGeneration property...
+            $newImage = $lab.AzureSettings.VMImages | Where-Object Skus -match $pattern
             if (-not $newImage)
             {
-                Write-LogFunctionExitWithError -Message "Selected VM size $vmSize for $Machine only suppports G2 VMs, however no matching Generation 2 image was found for your selection, $imageRef!"
+                Write-LogFunctionExitWithError -Message "Selected VM size $vmSize for $Machine only suppports G2 VMs, however no matching Generation 2 image was found for your selection: Publisher $($imageRef.publisher), offer $($imageRef.offer), sku $($imageRef.skus)!"
                 return
             }
             $imageRef = $newImage
@@ -769,15 +770,33 @@ function Get-LWAzureVmSize
     }
     else
     {
-        switch ($lab.AzureSettings.DefaultRoleSize)
+        $pattern = switch ($lab.AzureSettings.DefaultRoleSize)
         {
-            'A' { $pattern = '^(Standard_A\d{1,2}|Basic_A\d{1,2})' }
-            'D' { $pattern = '^Standard_D\d{1,2}' }
-            'DS' { $pattern = '^Standard_DS\d{1,2}' }
-            'DC' { $pattern = '^Standard_DC\d{1,2}' }
-            'G' { $pattern = '^Standard_G\d{1,2}' }
-            'F' { $pattern = '^Standard_F\d{1,2}' }
-            default { $pattern = '^(Standard_A\d{1,2}|Basic_A\d{1,2})'}
+            'A' { '^(Standard_A\d{1,2}|Basic_A\d{1,2})' }
+            'AS' { '^Standard_AS\d{1,2}' }
+            'AC' { '^Standard_AC\d{1,2}' }
+            'D' { '^Standard_D\d{1,2}' }
+            'DS' { '^Standard_DS\d{1,2}' }
+            'DC' { '^Standard_DC\d{1,2}' }
+            "E" { '^Standard_E\d{1,2}' }
+            "ES" { '^Standard_ES\d{1,2}' }
+            "EC" { '^Standard_EC\d{1,2}' }
+            'F' { '^Standard_F\d{1,2}' }
+            'FS' { '^Standard_FS\d{1,2}' }
+            'FC' { '^Standard_FC\d{1,2}' }
+            'G' { '^Standard_G\d{1,2}' }
+            'GS' { '^Standard_GS\d{1,2}' }
+            'GC' { '^Standard_GC\d{1,2}' }
+            'H' {'^Standard_H\d{1,2}'}
+            'HS' { '^Standard_HS\d{1,2}' }
+            'HC' { '^Standard_HC\d{1,2}' }
+            'L' {'^Standard_L\d{1,2}'}
+            'LS' { '^Standard_LS\d{1,2}' }
+            'LC' { '^Standard_LC\d{1,2}' }
+            'N' {'^Standard_N\d{1,2}'}
+            'NS' { '^Standard_NS\d{1,2}' }
+            'NC' { '^Standard_NC\d{1,2}' }
+            default { '^(Standard_A\d{1,2}|Basic_A\d{1,2})'}
         }
 
         $roleSize = $lab.AzureSettings.RoleSizes |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Enhancements
 
+- Enabling additional role sizes, who are we to judge
+
 ### Bugs
 
 - Fixing serialization issue in SCOM role
+- Fixing issue with Azure role sizes requiring Gen 2 VMs
+- Fixing issue with Az.Storage module not being able to use backslashes
 
 ## 5.43.0 (2022-06-30)
 

--- a/LabXml/Azure/AzureRmVmSize.cs
+++ b/LabXml/Azure/AzureRmVmSize.cs
@@ -12,11 +12,11 @@ namespace AutomatedLab.Azure
         public int? MaxDataDiskCount { get; set; }
         public int ResourceDiskSizeInMB { get; set; }
         public int OSDiskSizeInMB { get; set; }
-        public List<string> Generation {get; set;}
+        public SerializableList<string> Generation {get; set;}
 
         public AzureRmVmSize()
         {
-            Generation = new List<string>(){ "v1" };
+            Generation = new SerializableList<string>();
         }
 
         public override string ToString()

--- a/LabXml/Azure/AzureRmVmSize.cs
+++ b/LabXml/Azure/AzureRmVmSize.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace AutomatedLab.Azure
 {
@@ -11,9 +12,12 @@ namespace AutomatedLab.Azure
         public int? MaxDataDiskCount { get; set; }
         public int ResourceDiskSizeInMB { get; set; }
         public int OSDiskSizeInMB { get; set; }
+        public List<string> Generation {get; set;}
 
         public AzureRmVmSize()
-        { }
+        {
+            Generation = new List<string>(){ "v1" };
+        }
 
         public override string ToString()
         {

--- a/LabXml/Azure/AzureRmVmSize.cs
+++ b/LabXml/Azure/AzureRmVmSize.cs
@@ -12,12 +12,11 @@ namespace AutomatedLab.Azure
         public int? MaxDataDiskCount { get; set; }
         public int ResourceDiskSizeInMB { get; set; }
         public int OSDiskSizeInMB { get; set; }
-        public SerializableList<string> Generation {get; set;}
+        public bool Gen1Supported {get; set;}
+        public bool Gen2Supported {get; set;}
 
         public AzureRmVmSize()
-        {
-            Generation = new SerializableList<string>();
-        }
+        {  }
 
         public override string ToString()
         {


### PR DESCRIPTION
## Description
Fixes #1333 

- Enabling additional role sizes
- Fixing issue with Azure role sizes requiring Gen 2 VMs
- Fixing issue with Az.Storage module not being able to use backslashes

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
```powershell
New-LabDefinition -Name Scom2019Dev -DefaultVirtualizationEngine Azure

Add-LabAzureSubscription -DefaultLocationName 'west europe'

$PSDefaultParameterValues = @{
    'Add-LabMachineDefinition:OperatingSystem' = 'Windows Server 2019 Datacenter (Desktop Experience)'
    'Add-LabMachineDefinition:DomainName'      = 'contoso.com'
    'Add-LabMachineDefinition:Memory'          = 8GB
    'Add-LabMachineDefinition:Tools'          = "$labsources\Tools"
}

# Define the domain environment
Add-LabDomainDefinition -Name contoso.com -AdminUser Install -AdminPassword Somepass1
Set-LabInstallationCredential -Username Install -Password Somepass1

Add-LabIsoImageDefinition -Name ScomManagement -Path $labsources\ISOs\mu_system_center_operations_manager_2019_x64_dvd_b3488f5c.iso -verbo
Add-LabIsoImageDefinition -Name ScomManagement1 -Path $labsources/ISOs/mu_system_center_operations_manager_2019_x64_dvd_b3488f5c.iso -verbo


Add-LabMachineDefinition -Name DC01  -Roles RootDc -Domain contoso.com -AzureRoleSize Standard_DS2_v2
Add-LabMachineDefinition -Name SCOM2019  -Roles SQLServer2017,ScomReporting,ScomManagement,ScomConsole -Domain contoso.com -AzureRoleSize Standard_DC4s_v3

Install-Lab
Show-LabDeploymentSummary -Detailed
```