### PR TITLE
Fix for using ResourceName in LabMachineDefinition

### DIFF
--- a/AutomatedLabWorker/functions/VirtualMachines/New-LWHypervVM.ps1
+++ b/AutomatedLabWorker/functions/VirtualMachines/New-LWHypervVM.ps1
@@ -873,7 +873,7 @@ Stop-Transcript
     $writeVmConnectConfigFile = Get-LabConfigurationItem -Name VMConnectWriteConfigFile
     if ($writeVmConnectConfigFile)
     {
-        New-LWHypervVmConnectSettingsFile -VmName $Machine.Name
+        New-LWHypervVmConnectSettingsFile -VmName $Machine.ResourceName
     }
 
     Write-LogFunctionExit


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
I changed my local version.

Before:
![image](https://github.com/AutomatedLab/AutomatedLab/assets/66946165/53214943-81f2-4552-8ca3-2e195083c9c3)

After:
![image](https://github.com/AutomatedLab/AutomatedLab/assets/66946165/64c016f6-be84-408a-9950-ba3ff64f1800)

