### PR TITLE
Added error handling to 'Connect-LWAzureLabSourcesDrive'

### DIFF
--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Connect-LWAzureLabSourcesDrive.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Connect-LWAzureLabSourcesDrive.ps1
@@ -50,8 +50,13 @@
 
     } -ArgumentList $labSourcesStorageAccount.Path, $labSourcesStorageAccount.StorageAccountName, $labSourcesStorageAccount.StorageAccountKey
 
-    $Session | Add-Member -Name ALLabSourcesMappingResult -Value $result -MemberType NoteProperty
-    $Session | Add-Member -Name ALLabSourcesMapped -Value $result.ALLabSourcesMapped -MemberType NoteProperty
+    $Session | Add-Member -Name ALLabSourcesMappingResult -Value $result -MemberType NoteProperty -Force
+    $Session | Add-Member -Name ALLabSourcesMapped -Value $result.ALLabSourcesMapped -MemberType NoteProperty -Force
+
+    if ($result.ReturnCode -ne 0)
+    {
+        Write-LogFunctionExitWithError -Message "Connecting session '$($s.Name)' to LabSources folder failed" -Details $result.NetConnectResult
+    }
 
     Write-LogFunctionExit
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added some help to discover the error cause when `New-LabAzureResourceGroupDeployment` failed
 - Added stored procedures for DSC database cleanup
 - Improved the discovery of Azure role sizes
+- Added error handling to 'Connect-LWAzureLabSourcesDrive'
 
 ### Bugs
 


### PR DESCRIPTION
## Description

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Called `Connect-LWAzureLabSourcesDrive` within some labs manually.