### PR TITLE
'Clear-LabCache' did not remove global variables used for caching.

### DIFF
--- a/AutomatedLabCore/functions/Core/Clear-LabCache.ps1
+++ b/AutomatedLabCore/functions/Core/Clear-LabCache.ps1
@@ -15,6 +15,19 @@
     {
         Remove-Item -Path Microsoft.PowerShell.Core\Registry::HKEY_CURRENT_USER\Software\AutomatedLab\Cache -Force -ErrorAction SilentlyContinue
     }
+
+    Remove-Variable -Name AL_*,
+        cacheAzureRoleSizes,
+        cacheVmImages,
+        cacheVMs,
+        taskStart,
+        PSLog_*,
+        labDeploymentNoNewLine,
+        labExported,
+        indent,
+        firstAzureVMCreated,
+        existingAzureNetworks -ErrorAction SilentlyContinue
+
     Write-PSFMessage 'AutomatedLab cache removed'
 
     Write-LogFunctionExit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 - Fixed a bug in 'Initialize-LWAzureVM' comparing the PowerShell version (#1517).
 - Fix issue exporting service-communication/SSL certificate to secondary AD FS nodes.
-- Fix issue with DNS settings on individual Azure VMs
+- Fix issue with DNS settings on individual Azure VMs.
+- 'Clear-LabCache' did not remove global variables used for caching.
 
 ## 5.48.0 (2023-04-05)
 


### PR DESCRIPTION
## Description

`Clear-LabCache` did not remove global variables used for caching.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Azure deployments.