### PR TITLE
SkipDeployment included in state-changing Cmdlets

### DIFF
--- a/AutomatedLab/AutomatedLabVirtualMachines.psm1
+++ b/AutomatedLab/AutomatedLabVirtualMachines.psm1
@@ -275,6 +275,8 @@ function Start-LabVM
             $vms = $availableVMs | Where-Object { -not $_.SkipDeployment }
         }
 
+        $vms = $vms | Where-Object SkipDeployment -eq $false
+
         #if there are no VMs to start, just write a warning
         if (-not $vms)
         {
@@ -797,14 +799,14 @@ function Wait-LabVM
         {
             Write-PSFMessage "The following machines are ready: $($completed -join ', ')"
 
-            foreach ($machine in $completed)
+            foreach ($machine in (Get-LabVM -ComputerName $completed))
             {
-                if ($machine.SkipDeployment -or (Get-LabVM -ComputerName $machine).HostType -ne 'HyperV') { continue }
-                $machineMetadata = Get-LWHypervVMDescription -ComputerName $(Get-LabVM -ComputerName $machine).ResourceName
+                if ($machine.SkipDeployment -or $machine.HostType -ne 'HyperV') { continue }
+                $machineMetadata = Get-LWHypervVMDescription -ComputerName $machine.ResourceName
                 if ($machineMetadata.InitState -eq [AutomatedLab.LabVMInitState]::Uninitialized)
                 {
                     $machineMetadata.InitState = [AutomatedLab.LabVMInitState]::ReachedByAutomatedLab
-                    Set-LWHypervVMDescription -Hashtable $machineMetadata -ComputerName $(Get-LabVM -ComputerName $machine).ResourceName
+                    Set-LWHypervVMDescription -Hashtable $machineMetadata -ComputerName $machine.ResourceName
                     Enable-LabAutoLogon -ComputerName $ComputerName
                 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   - relative path ISOs was returned with file name, which prompted AL to always upload and fail
 - Fix issue when multiple Azure networks are deployed
 - Incompatible Azure role sizes could be selected. Filtering down to x64 to prevent that.
+- SkipDeployment was not fully utilized
+  - Cmdlets modifying machine status now skip SkipDeployment VMs, as cmdlet usage often does not make sense anyways
 
 ## 5.45.0 (2022-09-01)
 

--- a/Help/Wiki/Basic/addmachines.md
+++ b/Help/Wiki/Basic/addmachines.md
@@ -10,15 +10,17 @@ When you are using the automatic machine definitions, the memory requirements wi
 
 ## Deploying a lab with Linux VMs
 With AutomatedLab Linux VMs can be deployed just as easily as Windows VMs. The current implementation should take care of the following distributions:
-- RHEL 7 (*)
-- CentOS 7
-- Fedora 27
-- SLES 12.3 (*)
+- RHEL 7+ (*)
+- CentOS 7+
+- Fedora 27+
+- SLES 12.3+ (*)
 - OpenSuSE
 
-At the moment the machines do not support any of AutomatedLab's roles since our roles are Windows-based. However, your VMs should come up domain-joined and capable of receiving WinRM requests. AutomatedLab uses kickstart (RHEL-based) or AutoYAST (SLES-based) to configure everything that would be configured in the unattend file of a Windows machine.
+At the moment the machines do not support any of AutomatedLab's roles since our roles are Windows-based. However, your VMs should come up domain-joined and capable of receiving WinRM or SSH requests. AutomatedLab uses kickstart (RHEL-based) or AutoYAST (SLES-based) to configure everything that would be configured in the unattend file of a Windows machine.
 
 WinRM support is spotty with distributions like OpenSuSE and Fedora. Fedora being too cutting-edge does not allow PowerShell and omi-psrp-server to be installed, while OpenSuSE currently has the wrong package dependencies and fails installing PowerShell as well.
+
+To address this issue, please use the parameters `SshPublicKeyPath` and `SshPrivateKeyPath` when deploying Linux hosts.
 
 ## Simple Linux lab
 You can find the Linux lab here: [AL Loves Linux](https://github.com/AutomatedLab/AutomatedLab/blob/develop/LabSources/SampleScripts/HyperV/AL%20Loves%20Linux.ps1)

--- a/Help/Wiki/Basic/modifylab.md
+++ b/Help/Wiki/Basic/modifylab.md
@@ -1,0 +1,50 @@
+Once installed, a lab can still be modified to some extent. As a general rule of thumb: Changes
+that the product does not support, AutomatedLab does not support as well. For example, you cannot
+change the domain that has been deployed after the installation without first removing the Domain Controller
+VMs.
+
+## Add and remove machines
+
+An AutomatedLab is defined by several XML files we export in the background. Those can
+be modified to some extent by AutomatedLab cmdlets.
+
+To remove a VM, import the lab first, then remove it:
+
+```powershell
+Import-Lab -Name YourLab -NoValidation # NoValidation - fast import, because we don't need validation to run every time
+Remove-LabVm -Name YourMachine # That is enough to remove the resource
+```
+
+To modify a deployment, either:
+ 
+```powershell
+Import-LabDefinition -Name YourLab
+Add-LabMachineDefinition -Name newMachine
+Remove-LabMachineDefinition -Name AnotherMachine
+Install-Lab
+```
+
+or add the machine definitions in your original script - AutomatedLab detects if a role has been deployed and skips it. As long
+as you do not intend to change key settings, like the domain that is getting deployed, you can simply rerun the same script after
+you have added a couple of machines.
+
+## 2 - Deploy labs that use existing lab infrastructure
+
+Labs can be installed into existing infrastructure. While there is no general way of doing this,
+a few pointers are:
+
+- Take care of networking - usually, existing on-premises components will be reached by connecting
+  the lab VMs to an external switch. This can be added using `Add-LabVirtualNetworkDefinition -HyperVProperties @{SwitchType = 'External'}
+- Add references to roles like Domain Controllers using the `SkipDeployment` parameter
+- Include the required credentials to connect to machines referenced using the `SkipDeployment` parameter!
+
+Want to connect a lab using an IPSEC VPN? Maybe take a look at [this sample](../SampleScripts/Azure/en-us/VpnConnectedLab.md).
+
+```powershell
+New-LabDefinition -Name ConnectToEnv -DefaultVirtualizationEngine HyperV
+Add-LabDomainDefinition -Name contoso.com -AdminUser admin -AdminPassword 'S00perS3cure!'
+Add-LabVirtualNetworkDefinition -Name prodnet -AddressSpace 10.0.1.0/24 -HyperVProperties @{SwitchType = 'External'; AdapterName = '10GB'}
+Add-LabMachineDefinition -Name DC1 -DomainName contoso.com -Role RootDc -SkipDeployment -IpAddress 10.0.1.101
+Add-LabMachineDefinition -Name MS1 -DomainName contoso.com -Network prodnet -IpAddress 10.0.1.10
+Install-Lab
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Creating a new lab: Wiki/Basic/createnewlab.md
   - Networks and IP Addresses: Wiki/Basic/networksandaddresses.md
   - Adding machines: Wiki/Basic/addmachines.md
+  - Modifying labs: Wiki/Basic/modifylab.md
   - Preparing a fully offline environment: Wiki/Basic/fullyoffline.md
   - Joining lab VMs to existing domain: Wiki/Basic/joindomain.md
   - Parallel deployments: Wiki/Advanced/resourcenaming.md


### PR DESCRIPTION
## Description

Start/Stop/Restart/Checkpoint/Restore/Wait-LabVm did not make use of SkipDeployment parameter, leading to some issues with samples like <https://github.com/AutomatedLab/AutomatedLab/discussions/1404> for instance.

Since it does not make sense anyway to use the aforementioned cmdlets with machines that might reside on other Hypervisors, Hosts and so on, I've included the SkipDeployment parameter a bit more liberally.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Used the code from <https://github.com/AutomatedLab/AutomatedLab/discussions/1404> to validate that resources are really skipped.