### PR TITLE
Fix issue in Stop-LabVm and Stop-LWHyperVVM

### DIFF
--- a/AutomatedLabCore/functions/Remoting/Invoke-LabCommand.ps1
+++ b/AutomatedLabCore/functions/Remoting/Invoke-LabCommand.ps1
@@ -327,7 +327,7 @@
         $session = @(New-LabPSSession -ComputerName $machines -DoNotUseCredSsp:$DoNotUseCredSsp -UseLocalCredential:$UseLocalCredential -Credential $credential -IgnoreAzureLabSources:$IgnoreAzureLabSources.IsPresent)
         if (-not $session)
         {
-            Write-LogFunctionExitWithError "Could not create a session to machine '$machines'"
+            Write-ScreenInfo -Type Error -Message "Could not create a session to machine '$machines'"
             return
         }
 

--- a/AutomatedLabCore/functions/VirtualMachines/Stop-LabVM.ps1
+++ b/AutomatedLabCore/functions/VirtualMachines/Stop-LabVM.ps1
@@ -100,6 +100,11 @@
                 {
                     $remainingTarget
                 }
+                elseif ($remainingTarget -is [System.Management.Automation.Runspaces.Runspace] -and $remainingTarget.ConnectionInfo.ComputerName -as [ipaddress])
+                {
+                    # Special case - return value is an IP address instead of a host name. We need to look it up.
+                    $machines | Where-Object Ipv4Address -eq $remainingTarget.ConnectionInfo.ComputerName
+                }
                 elseif ($remainingTarget -is [System.Management.Automation.Runspaces.Runspace])
                 {
                     $remainingTarget.ConnectionInfo.ComputerName
@@ -113,7 +118,7 @@
         }
 
         if ($remainingTargets.Count -gt 0) {
-            Stop-LabVM2 -ComputerName $remainingTargets
+            Stop-LabVM2 -ComputerName ($remainingTargets | Sort-Object -Unique)
         }
 
         if ($Wait)

--- a/AutomatedLabCore/functions/VirtualMachines/Stop-LabVM.ps1
+++ b/AutomatedLabCore/functions/VirtualMachines/Stop-LabVM.ps1
@@ -72,8 +72,7 @@
 
         if ($hypervVms)
         {
-            Stop-LWHypervVM -ComputerName $hypervVms -TimeoutInMinutes $ShutdownTimeoutInMinutes -ProgressIndicator $ProgressIndicator -NoNewLine:$NoNewLine `
-            -ErrorVariable hypervErrors -ErrorAction SilentlyContinue
+            Stop-LWHypervVM -ComputerName $hypervVms -TimeoutInMinutes $ShutdownTimeoutInMinutes -ProgressIndicator $ProgressIndicator -NoNewLine:$NoNewLine -ErrorAction SilentlyContinue
         }
         if ($azureVms)
         {

--- a/AutomatedLabCore/internal/functions/Stop-LabVM2.ps1
+++ b/AutomatedLabCore/internal/functions/Stop-LabVM2.ps1
@@ -29,10 +29,10 @@
         Stop-Computer -Force
     }
 
-    $jobs = Invoke-LabCommand -ComputerName $ComputerName -ActivityName Shutdown -NoDisplay -ScriptBlock $scriptBlock -AsJob -PassThru
+    $jobs = Invoke-LabCommand -ComputerName $ComputerName -ActivityName Shutdown -NoDisplay -ScriptBlock $scriptBlock -AsJob -PassThru -ErrorAction SilentlyContinue
     $jobs | Wait-Job -Timeout ($ShutdownTimeoutInMinutes * 60) | Out-Null
 
-    if ($jobs.Count -ne ($jobs | Where-Object State -eq Completed).Count)
+    if (-not $jobs -or ($jobs.Count -ne ($jobs | Where-Object State -eq Completed).Count))
     {
         Write-ScreenInfo "Not all machines stopped in the timeout of $ShutdownTimeoutInMinutes" -Type Warning
     }

--- a/AutomatedLabWorker/functions/Core/Invoke-LWCommand.ps1
+++ b/AutomatedLabWorker/functions/Core/Invoke-LWCommand.ps1
@@ -112,13 +112,13 @@
         @($Session | Foreach-Object {
                 if ($_.State -eq 'Broken')
                 {
-                    New-LabPSSession -Session $_
+                    New-LabPSSession -Session $_ -ErrorAction SilentlyContinue
                 }
                 else
                 {
                     $_
                 }
-        })
+        } | Where-Object {$_}) # Remove empty values. Invoke-LWCommand fails too early if AsJob is present and a broken session cannot be recreated
     )
 
     if (-not $ActivityName)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed an issue which prevented the promotion process of additional Active Directory Domain
   Controllers from being restartable (#1608).
 - Fixed a syntax issue in 'CreateDscSqlDatabase.ps1'.
+- Fixed an issue in Stop-LabVm (#1619) with invalid error objects.
 
 ## 5.50.0 (2023-11-10)
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #1619

This issue is an unholy combination of several smaller things. Invoke-LabCommand returned error records that were not handled properly, due to our use of Write-FunctionExitWithError which I replaced.

Invoke-LWCommand produced unnecessary errors which resulted in no jobs being passed through which needed handling elsewhere as well. Also, the AsJob parameter appears somewhat questionable if the function is so slow to prepare the jobs, but that is a different issue :)

Due to our number of retries, the same VM was passed three times, so I added in a Sort -Unique to further remove potential for errors.

Lastly, in Stop-LWHyperVVM, in case there were no jobs due to session failures, those failures are also used to select machines that need to be force-stopped. As a result, the Stop-LWHyperVVM function should not return any errors any longer, as we will always reach the force-stopping code.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Standard lab deployment with a single Domain Controller, changed the Admin user's credential, tried Stop-LabVm. Due to the Access Denied errors, the code flowed into Stop-LabVm2, where it ultimately failed gracefully with a warning. Not sure if this deserves another issue: If the VM cannot be stopped