### PR TITLE
fixes error creating AdfsSsl cert template during AD FS role install

### DIFF
--- a/AutomatedLab/AutomatedLabADFS.psm1
+++ b/AutomatedLab/AutomatedLabADFS.psm1
@@ -72,7 +72,7 @@ function Install-LabAdfs
 
         if (-not (Test-LabCATemplate -TemplateName AdfsSsl -ComputerName $ca))
         {
-            New-LabCATemplate -TemplateName AdfsSsl -DisplayName 'ADFS SSL' -SourceTemplateName WebServer -ApplicationPolicy ServerAuthentication `
+            New-LabCATemplate -TemplateName AdfsSsl -DisplayName 'ADFS SSL' -SourceTemplateName WebServer -ApplicationPolicy "Server Authentication" `
             -EnrollmentFlags Autoenrollment -PrivateKeyFlags AllowKeyExport -Version 2 -SamAccountName 'Domain Computers' -ComputerName $ca -ErrorAction Stop
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - able to deploy Exchange 2019 CU11 and CU12 because of a change in the command line parameters.
 - Fix minor issue with sending AL.Common to newly installed VMs
 - Ensure required resource providers and features are registered (#1510)
+- Fix error creating AdfsSsl certificate template during AD FS role installation.
 
 ## 5.47.0 (2023-02-20)
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

The cmdlet **Install-LabAdfs** calls **New-LabCATemplate** with an incorrect argument.  -ApplicationPolicy's ValidateSet includes "Server Authentication", instead of "ServerAuthentication".  This issue prevents successful install of AD FS role.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

Tested while installing AD FS role on Server 2022 and Server 2019 images.
