### PR TITLE
Compatibility for ancient server versions

### DIFF
--- a/AutomatedLabTest/internal/tests/RootDC.tests.ps1
+++ b/AutomatedLabTest/internal/tests/RootDC.tests.ps1
@@ -19,7 +19,7 @@ Describe "[$($Lab.Name)] DC Generic" -Tag RootDC, DC, FirstChildDC {
         {
             It "$vm should respond to ADWS calls" -TestCases @{vm = $vm } {
             
-                { Invoke-LabCommand -ComputerName $vm -ScriptBlock { Get-ADUser -Identity $env:USERNAME } -PassThru -NoDisplay } | Should -Not -Throw
+                { Invoke-LabCommand -ComputerName $vm -ScriptBlock { Import-Module ActiveDirectory; Get-ADUser -Identity $env:USERNAME } -PassThru -NoDisplay } | Should -Not -Throw
             }
         }
     }
@@ -31,7 +31,7 @@ Describe "[$($Lab.Name)] RootDC specific" -Tag RootDC {
     {
         It "$(Get-LabVM -Role RootDC) should hold PDC emulator FSMO role" -TestCases @{vm = $vm } {
         
-            Invoke-LabCommand -ComputerName $vm -ScriptBlock { (Get-ADDomain).PDCEmulator } -PassThru -NoDisplay | Should -Be $vm.FQDN
+            Invoke-LabCommand -ComputerName $vm -ScriptBlock { Import-Module ActiveDirectory; (Get-ADDomain).PDCEmulator } -PassThru -NoDisplay | Should -Be $vm.FQDN
         }
     }
 }


### PR DESCRIPTION

## Description

Fixes #1357 but there is no telling how much else there is hidden in the many remote commands we use to configure modern systems.

The rest of the fix is to `Install-Module AutomatedLab.Common -RequiredVersion 2.2.242` since the error message comes from there.

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
