### PR TITLE
Disks stored in correct disk path

### DIFF
--- a/AutomatedLab/AutomatedLab.psm1
+++ b/AutomatedLab/AutomatedLab.psm1
@@ -1561,7 +1561,7 @@ function Remove-Lab
                         Write-PSFMessage 'Removing disks...'
                         foreach ($disk in $disks)
                         {
-                            Write-PSFMessage "Removing disk '($disk.Name)'"
+                            Write-PSFMessage "Removing disk '$($disk.Name)'"
 
                             if (Test-Path -Path $disk.Path)
                             {

--- a/AutomatedLab/AutomatedLabDisks.psm1
+++ b/AutomatedLab/AutomatedLabDisks.psm1
@@ -354,7 +354,7 @@ function Get-LabVHDX
         {
             if ($vm = Get-LabMachineDefinition | Where-Object { $_.Disks.Name -contains $disk.Name })
             {
-                $disk.Path = Join-Path -Path $lab.Target.Path -ChildPath $vm.Name
+                $disk.Path = Join-Path -Path $lab.Target.Path -ChildPath $vm.ResourceName
             }
             else
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed output of `Add-LabDomainDefinition` (#1428)
 - Fixed OS disk ignoring Storage SKU (#1434)
 - Fixed outbound NAT rules attached to wrong resource
+- Fixed issue with disks being stored in wrong folder if resourcename was used
 
 ## 5.46.0 (2022-11-24)
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #1437 by sorting disks into a ResourceName subfolder if they are attached to a VM.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
```powershell
New-LabDefinition -Name test -Default HyperV

Add-LabDiskDefinition -Name blob -DiskSizeInGb 5
Add-LabMachineDefinition -Name blob -ResourceName blib -DiskName blob -OperatingSystem 'Windows Server 2019 Datacenter (Desktop Experience)'
Install-Lab
```