### PR TITLE
Fix missing custom site name&code and Windows Defender variables when deploying SCCM lab. Fixes #1555

### DIFF
--- a/AutomatedLabCore/internal/functions/Install-CMSite.ps1
+++ b/AutomatedLabCore/internal/functions/Install-CMSite.ps1
@@ -169,7 +169,7 @@
 
     try
     {
-        $result = Invoke-LabCommand -ComputerName $CMServer -ActivityName "Adding Windows Defender exclusions" -Variable (Get-Variable "AVExcludedPaths", "AVExcludedProcesses") -ScriptBlock {
+        $result = Invoke-LabCommand -ComputerName $CMServer -ActivityName "Adding Windows Defender exclusions" -Variable (Get-Variable "configurationManagerAVExcludedPaths", "configurationManagerAVExcludedProcesses") -ScriptBlock {
             Add-MpPreference -ExclusionPath $configurationManagerAVExcludedPaths -ExclusionProcess $configurationManagerAVExcludedProcesses -ErrorAction "Stop"
             Set-MpPreference -RealTimeScanDirection "Incoming" -ErrorAction "Stop"
         } -ErrorAction Stop

--- a/AutomatedLabCore/internal/functions/Install-CMSite.ps1
+++ b/AutomatedLabCore/internal/functions/Install-CMSite.ps1
@@ -71,6 +71,8 @@
     }
 
     $CMSetupConfig['[Options]'].SDKServer = $CMServer.FQDN
+    $CMSetupConfig['[Options]'].SiteCode = $CMSiteCode
+    $CMSetupConfig['[Options]'].SiteName = $CMSiteName
     $CMSetupConfig['[CloudConnectorOptions]'].CloudConnectorServer = $CMServer.FQDN
     $CMSetupConfig['[SQLConfigOptions]'].SQLServerName = $SqlServerName
     $CMSetupConfig['[SQLConfigOptions]'].DatabaseName = $DatabaseName

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs
 
+- Fix missing Site Name and Site Code when custom values provided (#1555).
 - Fix Windows Defender variables mismatch (#1555).
 - Fix for using ResourceName in LabMachineDefinition (#1592).
 - Fixed issues deploying CM-2103 custom role (#1594).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs
 
+- Fix Windows Defender variables mismatch (#1555).
 - Fix for using ResourceName in LabMachineDefinition (#1592).
 - Fixed issues deploying CM-2103 custom role (#1594).
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
After editing AutomatedLabCore.psm1, I re-imported module with -Force switch. Then using CM-2203.ps1 script I deployed SCCM lab multiple times without terminating error.