### PR TITLE
Fixes #1633, 'Get-VMSwitch' is not recognized as a name of a cmdlet...

### DIFF
--- a/AutomatedLabCore/internal/functions/Remove-LabNetworkSwitches.ps1
+++ b/AutomatedLabCore/internal/functions/Remove-LabNetworkSwitches.ps1
@@ -22,7 +22,7 @@
     }
 
     $virtualNetworks = $Script:data.VirtualNetworks | Where-Object { $_.HostType -eq 'HyperV' -and $_.Name -ne 'Default Switch' }
-    $virtualNetworks = Get-LabVirtualNetwork -Name $virtualNetworks.Name
+    $virtualNetworks = Get-LabVirtualNetwork -Name $virtualNetworks.Name -ErrorAction SilentlyContinue
     foreach ($virtualNetwork in $virtualNetworks)
     {
         Write-PSFMessage "Removing Hyper-V network switch '$($virtualNetwork.ResourceName)'..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed an issue in Stop-LabVm (#1619) with invalid error objects.
 - Fixed an issue in 'New-LWHypervVmConnectSettingsFile' storing
   the config file if the directory does not yet exist (#1611).
+- Suppressed an error message removing virtual networks (#1633).
 
 ## 5.51.0 (2024-03-18)
 


### PR DESCRIPTION
## Description

Suppressed an error message removing virtual networks (#1633).

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Simple deployment and removal on Azure.