### PR TITLE
Improve speed in Hyper-V cluster

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -899,6 +899,12 @@ function Get-LWHypervVM
     }
 
     [object[]]$vm = Get-VM @param
+    $vm = $vm | Sort-Object -Unique -Property Name
+
+    if ($Name.Count -gt 0 -and $vm.Count -eq $Name.Count)
+    {
+        return $vm
+    }
 
     if (-not $script:clusterDetected -and (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue)) { $script:clusterDetected = Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Allow integration of MOF and meta.MOF for first boot (in OS disk), enabling advanced configurations
 - Remove necessity to send Al.Common to all lab VMs
 - Speed Test URLs for Azure updated
+- Speed up cluster check
 
 ### Bugs
 


### PR DESCRIPTION
## Description

There was not much that could be done. To improve speed with Get-LWHyperVVM, the function will return early if `-Name` is used and the list of `-Name` is equal to the list of VMs returned by Get-VM. If this is not the case, we still run the more expensive operations Get-Cluster and Get-ClusterResource.

For non-clustered systems, nothing changes.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
PowerShell Workshop Lab Hyper-V
Tested different calls to Get-LWHyperVVM to validate that code exits early if possible