### PR TITLE
Added '*.windows.net' to the local intranet zone

### DIFF
--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Connect-LWAzureLabSourcesDrive.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Connect-LWAzureLabSourcesDrive.ps1
@@ -18,6 +18,15 @@
     }
 
     $result = Invoke-Command -Session $Session -ScriptBlock {
+        #Add *.windows.net to Local Intranet Zone
+        $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Domains\windows.net'
+        if (-not (Test-Path -Path $path)) {
+            New-Item -Path $path -Force
+
+            New-ItemProperty $path -Name http -Value 1 -Type DWORD
+            New-ItemProperty $path -Name file -Value 1 -Type DWORD
+        }
+        
         $pattern = '^(OK|Unavailable) +(?<DriveLetter>\w): +\\\\automatedlab'
 
         #remove all drive connected to an Azure LabSources share that are no longer available

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Initialize-LWAzureVM.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Initialize-LWAzureVM.ps1
@@ -250,6 +250,13 @@ Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
             $party | Format-Volume -Force -UseLargeFRS:$diskObject.UseLargeFRS -AllocationUnitSize $diskObject.AllocationUnitSize -NewFileSystemLabel $diskObject.Label
         }
 
+        #Add *.windows.net to Local Intranet Zone
+        $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Domains\windows.net'
+        New-Item -Path $path -Force
+
+        New-ItemProperty $path -Name http -Value 1 -Type DWORD
+        New-ItemProperty $path -Name file -Value 1 -Type DWORD
+
         $null = try { Stop-Transcript -ErrorAction Stop } catch { }
     }
 

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Initialize-LWAzureVM.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Initialize-LWAzureVM.ps1
@@ -172,25 +172,46 @@ Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
         if (-not [string]::IsNullOrWhiteSpace($LabSourcesPath))
         {
             $script = @'
-    $labSourcesPath = '{0}'
+$output = ''
+$labSourcesPath = '{0}'
 
-    $pattern = '^(OK|Unavailable) +(?<DriveLetter>\w): +\\\\automatedlab'
+$pattern = '^(OK|Unavailable) +(?<DriveLetter>\w): +\\\\automatedlab'
 
-    #remove all drive connected to an Azure LabSources share that are no longer available
-    $drives = net.exe use
-    foreach ($line in $drives)
+#remove all drive connected to an Azure LabSources share that are no longer available
+$drives = net.exe use
+foreach ($line in $drives)
+{{
+    if ($line -match $pattern)
     {{
-        if ($line -match $pattern)
-        {{
-            net.exe use "$($Matches.DriveLetter):" /d
-        }}
+        $output += net.exe use "$($Matches.DriveLetter):" /d
     }}
+}}
 
-    cmdkey.exe /add:{1} /user:{2} /pass:{3}
+$output += cmdkey.exe /add:{1} /user:{2} /pass:{3}
 
-    Start-Sleep -Seconds 1
+Start-Sleep -Seconds 1
 
-    net.exe use * {0} /u:{2} {3}
+net.exe use * {0} /u:{2} {3}
+
+$initialErrorCode = $LASTEXITCODE
+    
+if ($LASTEXITCODE -eq 2) {{
+    $hostName = ([uri]$labSourcesPath).Host
+	$dnsRecord = Resolve-DnsName -Name $hostname | Where-Object {{ $_ -is [Microsoft.DnsClient.Commands.DnsRecord_A] }}
+    $ipAddress = $dnsRecord.IPAddress
+    $alternativeLabSourcesPath = $labSourcesPath.Replace($hostName, $ipAddress)
+    $output += net.exe use * $alternativeLabSourcesPath /u:{2} {3}
+}}
+
+$finalErrorCode = $LASTEXITCODE
+
+[pscustomobject]@{{
+    Output = $output
+    InitialErrorCode = $initialErrorCode
+    FinalErrorCode = $finalErrorCode
+    LabSourcesPath = $labSourcesPath
+    AlternativeLabSourcesPath  = $alternativeLabSourcesPath 
+}}
 '@
 
             $cmdkeyTarget = ($LabSourcesPath -split '\\')[2]
@@ -227,6 +248,13 @@ Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
             Set-DnsClientServerAddress -InterfaceIndex $idx -ServerAddresses $DnsServers
         }
 
+        #Add *.windows.net to Local Intranet Zone
+        $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Domains\windows.net'
+        New-Item -Path $path -Force
+
+        New-ItemProperty $path -Name http -Value 1 -Type DWORD
+        New-ItemProperty $path -Name file -Value 1 -Type DWORD
+
         if (-not $Disks) { $null = try { Stop-Transcript -ErrorAction Stop } catch { }; return }
         
         # Azure InvokeRunAsCommand is not very clever, so we sent the stuff as JSON
@@ -249,13 +277,6 @@ Subsystem powershell c:/progra~1/powershell/7/pwsh.exe -sshs -NoLogo
             }
             $party | Format-Volume -Force -UseLargeFRS:$diskObject.UseLargeFRS -AllocationUnitSize $diskObject.AllocationUnitSize -NewFileSystemLabel $diskObject.Label
         }
-
-        #Add *.windows.net to Local Intranet Zone
-        $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Domains\windows.net'
-        New-Item -Path $path -Force
-
-        New-ItemProperty $path -Name http -Value 1 -Type DWORD
-        New-ItemProperty $path -Name file -Value 1 -Type DWORD
 
         $null = try { Stop-Transcript -ErrorAction Stop } catch { }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix issue with DNS settings on individual Azure VMs.
 - 'Clear-LabCache' did not remove global variables used for caching.
 - AutomatedLab.Common was not copied properly to HyperV
+- Added '*.windows.net' to the local intranet zone for fixing installation issues on Azure machines
 
 ## 5.48.0 (2023-04-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Added some help to discover the error cause when `New-LabAzureResourceGroupDeployment` failed
 - Added stored procedures for DSC database cleanup
 - Improved the discovery of Azure role sizes
+- Added '*.windows.net' to the local intranet zone for fixing installation issues on Azure machines as well as the IP address of the Azure LabSources host
+- The script 'AzureLabSources.ps1' maps the share via IP address if mapping via names fails. It
+  sometimes files mapping by name with the error 'A specified logon session does not exist'
 
 ### Bugs
 
@@ -20,7 +23,6 @@
 - Fix issue with DNS settings on individual Azure VMs.
 - 'Clear-LabCache' did not remove global variables used for caching.
 - AutomatedLab.Common was not copied properly to HyperV
-- Added '*.windows.net' to the local intranet zone for fixing installation issues on Azure machines
 
 ## 5.48.0 (2023-04-05)
 


### PR DESCRIPTION
## Description

When installing software from the Azure LabSources share with `Install-LabSoftwarePackage` and the switch `UseShellExecute`, the Azure LabSources share must be within the local intranet.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Exchange 2019 deployment on Azure.