### PR TITLE
Enable SSH Remoting for all Azure labs

### DIFF
--- a/AutomatedLab/AutomatedLab.init.ps1
+++ b/AutomatedLab/AutomatedLab.init.ps1
@@ -124,6 +124,7 @@ Set-PSFConfig -Module 'AutomatedLab' -Name OsRoot -Value $osroot -Initialize -Va
 Set-PSFConfig -Module 'AutomatedLab' -Name OverridePowerPlan -Value $true -Initialize -Validation bool -Description 'On Windows: Indicates that power settings will be set to High Power during lab deployment'
 Set-PSFConfig -Module 'AutomatedLab' -Name SendFunctionTelemetry -Value $false -Initialize -Validation bool -Description 'Indicates if function call telemetry is sent' -Hidden
 Set-PSFConfig -Module 'AutomatedLab' -Name DoNotPrompt -Value $false -Initialize -Validation bool -Description 'Indicates that AutomatedLab should not display prompts. Workaround for environments that register as interactive, even if they are not' -Hidden
+Set-PSFConfig -Module 'AutomatedLab' -Name DoNotWaitForLinux -Value $false -Initialize -Validation bool -Description 'Indicates that you will not wait for Linux VMs to be ready, e.g. because you are offline and PowerShell cannot be installed.'
 
 #PSSession settings
 Set-PSFConfig -Module 'AutomatedLab' -Name InvokeLabCommandRetries -Value 3 -Initialize -Validation integer -Description 'Number of retries for Invoke-LabCommand'

--- a/AutomatedLab/AutomatedLab.psd1
+++ b/AutomatedLab/AutomatedLab.psd1
@@ -66,7 +66,7 @@
         'HostsFile',
         'AutomatedLabUnattended',
         'AutomatedLabNotifications',
-        @{ModuleName='AutomatedLab.Common'; ModuleVersion='2.1.230'; }
+        @{ModuleName='AutomatedLab.Common'; ModuleVersion='2.2.247'; }
         'PSFramework'
         'AutomatedLabTest'
     )

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1296,7 +1296,7 @@ function Install-Lab
         $linuxHosts = (Get-LabVM -IncludeLinux | Where-Object OperatingSystemType -eq 'Linux').Count
         Write-ScreenInfo -Message 'Starting remaining machines' -TaskStart
         $timeoutRemaining = 60
-        if ($linuxHosts)
+        if ($linuxHosts -and -not (Get-LabConfigurationItem -Name DoNotWaitForLinux -Default $false))
         {
             $timeoutRemaining = 15
             Write-ScreenInfo -Type Warning -Message "There are $linuxHosts Linux hosts in the lab.
@@ -1325,7 +1325,8 @@ function Install-Lab
 
         Write-ScreenInfo -Message 'Waiting for machines to start up...' -NoNewLine
 
-        Start-LabVM -All -DelayBetweenComputers $DelayBetweenComputers -ProgressIndicator 30 -TimeoutInMinutes $timeoutRemaining -Wait
+        $toStart = Get-LabVM -IncludeLinux:$(-not (Get-LabConfigurationItem -Name DoNotWaitForLinux -Default $false))
+        Start-LabVM -ComputerName $toStart -DelayBetweenComputers $DelayBetweenComputers -ProgressIndicator 30 -TimeoutInMinutes $timeoutRemaining -Wait
 
         $userName = (Get-Lab).DefaultInstallationCredential.UserName
         $nonDomainControllers = Get-LabVM -Filter { $_.Roles.Name -notcontains 'RootDc' -and $_.Roles.Name -notcontains 'DC' -and $_.Roles.Name -notcontains 'FirstChildDc' -and -not $_.SkipDeployment }

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1382,7 +1382,7 @@ function Install-Lab
         Write-ScreenInfo -Message 'Done' -TaskEnd
     }
 
-    if ($InstallSshKnownHosts -or $performAll)
+    if (($InstallSshKnownHosts -and (Get-LabVm).SshPublicKey) -or $performAll)
     {
         Write-ScreenInfo -Message "Adding lab machines to $home/.ssh/known_hosts" -TaskStart
         

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1583,8 +1583,11 @@ function Remove-Lab
                 Write-ScreenInfo -Message 'Removing entries in the hosts file'
                 Clear-HostFile -Section $Script:data.Name -ErrorAction SilentlyContinue
 
-                Write-ScreenInfo -Message 'Removing SSH known hosts'
-                UnInstall-LabSshKnownHost
+                if ($labMachines.SshPublicKey)
+                {
+                    Write-ScreenInfo -Message 'Removing SSH known hosts'
+                    UnInstall-LabSshKnownHost
+                }
             }
 
             Write-ScreenInfo -Message 'Removing virtual networks'

--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1332,7 +1332,14 @@ function Install-Lab
         if ($nonDomainControllers) {
             Invoke-LabCommand -ActivityName 'Setting PasswordNeverExpires for local deployment accounts' -ComputerName $nonDomainControllers -ScriptBlock {
                 # Still supporting ANCIENT server 2008 R2 with it's lack of CIM cmdlets :'(
-                Get-WmiObject -Query "Select * from Win32_UserAccount where name = '$userName' and localaccount='true'" | Set-WmiInstance -Arguments @{ PasswordExpires = $false}
+                    if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)
+                    {
+                        Get-CimInstance -Query "Select * from Win32_UserAccount where name = '$userName' and localaccount='true'" | Set-CimInstance -Property @{ PasswordExpires = $false}
+                    }
+                    else
+                    {
+                        Get-WmiObject -Query "Select * from Win32_UserAccount where name = '$userName' and localaccount='true'" | Set-WmiInstance -Arguments @{ PasswordExpires = $false}
+                    }
             } -Variable (Get-Variable userName) -NoDisplay
         }
 

--- a/AutomatedLab/AutomatedLabADCS.psm1
+++ b/AutomatedLab/AutomatedLabADCS.psm1
@@ -1281,26 +1281,14 @@ function Get-LabCertificate
     Write-LogFunctionEntry
 
     $variables = Get-Variable -Name PSBoundParameters
-    $functions = Get-Command -Name Get-Certificate2, Sync-Parameter
 
     foreach ($computer in $ComputerName)
     {
-        Invoke-LabCommand -ActivityName "Adding 'AutomatedLab.Common.dll'" -ComputerName $ComputerName -ScriptBlock {
-            if ($PSEdition -eq 'core')
-            {
-                Add-Type -Path '/ALLibraries/core/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
-            }
-            elseif ([System.Environment]::OSVersion.Version -ge '6.3')
-            {
-                Add-Type -Path '/ALLibraries/full/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
-            }
-        } -NoDisplay
-
         Invoke-LabCommand -ActivityName 'Exporting certificates' -ComputerName $ComputerName -ScriptBlock {
             Sync-Parameter -Command (Get-Command -Name Get-Certificate2)
             Get-Certificate2 @ALBoundParameters
 
-        } -Variable $variables -Function $functions -PassThru -NoDisplay
+        } -Variable $variables -PassThru -NoDisplay
     }
 
     Write-LogFunctionExit
@@ -1347,18 +1335,6 @@ function Add-LabCertificate
     process
     {
         $variables = Get-Variable -Name PSBoundParameters
-        $functions = Get-Command -Name Add-Certificate2, Sync-Parameter
-
-        Invoke-LabCommand -ActivityName "Adding 'AutomatedLab.Common.dll'" -ComputerName $ComputerName -ScriptBlock {
-            if ($PSEdition -eq 'core')
-            {
-                Add-Type -Path '/ALLibraries/core/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
-            }
-            elseif ([System.Environment]::OSVersion.Version -ge '6.3')
-            {
-                Add-Type -Path '/ALLibraries/full/AutomatedLab.Common.dll' -ErrorAction SilentlyContinue
-            }
-        } -NoDisplay
 
         if ($Path)
         {
@@ -1372,7 +1348,7 @@ function Add-LabCertificate
             Sync-Parameter -Command (Get-Command -Name Add-Certificate2)
             Add-Certificate2 @ALBoundParameters | Out-Null
 
-        } -Variable $variables -Function $functions -PassThru -NoDisplay
+        } -Variable $variables -PassThru -NoDisplay
 
     }
 

--- a/AutomatedLab/AutomatedLabADCS.psm1
+++ b/AutomatedLab/AutomatedLabADCS.psm1
@@ -2421,7 +2421,14 @@ function Install-LabCAMachine
             $DatabaseDirectoryDrive = ($param.DatabaseDirectory.split(':')[0]) + ':'
 
             $disk = Invoke-LabCommand -ComputerName $Machine -ScriptBlock {
-                Get-WmiObject -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$DatabaseDirectoryDrive"""
+                if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)
+                {
+                    Get-CimInstance -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$DatabaseDirectoryDrive"""
+                }
+                else
+                {
+                    Get-WmiObject -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$DatabaseDirectoryDrive"""
+                }
             } -Variable (Get-Variable -Name DatabaseDirectoryDrive) -PassThru
 
             if (-not $disk -or -not $disk.DriveType -eq 3)
@@ -2435,7 +2442,14 @@ function Install-LabCAMachine
         {
             $LogDirectoryDrive = ($param.LogDirectory.split(':')[0]) + ':'
             $disk = Invoke-LabCommand -ComputerName $Machine -ScriptBlock {
-                Get-WmiObject -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$LogDirectoryDrive"""
+                if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)
+                {
+                    Get-CimInstance -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$LogDirectoryDrive"""
+                }
+                else
+                {
+                    Get-WmiObject -Namespace Root\CIMV2 -Class Win32_LogicalDisk -Filter "DeviceID = ""$LogDirectoryDrive"""
+                }
             } -Variable (Get-Variable -Name LogDirectoryDrive) -PassThru
             if (-not $disk -or -not $disk.DriveType -eq 3)
             {
@@ -3047,7 +3061,16 @@ function Publish-LabCAInstallCertificates
             {
                 Write-Verbose -Message "Install certificate ($((Get-PfxCertificate $certfile.FullName).Subject)) on machine $(hostname)"
                 #If workgroup, publish to local store
-                if ((Get-WmiObject -Namespace root\cimv2 -Class Win32_ComputerSystem).DomainRole -eq 2)
+                $domJoined = if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)
+                {
+                    (Get-CimInstance -Namespace root\cimv2 -Class Win32_ComputerSystem).DomainRole -eq 2
+                }
+                else
+                {
+                    (Get-WmiObject -Namespace root\cimv2 -Class Win32_ComputerSystem).DomainRole -eq 2
+                }
+
+                if ($domJoined)
                 {
                     Write-Verbose -Message '  Machine is not domain joined. Publishing certificate to local store'
 

--- a/AutomatedLab/AutomatedLabADDS.psm1
+++ b/AutomatedLab/AutomatedLabADDS.psm1
@@ -1765,7 +1765,14 @@ function Reset-DNSConfiguration
             (
                 $DnsServers
             )
-            $AdapterNames = (Get-WmiObject -Namespace Root\CIMv2 -Class Win32_NetworkAdapter | Where-Object {$_.PhysicalAdapter}).NetConnectionID
+            $AdapterNames = if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)
+            {
+                (Get-CimInstance -Namespace Root\CIMv2 -Class Win32_NetworkAdapter | Where-Object {$_.PhysicalAdapter}).NetConnectionID
+            }
+            else
+            {
+                (Get-WmiObject -Namespace Root\CIMv2 -Class Win32_NetworkAdapter | Where-Object {$_.PhysicalAdapter}).NetConnectionID
+            }
             foreach ($AdapterName in $AdapterNames)
             {
                 netsh.exe interface ipv4 set dnsservers "$AdapterName" static $DnsServers primary

--- a/AutomatedLab/AutomatedLabHybrid.psm1
+++ b/AutomatedLab/AutomatedLabHybrid.psm1
@@ -512,8 +512,16 @@ function Connect-OnPremisesWithAzure
             $MacAddress
         )
 
-        $externalAdapter = Get-WmiObject -Class Win32_NetworkAdapter -Filter ('MACAddress = "{0}"' -f $MacAddress) |
-            Select-Object -ExpandProperty NetConnectionID
+        if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)
+        {
+            $externalAdapter = Get-CimInstance -Class Win32_NetworkAdapter -Filter ('MACAddress = "{0}"' -f $MacAddress) |
+                Select-Object -ExpandProperty NetConnectionID
+        }
+        else
+        {
+            $externalAdapter = Get-WmiObject -Class Win32_NetworkAdapter -Filter ('MACAddress = "{0}"' -f $MacAddress) |
+                Select-Object -ExpandProperty NetConnectionID
+        }
 
         Set-Service -Name RemoteAccess -StartupType Automatic
         Start-Service -Name RemoteAccess -ErrorAction SilentlyContinue

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -1317,13 +1317,13 @@ function Install-LabSshKnownHost
     {
         if ($lab.DefaultVirtualizationEngine -eq 'Azure')
         {
-            ssh-keyscan -p $machine.LoadBalancerSshPort $machine.AzureConnectionInfo.DnsName | Add-Content $home/.ssh/known_hosts
-            ssh-keyscan -p $machine.LoadBalancerSshPort $machine.AzureConnectionInfo.VIP | Add-Content $home/.ssh/known_hosts
+            ssh-keyscan -p $machine.LoadBalancerSshPort $machine.AzureConnectionInfo.DnsName 2>$null | Add-Content $home/.ssh/known_hosts
+            ssh-keyscan -p $machine.LoadBalancerSshPort $machine.AzureConnectionInfo.VIP 2>$null | Add-Content $home/.ssh/known_hosts
         }
         else
         {
-            ssh-keyscan $machine.Name | Add-Content $home/.ssh/known_hosts
-            if ($machine.IpV4Address) {ssh-keyscan $machine.IpV4Address | Add-Content $home/.ssh/known_hosts}
+            ssh-keyscan $machine.Name 2>$null | Add-Content $home/.ssh/known_hosts
+            if ($machine.IpV4Address) {ssh-keyscan $machine.IpV4Address 2>$null | Add-Content $home/.ssh/known_hosts}
         }
     }
 }

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -181,7 +181,7 @@ function New-LabPSSession
                 $param.Remove('UseSsl')
                 $param['KeyFilePath'] = $m.SshPrivateKeyPath
                 $param['Port'] = if ($m.HostType -eq 'Azure') {$m.AzureConnectionInfo.SshPort} else { 22 }
-                $param['UserName'] = $cred.UserName
+                $param['UserName'] = $cred.UserName.Replace("$($m.Name)\", '')
             }
             elseif ($m.OperatingSystemType -eq 'Linux')
             {

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -182,7 +182,6 @@ function New-LabPSSession
                 $param['KeyFilePath'] = $m.SshPrivateKeyPath
                 $param['Port'] = if ($m.HostType -eq 'Azure') {$m.AzureConnectionInfo.SshPort} else { 22 }
                 $param['UserName'] = $cred.UserName
-                $connectionName = $m.Name
             }
             elseif ($m.OperatingSystemType -eq 'Linux')
             {
@@ -1316,8 +1315,15 @@ function Install-LabSshKnownHost
 
     foreach ($machine in $machines)
     {
-        ssh-keyscan $machine.Name | Add-Content $home/.ssh/known_hosts
-        if ($machine.IpV4Address) {ssh-keyscan $machine.IpV4Address | Add-Content $home/.ssh/known_hosts}
+        if ($lab.DefaultVirtualizationEngine -eq 'Azure')
+        {
+            ssh-keyscan -p $machine.LoadBalancerSshPort $machine.AzureConnectionInfo.DnsName | Add-Content $home/.ssh/known_hosts
+        }
+        else
+        {
+            ssh-keyscan $machine.Name | Add-Content $home/.ssh/known_hosts
+            if ($machine.IpV4Address) {ssh-keyscan $machine.IpV4Address | Add-Content $home/.ssh/known_hosts}
+        }
     }
 }
 #endregion

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -166,11 +166,12 @@ function New-LabPSSession
                 $param.Add('Port', 5985)
             }
 
-            if (((Get-Command New-PSSession).Parameters.Values.Name -notcontains 'HostName') -and $m.OperatingSystemType -eq 'Linux' -and -not [string]::IsNullOrWhiteSpace($m.SshPrivateKeyPath))
+            if (((Get-Command New-PSSession).Parameters.Values.Name -notcontains 'HostName') -and -not [string]::IsNullOrWhiteSpace($m.SshPrivateKeyPath))
             {
                 Write-ScreenInfo -Type Warning -Message "SSH Transport is not available from within Windows PowerShell."
             }
-            if (((Get-Command New-PSSession).Parameters.Values.Name -contains 'HostName') -and $m.OperatingSystemType -eq 'Linux' -and -not [string]::IsNullOrWhiteSpace($m.SshPrivateKeyPath))
+
+            if (($lab.DefaultVirtualizationEngine -eq 'Azure' -or (((Get-Command New-PSSession).Parameters.Values.Name -contains 'HostName') -and $m.OperatingSystemType -eq 'Linux')) -and -not [string]::IsNullOrWhiteSpace($m.SshPrivateKeyPath))
             {
                 $param['HostName'] = $param['ComputerName']
                 $param.Remove('ComputerName')

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -1313,6 +1313,8 @@ function Install-LabSshKnownHost
         return
     }
 
+    if (-not (Test-Path -Path $home/.ssh/known_hosts)) {$null = New-Item -ItemType File -Path $home/.ssh/known_hosts}
+
     foreach ($machine in $machines)
     {
         if ($lab.DefaultVirtualizationEngine -eq 'Azure')

--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -1330,7 +1330,7 @@ function Install-LabSshKnownHost
         return
     }
 
-    if (-not (Test-Path -Path $home/.ssh/known_hosts)) {$null = New-Item -ItemType File -Path $home/.ssh/known_hosts}
+    if (-not (Test-Path -Path $home/.ssh/known_hosts)) {$null = New-Item -ItemType File -Path $home/.ssh/known_hosts -Force}
     $knownHostContent = Get-LabSshKnownHost
 
     foreach ($machine in $machines)
@@ -1397,17 +1397,13 @@ function UnInstall-LabSshKnownHost
     [CmdletBinding()]
     param ( )
 
+    if (-not (Test-Path -Path $home/.ssh/known_hosts)) { return }
+
     $lab = Get-Lab
-    if (-not $lab)
-    {
-        return
-    }
+    if (-not $lab) { return }
 
     $machines = Get-LabVM -All -IncludeLinux | Where-Object -FilterScript { -not $_.SkipDeployment }
-    if (-not $machines)
-    {
-        return
-    }
+    if (-not $machines) { return }
 
     $content = Get-Content -Path $home/.ssh/known_hosts
     foreach ($machine in $machines)

--- a/AutomatedLab/AutomatedLabTfs.psm1
+++ b/AutomatedLab/AutomatedLabTfs.psm1
@@ -67,7 +67,14 @@ function Install-LabTeamFoundationEnvironment
             while (-not $dvdDrive -and (($startTime).AddSeconds(120) -gt (Get-Date)))
             {
                 Start-Sleep -Seconds 2
-                $dvdDrive = (Get-WmiObject -Class Win32_CDRomDrive | Where-Object MediaLoaded).Drive
+                if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)
+                {
+                    $dvdDrive = (Get-CimInstance -Class Win32_CDRomDrive | Where-Object MediaLoaded).Drive
+                }
+                else
+                {
+                    $dvdDrive = (Get-WmiObject -Class Win32_CDRomDrive | Where-Object MediaLoaded).Drive
+                }
             }
 
             if ($dvdDrive)

--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -799,63 +799,62 @@ function Wait-LabVM
 
             foreach ($machine in $completed)
             {
-                if ((Get-LabVM -ComputerName $machine).HostType -eq 'HyperV')
+                if ((Get-LabVM -ComputerName $machine).HostType -ne 'HyperV') { continue }
+                $machineMetadata = Get-LWHypervVMDescription -ComputerName $(Get-LabVM -ComputerName $machine).ResourceName
+                if ($machineMetadata.InitState -eq [AutomatedLab.LabVMInitState]::Uninitialized)
                 {
-                    $machineMetadata = Get-LWHypervVMDescription -ComputerName $(Get-LabVM -ComputerName $machine).ResourceName
-                    if ($machineMetadata.InitState -eq [AutomatedLab.LabVMInitState]::Uninitialized)
-                    {
-                        $machineMetadata.InitState = [AutomatedLab.LabVMInitState]::ReachedByAutomatedLab
-                        Set-LWHypervVMDescription -Hashtable $machineMetadata -ComputerName $(Get-LabVM -ComputerName $machine).ResourceName
-                        Enable-LabAutoLogon -ComputerName $ComputerName
-                        Copy-LabALCommon -ComputerName $ComputerName
-                    }
+                    $machineMetadata.InitState = [AutomatedLab.LabVMInitState]::ReachedByAutomatedLab
+                    Set-LWHypervVMDescription -Hashtable $machineMetadata -ComputerName $(Get-LabVM -ComputerName $machine).ResourceName
+                    Enable-LabAutoLogon -ComputerName $ComputerName
+                }
 
-                    if ($DoNotUseCredSsp -and ($machineMetadata.InitState -band [AutomatedLab.LabVMInitState]::EnabledCredSsp) -ne [AutomatedLab.LabVMInitState]::EnabledCredSsp)
-                    {
-                        $credSspEnabled = Invoke-LabCommand -ComputerName $machine -ScriptBlock {
+                if ($DoNotUseCredSsp -and ($machineMetadata.InitState -band [AutomatedLab.LabVMInitState]::EnabledCredSsp) -ne [AutomatedLab.LabVMInitState]::EnabledCredSsp)
+                {
+                    $credSspEnabled = Invoke-LabCommand -ComputerName $machine -ScriptBlock {
 
-                            if ($PSVersionTable.PSVersion.Major -eq 2)
-                            {
-                                $d = "{0:HH:mm}" -f (Get-Date).AddMinutes(1)
-                                $jobName = "AL_EnableCredSsp"
-                                $Path = 'PowerShell'
-                                $CommandLine = '-Command Enable-WSManCredSSP -Role Server -Force; Get-WSManCredSSP | Out-File -FilePath C:\EnableCredSsp.txt'
-                                schtasks.exe /Create /SC ONCE /ST $d /TN $jobName /TR "$Path $CommandLine" | Out-Null
-                                schtasks.exe /Run /TN $jobName | Out-Null
-                                Start-Sleep -Seconds 1
-                                while ((schtasks.exe /Query /TN $jobName) -like '*Running*')
-                                {
-                                    Write-Host '.' -NoNewline
-                                    Start-Sleep -Seconds 1
-                                }
-                                Start-Sleep -Seconds 1
-                                schtasks.exe /Delete /TN $jobName /F | Out-Null
-
-                                Start-Sleep -Seconds 5
-
-                                [bool](Get-Content -Path C:\EnableCredSsp.txt | Where-Object { $_ -eq 'This computer is configured to receive credentials from a remote client computer.' })
-                            }
-                            else
-                            {
-                                Enable-WSManCredSSP -Role Server -Force | Out-Null
-                                [bool](Get-WSManCredSSP | Where-Object { $_ -eq 'This computer is configured to receive credentials from a remote client computer.' })
-                            }
-
-
-                        } -PassThru -DoNotUseCredSsp -NoDisplay
-
-                        if ($credSspEnabled)
+                        if ($PSVersionTable.PSVersion.Major -eq 2)
                         {
-                            $machineMetadata.InitState = $machineMetadata.InitState -bor [AutomatedLab.LabVMInitState]::EnabledCredSsp
+                            $d = "{0:HH:mm}" -f (Get-Date).AddMinutes(1)
+                            $jobName = "AL_EnableCredSsp"
+                            $Path = 'PowerShell'
+                            $CommandLine = '-Command Enable-WSManCredSSP -Role Server -Force; Get-WSManCredSSP | Out-File -FilePath C:\EnableCredSsp.txt'
+                            schtasks.exe /Create /SC ONCE /ST $d /TN $jobName /TR "$Path $CommandLine" | Out-Null
+                            schtasks.exe /Run /TN $jobName | Out-Null
+                            Start-Sleep -Seconds 1
+                            while ((schtasks.exe /Query /TN $jobName) -like '*Running*')
+                            {
+                                Write-Host '.' -NoNewline
+                                Start-Sleep -Seconds 1
+                            }
+                            Start-Sleep -Seconds 1
+                            schtasks.exe /Delete /TN $jobName /F | Out-Null
+
+                            Start-Sleep -Seconds 5
+
+                            [bool](Get-Content -Path C:\EnableCredSsp.txt | Where-Object { $_ -eq 'This computer is configured to receive credentials from a remote client computer.' })
                         }
                         else
                         {
-                            Write-ScreenInfo "CredSsp could not be enabled on machine '$machine'" -Type Warning
+                            Enable-WSManCredSSP -Role Server -Force | Out-Null
+                            [bool](Get-WSManCredSSP | Where-Object { $_ -eq 'This computer is configured to receive credentials from a remote client computer.' })
                         }
 
-                        Set-LWHypervVMDescription -Hashtable $machineMetadata -ComputerName $(Get-LabVM -ComputerName $machine).ResourceName
+
+                    } -PassThru -DoNotUseCredSsp -NoDisplay
+
+                    if ($credSspEnabled)
+                    {
+                        $machineMetadata.InitState = $machineMetadata.InitState -bor [AutomatedLab.LabVMInitState]::EnabledCredSsp
                     }
+                    else
+                    {
+                        Write-ScreenInfo "CredSsp could not be enabled on machine '$machine'" -Type Warning
+                    }
+
+                    Set-LWHypervVMDescription -Hashtable $machineMetadata -ComputerName $(Get-LabVM -ComputerName $machine).ResourceName
                 }
+
+                Send-ModuleToPSSession -Module (Get-Module -ListAvailable -Name AutomatedLab.Common | Select-Object -First 1) -Session (New-LabPSSession $machine) -IncludeDependencies
             }
 
             Write-LogFunctionExit
@@ -2114,13 +2113,20 @@ function Test-LabAutoLogon
             $values['DefaultDomainName'] = try { (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -ErrorAction Stop).DefaultDomainName } catch { }
             $values['DefaultUserName'] = try { (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -ErrorAction Stop).DefaultUserName } catch { }
             $values['DefaultPassword'] = try { (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -ErrorAction Stop).DefaultPassword } catch { }
-            $values['LoggedOnUsers'] = (Get-WmiObject -Class Win32_LogonSession -Filter 'LogonType=2').GetRelationships('Win32_LoggedOnUser').Antecedent |
-            ForEach-Object {
-                # For deprecated OS versions...
-                # Output is convoluted vs the CimInstance variant: \\.\root\cimv2:Win32_Account.Domain="contoso",Name="Install"
-                $null = $_ -match 'Domain="(?<Domain>.+)",Name="(?<Name>.+)"'
-                -join ($Matches.Domain, '\', $Matches.Name)
-            } | Select-Object -Unique
+            if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)
+            {
+                $values['LoggedOnUsers'] = (Get-CimInstance -ClassName win32_logonsession -Filter 'logontype=2' | Get-CimAssociatedInstance -Association Win32_LoggedOnUser).Caption
+            }
+            else
+            {
+                $values['LoggedOnUsers'] = (Get-WmiObject -Class Win32_LogonSession -Filter 'LogonType=2').GetRelationships('Win32_LoggedOnUser').Antecedent |
+                ForEach-Object {
+                    # For deprecated OS versions...
+                    # Output is convoluted vs the CimInstance variant: \\.\root\cimv2:Win32_Account.Domain="contoso",Name="Install"
+                    $null = $_ -match 'Domain="(?<Domain>.+)",Name="(?<Name>.+)"'
+                    -join ($Matches.Domain, '\', $Matches.Name)
+                } | Select-Object -Unique
+            }
 
             $values
         } -PassThru -NoDisplay

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2034,7 +2034,7 @@ function Add-LabMachineDefinition
 
         if ((-not [string]::IsNullOrWhiteSpace($SshPublicKeyPath) -and [string]::IsNullOrWhiteSpace($SshPrivateKeyPath)) -or ([string]::IsNullOrWhiteSpace($SshPublicKeyPath) -and -not [string]::IsNullOrWhiteSpace($SshPrivateKeyPath)))
         {
-            Write-ScreenInfo -Type Warning -Message "Both SshPublicKeyPath and SshPrivateKeyPath need to be used to successfully remote to Linux VMs"
+            Write-ScreenInfo -Type Warning -Message "Both SshPublicKeyPath and SshPrivateKeyPath need to be used to successfully remote to Linux VMs (Host Windows, Engine Hyper-V) and Windows VMs (Host Linux/WSL, Engine Azure)"
         }
 
         if ($AzureProperties)
@@ -2111,29 +2111,29 @@ function Add-LabMachineDefinition
         $machine.OrganizationalUnit = $OrganizationalUnit
         $script:machines.Add($machine)
 
-        if ($OperatingSystem.OperatingSystemType -eq 'Windows' -and $SshPublicKeyPath)
+        if ($script:lab.DefaultVirtualizationEngine -eq 'HyperV' -and $OperatingSystem.OperatingSystemType -eq 'Windows' -and $SshPublicKeyPath)
         {
-            Write-ScreenInfo -Message "SSH Keys are ignored on Windows for the time being. Why not contribute to AutomatedLab and add the configuration of an ssh server?"
+            Write-ScreenInfo -Message "SSH Keys are ignored on Hyper-V and for Windows targets for the time being. Why not contribute to AutomatedLab and add the configuration of an ssh server?"
         }
-        elseif ($OperatingSystem.OperatingSystemType -eq 'Linux' -and $SshPublicKeyPath -and -not (Test-Path -Path $SshPublicKeyPath))
+        elseif (($script:lab.DefaultVirtualizationEngine -eq 'Azure' -or $OperatingSystem.OperatingSystemType -eq 'Linux') -and $SshPublicKeyPath -and -not (Test-Path -Path $SshPublicKeyPath))
         {
             throw "$SshPublicKeyPath does not exist. Rethink your decision."
         }
-        elseif ($OperatingSystem.OperatingSystemType -eq 'Linux' -and $SshPublicKeyPath)
+        elseif (($script:lab.DefaultVirtualizationEngine -eq 'Azure' -or $OperatingSystem.OperatingSystemType -eq 'Linux') -and $SshPublicKeyPath)
         {
             $machine.SshPublicKeyPath = $SshPublicKeyPath
             $machine.SshPublicKey = Get-Content -Raw -Path $SshPublicKeyPath
         }
 
-        if ($OperatingSystem.OperatingSystemType -eq 'Windows' -and $SshPrivateKeyPath)
+        if ($script:lab.DefaultVirtualizationEngine -eq 'HyperV' -and $OperatingSystem.OperatingSystemType -eq 'Windows' -and $SshPrivateKeyPath)
         {
-            Write-ScreenInfo -Message "SSH Keys are ignored on Windows for the time being. Why not contribute to AutomatedLab and add the configuration of an ssh server?"
+            Write-ScreenInfo -Message "SSH Keys are ignored on Hyper-V and for Windows targets for the time being. Why not contribute to AutomatedLab and add the configuration of an ssh server?"
         }
-        elseif ($OperatingSystem.OperatingSystemType -eq 'Linux' -and $SshPrivateKeyPath -and -not (Test-Path -Path $SshPrivateKeyPath))
+        elseif (($script:lab.DefaultVirtualizationEngine -eq 'Azure' -or $OperatingSystem.OperatingSystemType -eq 'Linux') -and $SshPrivateKeyPath -and -not (Test-Path -Path $SshPrivateKeyPath))
         {
             throw "$SshPrivateKeyPath does not exist. Rethink your decision."
         }
-        elseif ($OperatingSystem.OperatingSystemType -eq 'Linux' -and $SshPrivateKeyPath)
+        elseif (($script:lab.DefaultVirtualizationEngine -eq 'Azure' -or $OperatingSystem.OperatingSystemType -eq 'Linux') -and $SshPrivateKeyPath)
         {
             $machine.SshPrivateKeyPath = $SshPrivateKeyPath
         }

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2151,6 +2151,8 @@ function Add-LabMachineDefinition
             $machine.LoadBalancerWinRmHttpPort = $script:lab.AzureSettings.LoadBalancerPortCounter
             $script:lab.AzureSettings.LoadBalancerPortCounter++
             $machine.LoadBalancerWinrmHttpsPort = $script:lab.AzureSettings.LoadBalancerPortCounter
+            $script:lab.AzureSettings.LoadBalancerPortCounter++
+            $machine.LoadBalancerSshPort = $script:lab.AzureSettings.LoadBalancerPortCounter
         }
 
         if ($InstallationUserCredential)

--- a/AutomatedLabTest/internal/tests/00General.tests.ps1
+++ b/AutomatedLabTest/internal/tests/00General.tests.ps1
@@ -7,7 +7,7 @@
                 }
                 elseif ($Lab.DefaultVirtualizationEngine -eq 'HyperV')
                 {
-                    Get-LWHyperVVm -Name (Get-LabVm).ResourceName
+                    Get-LWHyperVVm -Name (Get-LabVm -IncludeLinux).ResourceName
                 }
 
                 $machines.Count | Should -Be $lab.Machines.Count

--- a/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartTimeZone.ps1
+++ b/AutomatedLabUnattended/Private/RedHat/Set-UnattendedKickstartTimeZone.ps1
@@ -8,7 +8,7 @@
 
     $tzInfo = Get-TimeZone -Id $TimeZone -ErrorAction SilentlyContinue
 
-    if (not $tzInfo) { Get-TimeZone }
+    if (-not $tzInfo) { Get-TimeZone }
 
     Write-PSFMessage -Message ('Since non-standard timezone names are used, we revert to Etc/GMT{0}' -f $tzInfo.BaseUtcOffset.TotalHours)
     if ($tzInfo.BaseUtcOffset.TotalHours -gt 0)

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1420,6 +1420,7 @@ function Initialize-LWAzureVM
 Port 22
 PasswordAuthentication no
 PubkeyAuthentication yes
+GSSAPIAuthentication yes
 AllowGroups Users Administrators
 AuthorizedKeysFile c:/al/ssh/keys
 Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
@@ -1591,7 +1592,7 @@ Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
     Wait-LWLabJob -Job $jobs -ProgressIndicator 5 -Timeout 30 -NoDisplay
     Install-LabSshKnownHost
     Copy-LabFileItem -Path (Get-ChildItem -Path "$((Get-Module -Name AutomatedLab)[0].ModuleBase)\Tools\HyperV\*") -DestinationFolderPath /AL -ComputerName $Machine -UseAzureLabSourcesOnAzureVm $false
-    Copy-LabALCommon -ComputerName $Machine
+    Send-ModuleToPSSession -Module (Get-Module -ListAvailable -Name AutomatedLab.Common | Select-Object -First 1) -Session (New-LabPSSession $Machine) -IncludeDependencies
     Write-ScreenInfo -Message 'Finished' -TaskEnd
 
     Write-ScreenInfo -Message 'Stopping all new machines except domain controllers'

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -574,6 +574,9 @@
                 @{
                     id = "[concat(resourceId('Microsoft.Network/loadBalancers', '$($Lab.Name)$($nic.VirtualSwitch.ResourceName)loadbalancer'),'/inboundNatRules/$($machine.ResourceName.ToLower())winrmhttpsin')]"
                 }
+                @{
+                    id = "[concat(resourceId('Microsoft.Network/loadBalancers', '$($Lab.Name)$($nic.VirtualSwitch.ResourceName)loadbalancer'),'/inboundNatRules/$($machine.ResourceName.ToLower())sshin')]"
+                }
             )
              
             $nicTemplate = @{

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1555,6 +1555,7 @@ Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
     }
 
     Wait-LWLabJob -Job $jobs -ProgressIndicator 5 -Timeout 30 -NoDisplay
+    Install-LabSshKnownHost
     Copy-LabFileItem -Path (Get-ChildItem -Path "$((Get-Module -Name AutomatedLab)[0].ModuleBase)\Tools\HyperV\*") -DestinationFolderPath /AL -ComputerName $Machine -UseAzureLabSourcesOnAzureVm $false
     Copy-LabALCommon -ComputerName $Machine
     Write-ScreenInfo -Message 'Finished' -TaskEnd

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1544,7 +1544,6 @@ Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
         if ($m.IsDomainJoined)
         {
             $domain = $lab.Domains | Where-Object Name -eq $m.DomainName
-            $scriptParam.SshUser += "$($domain.Administrator.UserName)@$($m.DomainName)"
         }
 
         if ($DNSServers.Count -eq 0) { $scriptParam.Remove('DnsServers') }

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1353,6 +1353,8 @@ function Initialize-LWAzureVM
 
         Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine -Force
 
+        $dnsServer = Get-DnsClientServerAddress -InterfaceAlias Ethernet -AddressFamily IPv4
+        Set-DnsClientServerAddress -InterfaceAlias Ethernet -ServerAddresses 168.63.129.16
         $release = Invoke-RestMethod -Uri 'https://api.github.com/repos/powershell/powershell/releases/latest' -UseBasicParsing -ErrorAction SilentlyContinue
         $uri = ($release.assets | Where-Object name -like '*-win-x64.msi').browser_download_url
         if (-not $uri)
@@ -1391,6 +1393,8 @@ Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
                 $sshdConfig | Set-Content -Path (Join-Path -Path $env:ProgramData -ChildPath 'ssh/sshd_config')
                 Restart-Service -Name sshd
         }
+
+        Set-DnsClientServerAddress -InterfaceAlias Ethernet -ServerAddresses $dnsServer.ServerAddresses
 
         #Set Power Scheme to High Performance
         powercfg.exe -setactive 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c

--- a/AutomatedLabWorker/AutomatedLabWorker.psd1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psd1
@@ -108,7 +108,7 @@
         'PSFileTransfer',
         @{
             ModuleName    = "AutomatedLab.Common";
-            ModuleVersion = "2.1.230";
+            ModuleVersion = "2.2.247";
         }
     )
 

--- a/AutomatedLabWorker/AutomatedLabWorkerADCS.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerADCS.psm1
@@ -228,7 +228,7 @@ function Install-LWLabCAServers
 
 
         #region - Install CA
-        $hostOSVersion = [system.version](Get-WmiObject -Class Win32_OperatingSystem).Version
+        $hostOSVersion = [Environment]::OSVersion.Version
         if ($hostOSVersion -ge [system.version]'6.2')
         {
             $InstallFeatures = 'Import-Module -Name ServerManager; Add-WindowsFeature -IncludeManagementTools -Name ADCS-Cert-Authority'
@@ -711,7 +711,7 @@ function Install-LWLabCAServers2008
 
 
         #region - Install CA
-        $hostOSVersion = [system.version](Get-WmiObject -Class Win32_OperatingSystem).Version
+        $hostOSVersion = [Environment]::OSVersion.Version
         if ($hostOSVersion -ge [system.version]'6.2')
         {
             $InstallFeatures = 'Import-Module -Name ServerManager; Add-WindowsFeature -IncludeManagementTools -Name ADCS-Cert-Authority'

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -239,6 +239,7 @@ function New-LWHypervVM
         Add-UnattendedSynchronousCommand "restorecon -R /$($Machine.InstallationUser.UserName)/.ssh/" -Description 'Restore SELinux context'
         Add-UnattendedSynchronousCommand "sed -i 's|[#]*PubkeyAuthentication yes|PubkeyAuthentication yes|g' /etc/ssh/sshd_config" -Description 'PowerShell is so much better.'
         Add-UnattendedSynchronousCommand "sed -i 's|[#]*PasswordAuthentication yes|PasswordAuthentication no|g' /etc/ssh/sshd_config" -Description 'PowerShell is so much better.'
+        Add-UnattendedSynchronousCommand "sed -i 's|[#]*GSSAPIAuthentication yes|GSSAPIAuthentication yes|g' /etc/ssh/sshd_config" -Description 'PowerShell is so much better.'
         Add-UnattendedSynchronousCommand "chmod 700 /home/$($Machine.InstallationUser.UserName)/.ssh && chmod 600 /home/$($Machine.InstallationUser.UserName)/.ssh/authorized_keys" -Description 'SSH'
         Add-UnattendedSynchronousCommand "chmod 700 /root/.ssh && chmod 600 /root/.ssh/authorized_keys" -Description 'SSH'
         Add-UnattendedSynchronousCommand "chown -R $($Machine.InstallationUser.UserName):$($Machine.InstallationUser.UserName) /home/$($Machine.InstallationUser.UserName)/.ssh" -Description 'SSH'
@@ -600,6 +601,53 @@ function New-LWHypervVM
         Remove-Item -Path $tempPath -Recurse -ErrorAction SilentlyContinue
 
         Write-PSFMessage '...done'
+
+        
+
+    if ($Machine.OperatingSystemType -eq 'Windows' -and -not [string]::IsNullOrEmpty($Machine.SshPublicKey))
+    {
+        Add-UnattendedSynchronousCommand -Command 'PowerShell -File "C:\Program Files\OpenSSH-Win64\install-sshd.ps1"' -Description 'Configure SSH'
+        Add-UnattendedSynchronousCommand -Command 'PowerShell -Command "Set-Service -Name sshd -StartupType Automatic"' -Description 'Enable SSH'
+        Add-UnattendedSynchronousCommand -Command 'PowerShell -Command "Restart-Service -Name sshd"' -Description 'Restart SSH'
+
+        Write-PSFMessage 'Copying PowerShell 7 and setting up SSH'
+        $release = try {Invoke-RestMethod -Uri 'https://api.github.com/repos/powershell/powershell/releases/latest' -UseBasicParsing -ErrorAction Stop } catch {}
+        $uri = ($release.assets | Where-Object name -like '*-win-x64.zip').browser_download_url
+        if (-not $uri)
+        {
+            $uri = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.6/PowerShell-7.2.6-win-x64.zip'
+        }
+        $psArchive = Get-LabInternetFile -Uri $uri -Path "$labSources/SoftwarePackages/PS7.zip"
+
+        
+        $release = try {Invoke-RestMethod -Uri 'https://api.github.com/repos/powershell/win32-openssh/releases/latest' -UseBasicParsing -ErrorAction Stop } catch {}
+        $uri = ($release.assets | Where-Object name -like '*-win64.zip').browser_download_url
+        if (-not $uri)
+        {
+            $uri = 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/v8.9.1.0p1-Beta/OpenSSH-Win64.zip'
+        }
+        $sshArchive = Get-LabInternetFile -Uri $uri -Path "$labSources/SoftwarePackages/ssh.zip"
+
+        $null = New-Item -ItemType Directory -Force -Path (Join-Path -Path $vhdVolume -ChildPath 'Program Files\PowerShell\7')
+        Expand-Archive -Path "$labSources/SoftwarePackages/PS7.zip" -DestinationPath (Join-Path -Path $vhdVolume -ChildPath 'Program Files\PowerShell\7')
+        Expand-Archive -Path "$labSources/SoftwarePackages/ssh.zip" -DestinationPath (Join-Path -Path $vhdVolume -ChildPath 'Program Files')
+
+        $null = New-Item -ItemType File -Path (Join-Path -Path $vhdVolume -ChildPath '\AL\SSH\keys'),(Join-Path -Path $vhdVolume -ChildPath 'ProgramData\ssh\sshd_config') -Force
+        
+        $Machine.SshPublicKey | Add-Content -Path (Join-Path -Path $vhdVolume -ChildPath '\AL\SSH\keys')
+        
+        $sshdConfig = @"
+Port 22
+PasswordAuthentication no
+PubkeyAuthentication yes
+GSSAPIAuthentication yes
+AllowGroups Users Administrators
+AuthorizedKeysFile c:/al/ssh/keys
+Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
+"@
+            $sshdConfig | Set-Content -Path (Join-Path -Path $vhdVolume -ChildPath 'ProgramData\ssh\sshd_config')
+            Write-PSFMessage 'Done'
+    }
 
         if ($Machine.ToolsPath.Value)
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Get-LWHyperVVM: Issue with too many VMs returned in a cluster
 - Revert to old version of ApplicationInsights which is currently distributed with PowerShell 7
 - Fixed #1365. Only the first IP of a machine is registered using `Add-HostEntry`
+- Fix remoting issues originating from Linux hosts once and for all by using SSH remoting. Cases:
+  - Windows + PS6+ + Azure + Public/Private Key
+  - Windows + PS6+ + Hyper-V + Linux VM + Public/Private Key
+  - Linux + PS6+ + Azure + Public/Private Key
 
 ## 5.44.0 (2022-07-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@
 - Revert to old version of ApplicationInsights which is currently distributed with PowerShell 7
 - Fixed #1365. Only the first IP of a machine is registered using `Add-HostEntry`
 - Fix remoting issues originating from Linux hosts once and for all by using SSH remoting. Cases:
-  - Windows + PS6+ + Azure + Public/Private Key
-  - Windows + PS6+ + Hyper-V + Linux VM + Public/Private Key
+  - Windows + PS5: No change
+  - Windows + PS6+ + Azure: WSMAN preferred, Public/Private Key possible
+  - Windows + PS6+ + Hyper-V: WSMAN preferred, Public/Private Key possible. Public/Private Key more or less required for Linux workloads
   - Linux + PS6+ + Azure + Public/Private Key
+  - And of course: Mix and match. Some eligible targets using SSH, others WSMAN. 
 
 ## 5.44.0 (2022-07-22)
 

--- a/Help/Wiki/Basic/gettingstartedlinux.md
+++ b/Help/Wiki/Basic/gettingstartedlinux.md
@@ -68,7 +68,7 @@ private and public keys.
 ``` powershell
 New-LabDefinition -Name GettingStarted -DefaultVirtualizationEngine Azure
 
-Add-LabMachineDefinition -Name FirstServer -OperatingSystem 'Windows Server 2019 Datacenter' -SshPublicKeyPath $home\.ssh\MyPubKey.pub -SshPrivateKeyPath $home/.ssh/MyPrivKey
+Add-LabMachineDefinition -Name FirstServer -OperatingSystem 'Windows Server 2019 Datacenter' -SshPublicKeyPath $home/.ssh/MyPubKey.pub -SshPrivateKeyPath $home/.ssh/MyPrivKey
 
 Install-Lab
 
@@ -76,7 +76,7 @@ Show-LabDeploymentSummary
 ```
 
 All connections will use your key pair instead of a password. That however means that no second hop will be possible. The combination
-of `-k` and `-i` does not work together, as stated here: <https://www.man7.org/linux/man-pages/man1/ssh.1.html#AUTHENTICATION>
+of `-K` and `-i` does not work together, as stated here: <https://www.man7.org/linux/man-pages/man1/ssh.1.html#AUTHENTICATION>
 
 ## Next steps
 

--- a/Help/Wiki/Basic/gettingstartedlinux.md
+++ b/Help/Wiki/Basic/gettingstartedlinux.md
@@ -1,0 +1,63 @@
+# Getting started on Linux
+
+As the creators of AutomatedLab did not have Linux in mind from the beginning, Linux as the host system is still slightly behind on capabilites.
+Nevertheless, you very much can use Linux to deploy labs, provided you have access to an Azure subscription and are allowed to
+create resource groups. One will contain a storage account that is reused and contains your otherwise local lab sources.
+
+If you are not allowed to create resource groups, you need to have one resource group per lab that is being deployed with you being the resource
+group's contributor. The name of the resource group is to be the name of the lab.
+
+## Install and configure AutomatedLab
+
+Installation on Linux is recommended using the PowerShell Gallery.
+
+```powershell
+Install-Module AutomatedLab
+```
+
+If you did not run PowerShell as root (`su pwsh`), please customize and run the following command to set up the required folder structure:
+```powershell
+mkdir $home/automatedlab
+Set-PSFConfig -FullName AutomatedLab.LabAppDataRoot -Value $home/automatedlab -PassThru | Register-PSFConfig
+```
+
+At the time of writing, only Azure-based labs are available on Linux. In order to use AutomatedLab, the following commands should be run after installing AutomatedLab.
+
+```powershell
+Install-LabAzureRequiredModule
+Connect-AzAccount -UseDeviceAuthentication
+```
+
+Optionally, you can scaffold the lab sources directory containing sample scripts and other content. Some roles as well as custom roles require
+content from this directory anyways.
+
+```powershell
+mkdir $home/labsources
+Set-PSFConfig -FullName AutomatedLab.LabSourcesLocation -Value $home/labsources -PassThru | Register-PSFConfig
+New-LabSourcesFolder -Force
+```
+
+
+## Install the first lab
+
+To install a very basic lab with one VM, run the following commands in PowerShell
+
+***
+``` powershell
+New-LabDefinition -Name GettingStarted -DefaultVirtualizationEngine Azure
+
+Add-LabMachineDefinition -Name FirstServer -OperatingSystem 'Windows Server 2019 Datacenter'
+
+Install-Lab
+
+Show-LabDeploymentSummary
+```
+***
+
+## Next steps
+
+Now that you have deployed your first lab, what comes next? Would you like to connect to the machines and run remote commands without you knowing the password? Then start with [the docs on lab management](./invokelabcommand.md).
+
+Wondering how to transfer data to your new lab? Then start with [the docs on data exchange](./exchangedata.md).
+
+If you - like us - like to tinker around with things, check out the [possible settings](../Advanced/automatedlabconfig.md).

--- a/Help/Wiki/Basic/gettingstartedlinux.md
+++ b/Help/Wiki/Basic/gettingstartedlinux.md
@@ -54,6 +54,30 @@ Show-LabDeploymentSummary
 ```
 ***
 
+> **Warning**
+> AutomatedLab can only work if remoting is configured properly. This seems to be highly difficult on Linux.
+> Should you have issues with remoting, please first of all try to `Install-Module PSWSMAN; Install-WSMAN`
+> If this does not work for you, you can specify public and private key to connect. This will however
+> not work in all scenarios: A double hop is required for many roles like SQL, Azure DevOps or Certificate Authorities.
+
+## Install lab using SSH remoting
+
+To install the same basic lab with SSH remoting, run the following commands in PowerShell, using your own
+private and public keys.
+
+``` powershell
+New-LabDefinition -Name GettingStarted -DefaultVirtualizationEngine Azure
+
+Add-LabMachineDefinition -Name FirstServer -OperatingSystem 'Windows Server 2019 Datacenter' -SshPublicKeyPath $home\.ssh\MyPubKey.pub -SshPrivateKeyPath $home/.ssh/MyPrivKey
+
+Install-Lab
+
+Show-LabDeploymentSummary
+```
+
+All connections will use your key pair instead of a password. That however means that no second hop will be possible. The combination
+of `-k` and `-i` does not work together, as stated here: <https://www.man7.org/linux/man-pages/man1/ssh.1.html#AUTHENTICATION>
+
 ## Next steps
 
 Now that you have deployed your first lab, what comes next? Would you like to connect to the machines and run remote commands without you knowing the password? Then start with [the docs on lab management](./invokelabcommand.md).

--- a/LabXml/Azure/AzureConnectionInfo.cs
+++ b/LabXml/Azure/AzureConnectionInfo.cs
@@ -12,6 +12,7 @@ namespace AutomatedLab.Azure
         public int Port { get; set; }
         public int HttpsPort { get; set; }
         public int RdpPort { get; set; }
+        public int SshPort { get; set; }
         public string ResourceGroupName { get; set; }
     }
 }

--- a/LabXml/Machines/Machine.cs
+++ b/LabXml/Machines/Machine.cs
@@ -83,6 +83,7 @@ namespace AutomatedLab
         public int LoadBalancerRdpPort { get; set; }
         public int LoadBalancerWinRmHttpPort { get; set; }
         public int LoadBalancerWinrmHttpsPort { get; set; }
+        public int LoadBalancerSshPort { get; set; }
 
         public List<string> LinuxPackageGroup { get; set; }
         public string SshPublicKey { get; set; }


### PR DESCRIPTION
## Description

To combat connectivity issues that stem from the highly fragmented nature of Linux distributions, I've chosen to enable and configure sshd with the PowerShell subsystem like we already do with Linux guests. This allows users to specify a key pair which is then used to connect their lab sessions.

If the key files are omitted, AutomatedLab uses WSMAN, which on Linux which seems to be as reliable as playing roulette.

Only thing to watch out for: SSH remoting can only work with PS6+ and the feature is only available from 2016 onwards, so I have added CimInstance calls to many roles. As I included a check if Get-CimInstance exists I don't anticipate issues. that being said, I did not find a 2008 R2 so many of my customers are still fond of to test this with.

For the time being, this is done purely for Azure-based labs. I did not have the capacity to test and include it in Hyper-V as well. The base disk would need modifying: The SSH service would need adding, the sshd_config would need creating, we would need to add the public keys and install PowerShell 7. All of it needs to be done before AutomatedLab starts its first connection.

I got bored and included two additional changes:
- Naming simplified for auxiliary Azure resources to allow unreasonably long lab names (Fixes #1374)
- Attempt to catch a transient Azure resource group deployment error which simply disappears when calling Install-Lab a second time. Unfortunately, not based on the exception type but on the error message itself. I do however hope that the code I am looking for is not translated and will not be changed. Fixes #1361 

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

Tested using the following lines + the big DSC lab on Hyper-V to validate nothing else broke. I don't think I missed something. The Linux bit was tested on Ubuntu WSL
```powershell
if ([Environment]::OSVersion.Platform -eq 'Win32NT')
{
    # Windows, Windows target, Azure. Local and Domain Credential, no changes
    New-LabDefinition -Name WinPs7Win -DefaultVirtualizationEngine Azure
    Add-LabAzureSubscription -SubscriptionName 'compuglobalhypermeganet-webshop' -DefaultLocationName 'west europe'
    
    Add-LabMachineDefinition -Name DC01 -Memory 8GB -OperatingSystem 'Windows Server 2019 Datacenter' -Domain contoso.com -Role RootDC 
    Add-LabMachineDefinition -Name WI01 -Memory 8GB -OperatingSystem 'Windows Server 2019 Datacenter'
    Install-Lab -nova

    New-LabPSSession -Computer WI01,DC01 -Verbose
    Remove-Lab -Confirm:$false

    # Windows, Windows target, Azure. Local and Domain Credential
    New-LabDefinition -Name WinPs7Win -DefaultVirtualizationEngine Azure
    Add-LabAzureSubscription -SubscriptionName 'compuglobalhypermeganet-webshop' -DefaultLocationName 'west europe'
    
    Add-LabMachineDefinition -Name DC01 -Memory 8GB -OperatingSystem 'Windows Server 2019 Datacenter' -Domain contoso.com -Role RootDC -SshPublicKeyPath C:\Users\janhe\.ssh\AzurePubKey.pub -SshPrivateKeyPath C:\Users\janhe\.ssh\AzurePubKey    
    Add-LabMachineDefinition -Name WI01 -Memory 8GB -OperatingSystem 'Windows Server 2019 Datacenter' -SshPublicKeyPath C:\Users\janhe\.ssh\AzurePubKey.pub -SshPrivateKeyPath C:\Users\janhe\.ssh\AzurePubKey
    Install-Lab -nova

    New-LabPSSession -Computer WI01,DC01 -Verbose
    Remove-Lab -Confirm:$false
    
    # Windows, Linux target, HyperV, no changes
    New-LabDefinition -Name WinPs7Linux -DefaultVirtualizationEngine HyperV
    Add-LabVirtualNetworkDefinition -Name lab -AddressSpace 192.168.178.0/24
    Add-LabVirtualNetworkDefinition -Name 'USBternet' -HyperVProperties @{ SwitchType = 'External'; AdapterName = 'Ethernet' }
    $netAdapter = @(
        New-LabNetworkAdapterDefinition -VirtualSwitch 'lab' -Ipv4Address 192.168.178.121
        New-LabNetworkAdapterDefinition -VirtualSwitch 'USBTernet' -UseDhcp
    )
    Add-LabMachineDefinition -Name CN01 -Memory 8GB -OperatingSystem 'Centos Linux 8' -NetworkAdapter $netAdapter -SshPublicKeyPath C:\Users\janhe\.ssh\AzurePubKey.pub -SshPrivateKeyPath C:\Users\janhe\.ssh\AzurePubKey
    Install-Lab -nova

    New-LabPSSession -Computer CN01 -Verbose
    Remove-Lab -Confirm:$false

    # Windows, Windows target, Hyper-V - no changes
    New-LabDefinition -Name WinPs7Win -DefaultVirtualizationEngine HyperV
    Add-LabMachineDefinition -Name WI01 -Memory 8GB -OperatingSystem 'Windows Server 2019 Datacenter'
    Install-Lab -nova

    New-LabPSSession -Computer WI01 -Verbose
    Remove-Lab -Confirm:$false
}
else
{
    # Linux, Windows target, Azure
    New-LabDefinition -Name LinuxPs7Win -DefaultVirtualizationEngine Azure
    Add-LabAzureSubscription -SubscriptionName 'compuglobalhypermeganet-webshop' -DefaultLocationName 'west europe'
    Add-LabMachineDefinition -Name WI01 -Memory 8GB -OperatingSystem 'Windows Server 2019 Datacenter' -SshPublicKeyPath /mnt/C/Users/janhe/.ssh/AzurePubKey.pub -SshPrivateKeyPath /mnt/C/Users/janhe/.ssh/AzurePubKey
    Install-Lab -nova

    New-LabPSSession -Computer WI01
    Remove-Lab -Confirm:$false
}
```