### PR TITLE
Fixed using wrong variable

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorker.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorker.psm1
@@ -884,7 +884,7 @@ function Wait-LWLabJob
         $jobs = Get-Job -Name $Name
     }
 
-    Write-ScreenInfo -Message "Waiting for job(s) to complete with ID(s): $($Job.Id -join ', ')" -TaskStart
+    Write-ScreenInfo -Message "Waiting for job(s) to complete with ID(s): $($jobs.Id -join ', ')" -TaskStart
 
     if ($jobs -and ($jobs.State -contains 'Running' -or $jobs.State -contains 'AtBreakpoint'))
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased (yyyy-MM-dd)
 
+### Bugs
+
+- Fixed using wrong variable in `Wait-LWLabJob` (#1425).
+
 ## 5.46.0 (2022-11-24)
 
 ### Enhancements


### PR DESCRIPTION
## Description

Fixes #1425 using wrong variable.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Simple lab dep.