### PR TITLE
fix issue exporting ssl cert during ad fs install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugs
 
 - Fixed a bug in 'Initialize-LWAzureVM' comparing the PowerShell version (#1517).
+- Fix issue exporting service-communication/SSL certificate to secondary AD FS nodes.
 
 ## 5.48.0 (2023-04-05)
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

The cmdlet **Get-LabCertificate** does not have a _-thumbprint_ parameter, and I've had issues using the SSL certificate imported using **Add-LabCertificate** during AD FS role configuration on secondary nodes.

Apologies in advance if this is being addressed elsewhere.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
This change was tested by creating a lab with:
    - 1 domain controller
    - 1 root CA
    - 2 AD FS servers

After the the build completed, verified that all AD FS nodes shared the same SSL/service-communication certificate and were successfully joined to the same farm.