### PR TITLE
Fixed #1611: New-LWHypervVmConnectSettingsFile does not create parent path

### DIFF
--- a/AutomatedLabWorker/functions/VirtualMachines/New-LWHypervVmConnectSettingsFile.ps1
+++ b/AutomatedLabWorker/functions/VirtualMachines/New-LWHypervVmConnectSettingsFile.ps1
@@ -84,8 +84,13 @@ function New-LWHypervVmConnectSettingsFile
         
         $machineVmConnectConfig.Settings.Add($setting)
         
-        #Files will be stored in path 'C:\Users\randr\AppData\Roaming\Microsoft\Windows\Hyper-V\Client\1.0'
+        #Files will be stored in path 'C:\Users\<Username>\AppData\Roaming\Microsoft\Windows\Hyper-V\Client\1.0'
         $configFilePath = '{0}\Microsoft\Windows\Hyper-V\Client\1.0\vmconnect.rdp.{1}.config' -f $env:APPDATA, $vm.Id
+        $configFileParentPath = Split-Path -Path $configFilePath -Parent
+        if (-not (Test-Path -Path $configFileParentPath -PathType Container))
+        {
+            mkdir -Path $configFileParentPath -Force | Out-Null
+        }
         $machineVmConnectConfig.Export($configFilePath)
     }
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix transient issue in 'Update-LabSysinternalsTools' (#1599).
 - Fixed an issue in Stop-LabVm (#1619) with invalid error objects.
+- Fixed an issue in 'New-LWHypervVmConnectSettingsFile' storing
+  the config file if the directory does not yet exist (#1611).
 
 ## 5.51.0 (2024-03-18)
 


### PR DESCRIPTION
## Description

Fixed an issue in 'New-LWHypervVmConnectSettingsFile' storing the config file if the directory does not yet exist (#1611).

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Single machine lab deployment in system context.