### PR TITLE
Fixes #1608: Secondary DC installation is not reentrant

### DIFF
--- a/AutomatedLabCore/internal/scripts/Variables.ps1
+++ b/AutomatedLabCore/internal/scripts/Variables.ps1
@@ -238,6 +238,7 @@ $adInstallFirstChildDc2012 = {
             -CreateDnsDelegation:$createDNSDelegation `
             -SafeModeAdministratorPassword $safeDsrmPassword `
             -Force `
+            -AllowDomainReinstall `
             -Credential $RootDomainCredential `
             -DomainType $domainType `
             -DomainMode $DomainMode `
@@ -373,6 +374,7 @@ $adInstallFirstChildDcPre2012 = {
       SiteName=$($SiteName)
       InstallDNS=Yes
       ConfirmGc=Yes
+      AllowDomainReinstall=Yes
       UserDomain=$($RootDomainCredential.UserName.Split('\')[0])
       UserName=$($RootDomainCredential.UserName.Split('\')[1])
       Password=$($RootDomainCredential.GetNetworkCredential().Password)
@@ -517,6 +519,7 @@ $adInstallDc2012 = {
         SiteName = $SiteName
         SafeModeAdministratorPassword = $safeDsrmPassword
         Force = $true
+        AllowDomainControllerReinstall = $true
         Credential = $RootDomainCredential
         SysvolPath = $SysvolPath
         DatabasePath = $DatabasePath
@@ -638,6 +641,7 @@ $adInstallDcPre2012 = {
       SiteName=$SiteName
       InstallDNS=Yes
       ConfirmGc=Yes
+      AllowDomainControllerReinstall=Yes
       UserDomain=$($RootDomainCredential.UserName.Split('\')[0])
       UserName=$($RootDomainCredential.UserName.Split('\')[1])
       Password=$($RootDomainCredential.GetNetworkCredential().Password)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix Windows Defender variables mismatch (#1555).
 - Fix for using ResourceName in LabMachineDefinition (#1592).
 - Fixed issues deploying CM-2103 custom role (#1594).
+- Fixed an issue which prevented the promotion process of additional Active Directory Domain Controllers from being restartable (#1608).
 
 ## 5.50.0 (2023-11-10)
 


### PR DESCRIPTION
## Description

- [x] I have tested my changes.  
- [x] I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] The PR has a meaningful title.  
- [x] I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

I only tested the changes with a root domain hosted by Windows Server 2022. I have neither tested child domain installation nor Windows Server 2008 R2, where the process differs heavily from Windows Server 2012+.
