### PR TITLE
Fixes #1365, Error when assigning more than one IP address to a machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Repair-LWHyperVNetworkConfig: WSMAN EnvelopeSize caused issues
 - Get-LWHyperVVM: Issue with too many VMs returned in a cluster
 - Revert to old version of ApplicationInsights which is currently distributed with PowerShell 7
+- Fixed #1365. Only the first IP of a machine is registered using `Add-HostEntry`
 
 ## 5.44.0 (2022-07-22)
 


### PR DESCRIPTION
## Description

Fixes #1365.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Tested with:

```
#It couldn't be easier. These 3 lines install a lab with just a single Windows 10 machine.
#AL takes care of configuring network settings like creating a virtual switch and finding a suitable IP range.

New-LabDefinition -Name 1365 -DefaultVirtualizationEngine HyperV

Add-LabVirtualNetworkDefinition -Name N1 -AddressSpace 192.168.55.0/24
Add-LabVirtualNetworkDefinition -Name N2 -AddressSpace 192.168.56.0/24

$nics = @()
$nics += New-LabNetworkAdapterDefinition -VirtualSwitch N1 -Ipv4Address 192.168.55.10, 192.168.55.11 -InterfaceName Corp
$nics += New-LabNetworkAdapterDefinition -VirtualSwitch N2 -Ipv4Address 192.168.56.10 -InterfaceName Backup
Add-LabMachineDefinition -Name S1 -Memory 4GB -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)' -NetworkAdapter $nics

$nics = New-LabNetworkAdapterDefinition -VirtualSwitch N1 -Ipv4Address 192.168.55.20, 192.168.55.21 -InterfaceName Corp
Add-LabMachineDefinition -Name S2 -Memory 4GB -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)' -NetworkAdapter $nics

Add-LabMachineDefinition -Name S3 -Memory 4GB -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)' -IpAddress 192.168.55.30 -Network N1

Install-Lab
```
