### PR TITLE
Fixes #1371: Assigning PostInstallationActivity resulted into a prompt due to missing arguments

### DIFF
--- a/AutomatedLab/AutomatedLabRemoting.psm1
+++ b/AutomatedLab/AutomatedLabRemoting.psm1
@@ -551,10 +551,24 @@ function Invoke-LabCommand
     Write-LogFunctionEntry
     $customRoleCount = 0
 
-    if ($PSCmdlet.ParameterSetName -in 'Script', 'ScriptBlock', 'ScriptFileContentDependency', 'ScriptBlockFileContentDependency','ScriptFileNameContentDependency')
+    $parameterSetsWithRetries = 'Script',
+        'ScriptBlock',
+        'ScriptFileContentDependency',
+        'ScriptBlockFileContentDependency',
+        'ScriptFileNameContentDependency',
+        'PostInstallationActivity',
+        'PreInstallationActivity'
+
+    if ($PSCmdlet.ParameterSetName -in $parameterSetsWithRetries)
     {
-        if (-not $Retries) { $Retries = Get-LabConfigurationItem -Name InvokeLabCommandRetries }
-        if (-not $RetryIntervalInSeconds) { $RetryIntervalInSeconds = Get-LabConfigurationItem -Name InvokeLabCommandRetryIntervalInSeconds }
+        if (-not $Retries)
+        {
+            $Retries = Get-LabConfigurationItem -Name InvokeLabCommandRetries
+        }
+        if (-not $RetryIntervalInSeconds)
+        {
+            $RetryIntervalInSeconds = Get-LabConfigurationItem -Name InvokeLabCommandRetryIntervalInSeconds
+        }
     }
 
     if ($AsJob)
@@ -847,7 +861,10 @@ function Invoke-LabCommand
         Write-ScreenInfo -Message 'Activity done' -TaskEnd
     }
 
-    if ($PassThru) { $results }
+    if ($PassThru)
+    {
+        $results
+    }
 
     Write-LogFunctionExit
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@
 - Build process includes integration tests
 - Get-LWHyperVVM: Additional setting to skip checking cluster in Get-LWHyperVVM to improve performance.
   - Mainly useful during deployments, and would not be registered, but rather just set before `Install-Lab`
-- DoNotPrompt now also enforces Enable-LabHostRemoting
+- DoNotPrompt now also enforces Enable-LabHostRemoting.
 
 ### Bugs
 
-- Repair-LWHyperVNetworkConfig: WSMAN EnvelopeSize caused issues
-- Get-LWHyperVVM: Issue with too many VMs returned in a cluster
-- Revert to old version of ApplicationInsights which is currently distributed with PowerShell 7
-- Fixing cosmetic issue #1363
-- Fixed #1365. Only the first IP of a machine is registered using `Add-HostEntry`
+- Repair-LWHyperVNetworkConfig: WSMAN EnvelopeSize caused issues.
+- Get-LWHyperVVM: Issue with too many VMs returned in a cluster.
+- Revert to old version of ApplicationInsights which is currently distributed with PowerShell 7.
+- Fixing cosmetic issue #1363.
+- Fixed #1365. Only the first IP of a machine is registered using `Add-HostEntry`.
+- Fixed #1371. Assigning PostInstallationActivity resulted into a prompt due to missing arguments.
 
 ## 5.44.0 (2022-07-22)
 


### PR DESCRIPTION
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

```powershell
$labName = 'Lab1371'

$env:AUTOMATEDLAB_TELEMETRY_OPTIN = 'true'
Set-PSFConfig -Module AutomatedLab -Name DoNotPrompt -Value $true

New-LabDefinition -Name $labName -DefaultVirtualizationEngine HyperV

Set-LabInstallationCredential -Username Install -Password Somepass1


mkdir -Path $global:labSources\Test | Out-Null
@'
'123' | Out-File -FilePath c:\test.txt
'@ | Set-Content -Path $global:labSources\Test\PostInstallActivityScript.ps1
$fePostInstallActivity = @()
$fePostInstallActivity += Get-LabPostInstallationActivity -ScriptFilePath $global:labSources\Test\PostInstallActivityScript.ps1 -DependencyFolder $global:labSources\Test

Add-LabMachineDefinition -Name M1 -OperatingSystem 'Windows Server 2022 Datacenter (Desktop Experience)' -PostInstallationActivity $fePostInstallActivity

Install-Lab

Remove-Item -Path $global:labSources\Test -Recurse -Force
```
