### PR TITLE
Documentation: Correct list formatting to adhere to Markdown standards

### DIFF
--- a/Help/index.md
+++ b/Help/index.md
@@ -14,8 +14,9 @@ AutomatedLab (AL) enables you to
 - .NET Core 2+ (PowerShell 6+)
 
 **Require one**:
-Hyper-V Host
-Azure Subscription
+
+- Hyper-V Host
+- Azure Subscription
 
 **Finally**:
 


### PR DESCRIPTION
List was not properly formatted using markdown. This caused MkDocs to render the two items on a single line.

