### PR TITLE
Update Start-LWHypervVM.ps1

### DIFF
--- a/AutomatedLabWorker/functions/VirtualMachines/Start-LWHypervVM.ps1
+++ b/AutomatedLabWorker/functions/VirtualMachines/Start-LWHypervVM.ps1
@@ -16,7 +16,7 @@
         [switch]$NoNewLine
     )
 
-    if ($PreDelay) {
+    if ($PreDelaySeconds) {
         $job = Start-Job -Name 'Start-LWHypervVM - Pre Delay' -ScriptBlock { Start-Sleep -Seconds $Using:PreDelaySeconds }
         Wait-LWLabJob -Job $job -NoNewLine -ProgressIndicator $ProgressIndicator -Timeout 15 -NoDisplay
     }
@@ -48,7 +48,7 @@
         }
     }
 
-    if ($PostDelay)
+    if ($PostDelaySeconds)
     {
         $job = Start-Job -Name 'Start-LWHypervVM - Post Delay' -ScriptBlock { Start-Sleep -Seconds $Using:PostDelaySeconds }
         Wait-LWLabJob -Job $job -NoNewLine:$NoNewLine -ProgressIndicator $ProgressIndicator -Timeout 15 -NoDisplay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased (yyyy-MM-dd)
+- Fix If-Condition in Start-LWHypervVM. Used wrong variables; PreDelaySeconds & PostDelaySeconds (#1582).
 
 ### Enhancements
 


### PR DESCRIPTION
if condition used wrong variable
PreDelay -> PreDelaySeconds
PostDelay -> PostDelaySeconds


- [X] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
