### PR TITLE
Enable TPM/SecureBoot support

### DIFF
--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -1471,13 +1471,13 @@ function Get-LabAzureAvailableRoleSize
     $availableRoleSizes = if ((Get-Command Get-AzComputeResourceSku).Parameters.ContainsKey('Location'))
     {
         Get-AzComputeResourceSku -Location $azLocation.Location | Where-Object {
-            $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription' -and ($_.Capabilities | Where-Object Name -eq CpuArchitectureType).CpuArchitectureType -notlike '*arm*'
+            $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription' -and ($_.Capabilities | Where-Object Name -eq CpuArchitectureType).Value -notlike '*arm*'
         }
     }
     else
     {
         Get-AzComputeResourceSku | Where-Object {
-            $_.Locations -contains $azLocation.Location -and $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription' -and ($_.Capabilities | Where-Object Name -eq CpuArchitectureType).CpuArchitectureType -notlike '*arm*'
+            $_.Locations -contains $azLocation.Location -and $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription' -and ($_.Capabilities | Where-Object Name -eq CpuArchitectureType).Value -notlike '*arm*'
         }
     }
     

--- a/AutomatedLab/AutomatedLabAzure.psm1
+++ b/AutomatedLab/AutomatedLabAzure.psm1
@@ -1471,14 +1471,14 @@ function Get-LabAzureAvailableRoleSize
     $availableRoleSizes = if ((Get-Command Get-AzComputeResourceSku).Parameters.ContainsKey('Location'))
     {
         Get-AzComputeResourceSku -Location $azLocation.Location | Where-Object {
-        $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription'
-    }
+            $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription' -and ($_.Capabilities | Where-Object Name -eq CpuArchitectureType).CpuArchitectureType -notlike '*arm*'
+        }
     }
     else
     {
         Get-AzComputeResourceSku | Where-Object {
-        $_.Locations -contains $azLocation.Location -and $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription'
-    }
+            $_.Locations -contains $azLocation.Location -and $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription' -and ($_.Capabilities | Where-Object Name -eq CpuArchitectureType).CpuArchitectureType -notlike '*arm*'
+        }
     }
     
 

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2997,18 +2997,17 @@ function Add-LabMachineDefinition
 
         if ($AzureProperties)
         {
+            if ($AzureRoleSize)
+            {
+                $AzureProperties['RoleSize'] = $AzureRoleSize # Adding keys to properties later did silently fail
+            }
+
             $machine.AzureProperties = $AzureProperties
         }
-        if ($AzureRoleSize)
+
+        if ($AzureRoleSize -and -not $AzureProperties)
         {
-            if (-not $AzureProperties)
-            {
-                $machine.AzureProperties = @{ RoleSize = $AzureRoleSize }
-            }
-            else
-            {
-                $machine.AzureProperties.RoleSize = $AzureRoleSize
-            }
+            $machine.AzureProperties = @{ RoleSize = $AzureRoleSize }
         }
 
         $machine.ToolsPath = $ToolsPath.Replace('<machinename>', $machine.Name)

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2032,7 +2032,7 @@ function Add-LabMachineDefinition
         }
 
         $azurePropertiesValidKeys = 'ResourceGroupName', 'UseAllRoleSizes', 'RoleSize', 'LoadBalancerRdpPort', 'LoadBalancerWinRmHttpPort', 'LoadBalancerWinRmHttpsPort', 'LoadBalancerAllowedIp', 'SubnetName', 'UseByolImage', 'AutoshutdownTime', 'AutoshutdownTimezoneId', 'StorageSku'
-        $hypervPropertiesValidKeys = 'AutomaticStartAction', 'AutomaticStartDelay', 'AutomaticStopAction'
+        $hypervPropertiesValidKeys = 'AutomaticStartAction', 'AutomaticStartDelay', 'AutomaticStopAction', 'EnableSecureBoot', 'SecureBootTemplate', 'EnableTpm'
 
         if (-not $VirtualizationHost -and -not (Get-LabDefinition).DefaultVirtualizationEngine)
         {

--- a/AutomatedLabDefinition/AutomatedLabDefinition.psm1
+++ b/AutomatedLabDefinition/AutomatedLabDefinition.psm1
@@ -2031,7 +2031,7 @@ function Add-LabMachineDefinition
             $machineRoles = " (Roles: $($Roles.Name -join ', '))" 
         }
 
-        $azurePropertiesValidKeys = 'ResourceGroupName', 'UseAllRoleSizes', 'RoleSize', 'LoadBalancerRdpPort', 'LoadBalancerWinRmHttpPort', 'LoadBalancerWinRmHttpsPort', 'LoadBalancerAllowedIp', 'SubnetName', 'UseByolImage', 'AutoshutdownTime', 'AutoshutdownTimezoneId', 'StorageSku'
+        $azurePropertiesValidKeys = 'ResourceGroupName', 'UseAllRoleSizes', 'RoleSize', 'LoadBalancerRdpPort', 'LoadBalancerWinRmHttpPort', 'LoadBalancerWinRmHttpsPort', 'LoadBalancerAllowedIp', 'SubnetName', 'UseByolImage', 'AutoshutdownTime', 'AutoshutdownTimezoneId', 'StorageSku', 'EnableSecureBoot', 'EnableTpm'
         $hypervPropertiesValidKeys = 'AutomaticStartAction', 'AutomaticStartDelay', 'AutomaticStopAction', 'EnableSecureBoot', 'SecureBootTemplate', 'EnableTpm'
 
         if (-not $VirtualizationHost -and -not (Get-LabDefinition).DefaultVirtualizationEngine)

--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -788,7 +788,6 @@
         if ($machine.AzureProperties['EnableSecureBoot'] -and -not $lab.AzureSettings.IsAzureStack) # Available only in public regions
         {            
             $machTemplate.properties.securityProfile = @{
-                encryptionAtHost = $false
                 securityType     = 'TrustedLaunch'
                 uefiSettings     = @{
                     secureBootEnabled = $true

--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -534,6 +534,12 @@ function New-LWHypervVM
         }
 
         $vm | Set-VMFirmware @vmFirmwareParameters
+
+        if ($Machine.HyperVProperties.EnableTpm -match '1|true|yes')
+        {
+            $vm | Set-VMKeyProtector -NewLocalKeyProtector
+            $vm | Enable-VMTPM
+        }
     }
 
     #remove the unconnected default network adapter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Remove necessity to send Al.Common to all lab VMs
 - Speed Test URLs for Azure updated
 - Speed up cluster check
+- Include settings to configure TPM and SecureBoot
 
 ### Bugs
 

--- a/Help/AutomatedLabDefinition/en-us/Add-LabMachineDefinition.md
+++ b/Help/AutomatedLabDefinition/en-us/Add-LabMachineDefinition.md
@@ -302,7 +302,13 @@ Accept wildcard characters: False
 
 ### -HypervProperties
 The HyperV properties.
-Currently valid properties: 'AutomaticStartAction', 'AutomaticStartDelay', 'AutomaticStopAction'
+Currently valid properties:
+- AutomaticStartAction, default Nothing, refer to Set-VM
+- AutomaticStartDelay, default 0, refer to Set-VM
+- AutomaticStopAction, default ShutDown, refer to Set-VM
+- EnableTpm, if value is 1, true or yes, TPM will be enabled
+- EnableSecureBoot, if value is on, SecureBoot will be enabled
+- SecureBootTemplate, MicrosoftWindows or MicrosoftUEFICertificateAuthority
 
 ```yaml
 Type: Hashtable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,6 @@ nav:
     - AzureStackHub.ps1: Wiki/SampleScripts/Azure/en-us/AzureStackHub.md
     - MultiForestLab 2012R2.ps1: Wiki/SampleScripts/Azure/en-us/MultiForestLab 2012R2.md
     - MultiNetMultiForest.ps1: Wiki/SampleScripts/Azure/en-us/MultiNetMultiForest.md
-    - Untitled-1.ps1: Wiki/SampleScripts/Azure/en-us/Untitled-1.md
     - VpnConnectedLab.ps1: Wiki/SampleScripts/Azure/en-us/VpnConnectedLab.md
     - VpnConnectedLabArc.ps1: Wiki/SampleScripts/Azure/en-us/VpnConnectedLabArc.md
   - HyperV:


### PR DESCRIPTION
## Description

We had a SecureBoot setting that was implemented but ignored for some reason. I enabled it and included a vTPM setting as well for both Hyper-V and Azure VMs. I did not include a check to see if the combination Azure Role Size and SecureBoot is supported as this list may change and is not easy to get automated (i.e. info not returned by Az cmdlets).

Three properties are now available. EnableSecureBoot, EnableTpm and SecureBootTemplate (Hyper-V only). The template was already retrieved and is now actually used.

Fixes #1470 

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
```powershell
New-LabDefinition -Name testaz -Default Azure
Add-LabAzureSubscription -DefaultLocationName 'west europe'
Add-LabMachineDefinition -Name test -AzureRoleSize Standard_DC2s_v2 -AzureProperties @{EnableSecureBoot = 'Sure why not'; EnableTpm = 'yes'} -OperatingSystem 'Windows Server 2022 Datacenter'
Install-Lab

New-LabDefinition -Name testhv -Default HyperV
Add-LabMachineDefinition -Name test -HyperVProperties @{EnableSecureBoot = 'Sure why not'; EnableTpm = 'yes'} -OperatingSystem 'Windows Server 2022 Datacenter'
Install-Lab
```