### PR TITLE
Add ReferenceDisk parameter

### DIFF
--- a/AutomatedLab/AutomatedLabDisks.psm1
+++ b/AutomatedLab/AutomatedLabDisks.psm1
@@ -13,7 +13,7 @@ function New-LabBaseImages
         return
     }
 
-    $oses = (Get-LabVm -All).OperatingSystem
+    $oses = (Get-LabVm -All | Where-Object {[string]::IsNullOrWhiteSpace($_.ReferenceDiskPath)}).OperatingSystem
 
     if (-not $lab.Sources.AvailableOperatingSystems)
     {

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2087,11 +2087,17 @@ function Add-LabMachineDefinition
         }
 
         $machine = New-Object AutomatedLab.Machine
-        if ($ReferenceDisk)
+        if ($ReferenceDisk -and $script:lab.DefaultVirtualizationEngine -eq 'HyperV')
         {
             Write-ScreenInfo -Type Warning -Message "Usage of the ReferenceDisk parameter makes your lab essentially unsupportable. Don't be mad at us if we cannot reproduce your random issue if you bring your own images."
             $machine.ReferenceDiskPath = $ReferenceDisk
         }
+
+        if ($ReferenceDisk -and $script:lab.DefaultVirtualizationEngine -ne 'HyperV')
+        {
+            Write-ScreenInfo -Type Warning -Message "Sorry, no custom reference disk allowed on $($script:lab.DefaultVirtualizationEngine). This parameter will be ignored."
+        }
+
         $machine.Name = $Name
         $machine.FriendlyName = $ResourceName
         $machine.OrganizationalUnit = $OrganizationalUnit

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -1943,7 +1943,9 @@ function Add-LabMachineDefinition
 
         [string]$SshPrivateKeyPath,
 
-        [string]$OrganizationalUnit
+        [string]$OrganizationalUnit,
+        
+        [string]$ReferenceDisk
     )
 
     begin
@@ -2085,6 +2087,11 @@ function Add-LabMachineDefinition
         }
 
         $machine = New-Object AutomatedLab.Machine
+        if ($ReferenceDisk)
+        {
+            Write-ScreenInfo -Type Warning -Message "Usage of the ReferenceDisk parameter makes your lab essentially unsupportable. Don't be mad at us if we cannot reproduce your random issue if you bring your own images."
+            $machine.ReferenceDiskPath = $ReferenceDisk
+        }
         $machine.Name = $Name
         $machine.FriendlyName = $ResourceName
         $machine.OrganizationalUnit = $OrganizationalUnit

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -431,7 +431,7 @@ function New-LWHypervVM
     }
     else
     {
-        $referenceDiskPath = $Machine.OperatingSystem.BaseDiskPath
+        $referenceDiskPath = if ($Machine.ReferenceDiskPath) { $Machine.ReferenceDiskPath } else { $Machine.OperatingSystem.BaseDiskPath }
         $systemDisk = New-VHD -Path $path -Differencing -ParentPath $referenceDiskPath -ErrorAction Stop
         Write-PSFMessage "`tcreated differencing disk '$($systemDisk.Path)' pointing to '$ReferenceVhdxPath'"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Enabling additional role sizes, who are we to judge
 - Set-LabDefaultOperatingSystem now supports Azure as well
+- Supporting arbitrary reference disk paths for individual VMs
 
 ### Bugs
 

--- a/LabXml/Machines/Machine.cs
+++ b/LabXml/Machines/Machine.cs
@@ -89,6 +89,7 @@ namespace AutomatedLab
         public string SshPublicKeyPath { get; set; }
         public string SshPrivateKeyPath { get; set; }
         public string OrganizationalUnit { get; set; }
+        public string ReferenceDiskPath {get; set;}
 
         public OperatingSystemType OperatingSystemType
         {


### PR DESCRIPTION
## Description

Fixes #1264 by adding a new ReferenceDisk parameter

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
```powershell
New-LabDefinition -Name ItsTheSmallThings -DefaultVirtualizationEngine HyperV

Add-LabMachineDefinition -Name Blobby -Memory 8GB -ReferenceDisk "D:\SomeOtherPath\BASE_WindowsServer2022Datacenter(DesktopExperience)_10.0.20292.1_50.vhdx" -OperatingSystem 'Windows Server 2022 Datacenter (Desktop Experience)'

Install-Lab
```