### PR TITLE
Azure Deployment Error Handling

### DIFF
--- a/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
+++ b/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
@@ -95,7 +95,7 @@
         if (-not $deployment)
         {
             $labFolder = Split-Path -Path $lab.LabFilePath -Parent
-            Write-Host "The deployment failed. To get more information about the  following error, please run the following command:" -ForegroundColor Magenta
+            Write-ScreenInfo "The deployment failed. To get more information about the  following error, please run the following command:"
             Write-Host "'New-AzResourceGroupDeployment -ResourceGroupName $($lab.AzureSettings.DefaultResourceGroup.ResourceGroupName) -TemplateFile $labFolder\armtemplate.json'" -ForegroundColor Magenta
             Write-LogFunctionExitWithError -Message "Deployment of resource group '$lab' failed with '$($rgDeploymentFail.Exception.Message)'" -ErrorAction Stop
         }

--- a/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
+++ b/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
@@ -96,7 +96,7 @@
         {
             $labFolder = Split-Path -Path $lab.LabFilePath -Parent
             Write-ScreenInfo "The deployment failed. To get more information about the  following error, please run the following command:"
-            Write-Host "'New-AzResourceGroupDeployment -ResourceGroupName $($lab.AzureSettings.DefaultResourceGroup.ResourceGroupName) -TemplateFile $labFolder\armtemplate.json'" -ForegroundColor Magenta
+            Write-ScreenInfo "'New-AzResourceGroupDeployment -ResourceGroupName $($lab.AzureSettings.DefaultResourceGroup.ResourceGroupName) -TemplateFile $labFolder\armtemplate.json'"
             Write-LogFunctionExitWithError -Message "Deployment of resource group '$lab' failed with '$($rgDeploymentFail.Exception.Message)'" -ErrorAction Stop
         }
     }

--- a/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
+++ b/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
@@ -94,8 +94,10 @@
         $deployment = New-LabAzureResourceGroupDeployment -Lab $lab -PassThru -Wait -ErrorAction SilentlyContinue -ErrorVariable rgDeploymentFail
         if (-not $deployment)
         {
-            Write-LogFunctionExitWithError -Message "Deployment of resource group '$lab' failed with '$($rgDeploymentFail.Exception.Message)'"
-            return
+            $labFolder = Split-Path -Path $lab.LabFilePath -Parent
+            Write-Host "The deployment failed. To get more information about the  following error, please run the following command:" -ForegroundColor Magenta
+            Write-Host "'New-AzResourceGroupDeployment -ResourceGroupName $($lab.AzureSettings.DefaultResourceGroup.ResourceGroupName) -TemplateFile $labFolder\armtemplate.json'" -ForegroundColor Magenta
+            Write-LogFunctionExitWithError -Message "Deployment of resource group '$lab' failed with '$($rgDeploymentFail.Exception.Message)'" -ErrorAction Stop
         }
     }
 

--- a/AutomatedLabDefinition/functions/Core/New-LabDefinition.ps1
+++ b/AutomatedLabDefinition/functions/Core/New-LabDefinition.ps1
@@ -50,6 +50,7 @@
 
     if ($DefaultVirtualizationEngine -eq 'Azure')
     {
+        Clear-Lab
         $null = Test-LabAzureModuleAvailability -ErrorAction SilentlyContinue
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Fixed a bug in 'Initialize-LWAzureVM' comparing the PowerShell version (#1517).
 - Fix issue exporting service-communication/SSL certificate to secondary AD FS nodes.
 - Fix issue with DNS settings on individual Azure VMs
+- Calling 'Clear-Lab' otherwise when trying to change the subscription 'Get-LWAzureVMConnectionInfo'
+  may have the previous lab information and changing the subscription does not work.
 
 ## 5.48.0 (2023-04-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Restructure project and harmonize build
 - Include client IP in JIT rules
 - Enable individual Gen1/Gen2 VMs (#1528)
+- Added some help to discover the error cause when `New-LabAzureResourceGroupDeployment` failed 
 
 ### Bugs
 


### PR DESCRIPTION
## Description

When the Azure deployment fails, not all exceptions are forwarded to the surface. For new users it is almost impossible to get the underlying cause of the deployment error. In my case it was a quota issue and I discovered the error when calling `New-AzResourceGroupDeployment` direclty.

Changing the subscription did not work as the previous lab was not removed. This happens now when `New-LabDefinition` is called and the `DefaultVirtualizationEngine` is `Azure`.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Deployed some labs in Azure.