### PR TITLE
Fixed syntax errors in 'CreateDscSqlDatabase.ps1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 - Fix Windows Defender variables mismatch (#1555).
 - Fix for using ResourceName in LabMachineDefinition (#1592).
 - Fixed issues deploying CM-2103 custom role (#1594).
-- Fixed an issue which prevented the promotion process of additional Active Directory Domain Controllers from being restartable (#1608).
+- Fixed an issue which prevented the promotion process of additional Active Directory Domain
+  Controllers from being restartable (#1608).
+- Fixed a syntax issue in 'CreateDscSqlDatabase.ps1'.
 
 ## 5.50.0 (2023-11-10)
 

--- a/LabSources/PostInstallationActivities/SetupDscPullServer/CreateDscSqlDatabase.ps1
+++ b/LabSources/PostInstallationActivities/SetupDscPullServer/CreateDscSqlDatabase.ps1
@@ -206,11 +206,11 @@ BEGIN
 	SET @oldDate = COALESCE(@Date, CONVERT(DATE, DATEADD(DAY, -180, GETDATE())))
 	SET @before1900 = '1900-01-01'
 
-    DELETE FROM DSC].[dbo].[StatusReport] WHERE CONVERT(DATE, [StartTime]) < @oldDate OR CONVERT(DATE, [EndTime]) < @oldDate
+    DELETE FROM [DSC].[dbo].[StatusReport] WHERE CONVERT(DATE, [StartTime]) < @oldDate OR CONVERT(DATE, [EndTime]) < @oldDate
 
-	DELETE FROM DSC].[dbo].[StatusReport] WHERE CONVERT(DATE, [StartTime]) < @before1900 OR CONVERT(DATE, [EndTime]) < @before1900
+	DELETE FROM [DSC].[dbo].[StatusReport] WHERE CONVERT(DATE, [StartTime]) < @before1900 OR CONVERT(DATE, [EndTime]) < @before1900
 
-	DELETE FROM DSC].[dbo].[StatusReportMetaData] WHERE CONVERT(DATE, [CreationTime]) < @oldDate
+	DELETE FROM [DSC].[dbo].[StatusReportMetaData] WHERE CONVERT(DATE, [CreationTime]) < @oldDate
 
 END
 GO


### PR DESCRIPTION
## Description

This fixes the following error:

```
18:35:39|00:47:22|00:00:00.001| - Executing lab command activity: 'Creating DSC SQL Database' on machines 'DSCCASQL01'
18:35:39|00:47:22|00:00:00.008|   - Waiting for completion
Incorrect syntax near ']'.
Incorrect syntax near ']'.
Incorrect syntax near ']'.
    + CategoryInfo          : InvalidOperation: (:) [Invoke-Sqlcmd], SqlPowerShellSqlExecutionException
    + FullyQualifiedErrorId : SqlError,Microsoft.SqlServer.Management.PowerShell.GetScriptCommand
    + PSComputerName        : 192.168.111.50
 
18:35:40|00:47:23|00:00:01.186|   - Activity done
```

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
DSC Workshop lab deployment.
