### PR TITLE
Fixed a bug in 'Initialize-LWAzureVM' comparing the PowerShell version (#1517)

### DIFF
--- a/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabAzureWorkerVirtualMachines.psm1
@@ -1813,13 +1813,13 @@ sudo systemctl restart sshd
     }
 
     Copy-LabFileItem -Path (Get-ChildItem -Path "$((Get-Module -Name AutomatedLab)[0].ModuleBase)\Tools\HyperV\*") -DestinationFolderPath /AL -ComputerName ($Machine | Where OperatingSystemType -eq 'Windows') -UseAzureLabSourcesOnAzureVm $false
-    $sessions = if ($PSVersionTable.PSVersion -ge 7)
+    $sessions = if ($PSVersionTable.PSVersion -ge [System.Version]'7.0')
     {
         New-LabPSSession $Machine
     }
     else
     {
-        Write-ScreenInfo -Type Warning -Message "Skipping copy of AutomatedLab.Common to Linux VMs as Windows PowerShell is used on the host."
+        Write-ScreenInfo -Type Warning -Message "Skipping copy of AutomatedLab.Common to Linux VMs as Windows PowerShell is used on the host and not PowerShell 7+."
         New-LabPSSession ($Machine | Where OperatingSystemType -eq 'Windows')
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bugs
 
+- Fixed a bug in 'Initialize-LWAzureVM' comparing the PowerShell version (#1517).
+
 ## 5.48.0 (2023-04-05)
 
 ### Enhancements


### PR DESCRIPTION
## Description

Fixes #1517.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Azure Lab Deployment does no longer throw an error.