### PR TITLE
Ensure that Cluster cmdlets are not implicitly imported

### DIFF
--- a/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
+++ b/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
@@ -46,7 +46,7 @@
             $result = New-LWHypervVM -Machine $machine
 
             $doNotAddToCluster = Get-LabConfigurationItem -Name DoNotAddVmsToCluster -Default $false
-            if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue))
+            if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -CommandType Cmdlet -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue))
             {
                 Write-ScreenInfo -Message "Adding $($machine.Name) ($($machine.ResourceName)) to cluster $((Get-Cluster).Name)"
                 if (-not (Get-ClusterGroup -Name $machine.ResourceName -ErrorAction SilentlyContinue))

--- a/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
+++ b/AutomatedLabCore/functions/VirtualMachines/New-LabVM.ps1
@@ -46,7 +46,7 @@
             $result = New-LWHypervVM -Machine $machine
 
             $doNotAddToCluster = Get-LabConfigurationItem -Name DoNotAddVmsToCluster -Default $false
-            if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -CommandType Cmdlet -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue))
+            if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -Module FailoverClusters -CommandType Cmdlet -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue))
             {
                 Write-ScreenInfo -Message "Adding $($machine.Name) ($($machine.ResourceName)) to cluster $((Get-Cluster).Name)"
                 if (-not (Get-ClusterGroup -Name $machine.ResourceName -ErrorAction SilentlyContinue))

--- a/AutomatedLabWorker/functions/VirtualMachines/Get-LWHypervVM.ps1
+++ b/AutomatedLabWorker/functions/VirtualMachines/Get-LWHypervVM.ps1
@@ -35,7 +35,7 @@
         return $vm
     }
 
-    if (-not $script:clusterDetected -and (Get-Command -Name Get-Cluster -CommandType Cmdlet -ErrorAction SilentlyContinue)) { $script:clusterDetected = Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue}
+    if (-not $script:clusterDetected -and (Get-Command -Name Get-Cluster -Module FailoverClusters -CommandType Cmdlet -ErrorAction SilentlyContinue)) { $script:clusterDetected = Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue}
 
     if (-not $DisableClusterCheck -and $script:clusterDetected)
     {

--- a/AutomatedLabWorker/functions/VirtualMachines/Get-LWHypervVM.ps1
+++ b/AutomatedLabWorker/functions/VirtualMachines/Get-LWHypervVM.ps1
@@ -35,7 +35,7 @@
         return $vm
     }
 
-    if (-not $script:clusterDetected -and (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue)) { $script:clusterDetected = Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue}
+    if (-not $script:clusterDetected -and (Get-Command -Name Get-Cluster -CommandType Cmdlet -ErrorAction SilentlyContinue)) { $script:clusterDetected = Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue}
 
     if (-not $DisableClusterCheck -and $script:clusterDetected)
     {

--- a/AutomatedLabWorker/functions/VirtualMachines/Remove-LWHypervVM.ps1
+++ b/AutomatedLabWorker/functions/VirtualMachines/Remove-LWHypervVM.ps1
@@ -27,7 +27,7 @@
 
     Write-PSFMessage "Removing VM '$($Name)'"
     $doNotAddToCluster = Get-LabConfigurationItem -Name DoNotAddVmsToCluster -Default $false
-    if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -CommandType Cmdlet -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue))
+    if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -Module FailoverClusters -CommandType Cmdlet -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue))
     {
         Write-PSFMessage "Removing Clustered Resource: $Name"
         $null = Get-ClusterGroup -Name $Name | Remove-ClusterGroup -RemoveResources -Force

--- a/AutomatedLabWorker/functions/VirtualMachines/Remove-LWHypervVM.ps1
+++ b/AutomatedLabWorker/functions/VirtualMachines/Remove-LWHypervVM.ps1
@@ -27,7 +27,7 @@
 
     Write-PSFMessage "Removing VM '$($Name)'"
     $doNotAddToCluster = Get-LabConfigurationItem -Name DoNotAddVmsToCluster -Default $false
-    if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue))
+    if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -CommandType Cmdlet -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue -WarningAction SilentlyContinue))
     {
         Write-PSFMessage "Removing Clustered Resource: $Name"
         $null = Get-ClusterGroup -Name $Name | Remove-ClusterGroup -RemoveResources -Force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix issue with DNS settings on individual Azure VMs.
 - 'Clear-LabCache' did not remove global variables used for caching.
 - AutomatedLab.Common was not copied properly to HyperV
+- Skip cluster checks on PS7
 
 ## 5.48.0 (2023-04-05)
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #1553 and fixes #1560

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Any of our sample scripts work, all should have the same issue if the FailoverClusters module exists but AL is not running on a cluster OR if a module exports Get-Cluster that is not FailoverClusters.