### PR TITLE
Improved Azure role size handling

### DIFF
--- a/AutomatedLabCore/functions/Azure/Add-LabAzureSubscription.ps1
+++ b/AutomatedLabCore/functions/Azure/Add-LabAzureSubscription.ps1
@@ -231,7 +231,7 @@
 
     Write-PSFMessage "Added $($script:lab.AzureSettings.StorageAccounts.Count) storage accounts"
 
-    if ($global:cacheAzureRoleSizes)
+    if ($global:cacheAzureRoleSizes -and $global:al_PreviousDefaultLocationName -eq $DefaultLocationName)
     {
         Write-ScreenInfo -Message "Querying available vm sizes for Azure location '$DefaultLocationName' (using cache)" -Type Info
         $defaultSizes = (Get-LabAzureDefaultLocation).VirtualMachineRoleSizes
@@ -242,7 +242,10 @@
         Write-ScreenInfo -Message "Querying available vm sizes for Azure location '$DefaultLocationName'" -Type Info
         $roleSizes = Get-LabAzureAvailableRoleSize -Location $DefaultLocationName
         $global:cacheAzureRoleSizes = $roleSizes
+
     }
+
+    $global:al_PreviousDefaultLocationName = $DefaultLocationName
 
     if ($roleSizes.Count -eq 0)
     {

--- a/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableRoleSize.ps1
+++ b/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableRoleSize.ps1
@@ -35,6 +35,7 @@
     if (-not $azLocation)
     {
         Write-ScreenInfo -Type Error -Message "No location found matching DisplayName '$DisplayName' or Name '$LocationName'"
+        return
     }
 
     $availableRoleSizes = if ((Get-Command Get-AzComputeResourceSku).Parameters.ContainsKey('Location'))

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
@@ -35,31 +35,31 @@
     {
         $pattern = switch ($lab.AzureSettings.DefaultRoleSize)
         {
-            'A' { '^(Standard_A\d{1,2}|Basic_A\d{1,2})' }
-            'AS' { '^Standard_AS\d{1,2}' }
-            'AC' { '^Standard_AC\d{1,2}' }
-            'D' { '^Standard_D\d{1,2}' }
-            'DS' { '^Standard_DS\d{1,2}' }
-            'DC' { '^Standard_DC\d{1,2}' }
-            "E" { '^Standard_E\d{1,2}' }
-            "ES" { '^Standard_ES\d{1,2}' }
-            "EC" { '^Standard_EC\d{1,2}' }
-            'F' { '^Standard_F\d{1,2}' }
-            'FS' { '^Standard_FS\d{1,2}' }
-            'FC' { '^Standard_FC\d{1,2}' }
-            'G' { '^Standard_G\d{1,2}' }
-            'GS' { '^Standard_GS\d{1,2}' }
-            'GC' { '^Standard_GC\d{1,2}' }
-            'H' { '^Standard_H\d{1,2}' }
-            'HS' { '^Standard_HS\d{1,2}' }
-            'HC' { '^Standard_HC\d{1,2}' }
-            'L' { '^Standard_L\d{1,2}' }
-            'LS' { '^Standard_LS\d{1,2}' }
-            'LC' { '^Standard_LC\d{1,2}' }
-            'N' { '^Standard_N\d{1,2}' }
-            'NS' { '^Standard_NS\d{1,2}' }
-            'NC' { '^Standard_NC\d{1,2}' }
-            default { '^(Standard_A\d{1,2}|Basic_A\d{1,2})' }
+            'A' { '^Standard_A\d{1,2}(_v\d{1,3})|Basic_A\d{1,2})' }
+            'AS' { '^Standard_AS\d{1,2}(_v\d{1,3})' }
+            'AC' { '^Standard_AC\d{1,2}(_v\d{1,3})' }
+            'D' { '^Standard_D\d{1,2}(_v\d{1,3})' }
+            'DS' { '^Standard_DS\d{1,2}(_v\d{1,3})' }
+            'DC' { '^Standard_DC\d{1,2}(_v\d{1,3})' }
+            "E" { '^Standard_E\d{1,2}(_v\d{1,3})' }
+            "ES" { '^Standard_ES\d{1,2}(_v\d{1,3})' }
+            "EC" { '^Standard_EC\d{1,2}(_v\d{1,3})' }
+            'F' { '^Standard_F\d{1,2}(_v\d{1,3})' }
+            'FS' { '^Standard_FS\d{1,2}(_v\d{1,3})' }
+            'FC' { '^Standard_FC\d{1,2}(_v\d{1,3})' }
+            'G' { '^Standard_G\d{1,2}(_v\d{1,3})' }
+            'GS' { '^Standard_GS\d{1,2}(_v\d{1,3})' }
+            'GC' { '^Standard_GC\d{1,2}(_v\d{1,3})' }
+            'H' { '^Standard_H\d{1,2}(_v\d{1,3})' }
+            'HS' { '^Standard_HS\d{1,2}(_v\d{1,3})' }
+            'HC' { '^Standard_HC\d{1,2}(_v\d{1,3})' }
+            'L' { '^Standard_L\d{1,2}(_v\d{1,3})' }
+            'LS' { '^Standard_LS\d{1,2}(_v\d{1,3})' }
+            'LC' { '^Standard_LC\d{1,2}(_v\d{1,3})' }
+            'N' { '^Standard_N\d{1,2}(_v\d{1,3})' }
+            'NS' { '^Standard_NS\d{1,2}(_v\d{1,3})' }
+            'NC' { '^Standard_NC\d{1,2}(_v\d{1,3})' }
+            default { '^(Standard_A\d{1,2}(_v\d{1,3})|Basic_A\d{1,2})' }
         }
 
         $roleSize = $lab.AzureSettings.RoleSizes |

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
@@ -689,7 +689,7 @@
 
         if (-not $vmSize)
         {
-            throw "No valid VM size found for $Machine!"
+            throw "No valid VM size found for '$Machine'. For a list of available role sizes, use the command 'Get-LabAzureAvailableRoleSize -LocationName $($lab.AzureSettings.DefaultLocation.Location)'"
         }
 
         Write-ScreenInfo -Type Verbose -Message "Adding $Machine with size $vmSize, publisher $($imageRef.publisher), offer $($imageRef.offer), sku $($imageRef.sku)!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enable individual Gen1/Gen2 VMs (#1528)
 - Added some help to discover the error cause when `New-LabAzureResourceGroupDeployment` failed
 - Added stored procedures for DSC database cleanup
+- Improved the discovery of Azure role sizes
 
 ### Bugs
 


### PR DESCRIPTION
## Description

The change is mainly querying the role sizes again if the lab location has changed.

Also changed the regex pattern so only standard Azure role sizes are used like

- Standard_F2
- Standard_F4

and skipping role sizes like

- Standard_E64-16s_v4
- Standard_E64-32s_v4
- Standard_E48bds_v5
- Standard_E64bds_v5

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Some Azure deployments.