### PR TITLE
Allow peering with random VNETs

### DIFF
--- a/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableSku.ps1
+++ b/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableSku.ps1
@@ -30,7 +30,8 @@
     Get-AzVMImageSku |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
 
     # Linux
     # Ubuntu - official
@@ -42,7 +43,9 @@
     Where-Object Skus -notmatch 'arm64' |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
+
     # RedHat - official
     $publishers |
     Where-Object PublisherName -eq 'RedHat' |
@@ -52,7 +55,9 @@
     Where-Object Skus -notmatch '(RAW|LVM|CI)' |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
+
     # CentOS - Roguewave, sounds slightly suspicious
     $publishers |
     Where-Object PublisherName -eq 'OpenLogic' |
@@ -61,7 +66,9 @@
     Get-AzVMImageSku |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
+
     # Kali
     $publishers |
     Where-Object PublisherName -eq 'Kali-Linux' |
@@ -69,7 +76,8 @@
     Get-AzVMImageSku |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
 
     # Desktop
     $publishers |
@@ -78,7 +86,8 @@
     Get-AzVMImageSku |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
 
     # SQL
     $publishers |
@@ -88,7 +97,8 @@
     Get-AzVMImage |
     Where-Object Skus -in 'Standard','Enterprise' |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
 
     # VisualStudio
     $publishers |
@@ -98,7 +108,8 @@
     Get-AzVMImage |
     Where-Object Offer -eq 'VisualStudio' |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
 
     # Client OS
     $publishers |
@@ -108,7 +119,8 @@
     Get-AzVMImage |
     Where-Object Offer -eq 'Windows' |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
 
     # Sharepoint 2013 and 2016
     $publishers |
@@ -118,5 +130,6 @@
     Get-AzVMImage |
     Where-Object Offer -eq 'MicrosoftSharePointServer' |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage }
+    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object PurchasePlan -eq $null
 }

--- a/AutomatedLabCore/functions/Azure/Get-LabAzureDefaultResourceGroup.ps1
+++ b/AutomatedLabCore/functions/Azure/Get-LabAzureDefaultResourceGroup.ps1
@@ -7,6 +7,8 @@
 
     Update-LabAzureSettings
 
+    if ($script:lab.AzureSettings.DefaultResourceGroup) { return $script:lab.AzureSettings.DefaultResourceGroup }
+
     $script:lab.AzureSettings.ResourceGroups | Where-Object ResourceGroupName -eq $script:lab.Name
 
     Write-LogFunctionExit

--- a/AutomatedLabCore/functions/Core/Install-Lab.ps1
+++ b/AutomatedLabCore/functions/Core/Install-Lab.ps1
@@ -203,7 +203,7 @@
                         $peerName = $externalPeer -split '/' | Select-Object -Last 1
                         $vNet = Get-AzResource -Id $externalPeer | Get-AzVirtualNetwork
                         Write-ScreenInfo -Type Verbose -Message ('Adding peering from {0} to {1} to VNet' -f $network.ResourceName, $peerName)
-                        Add-AzVirtualNetworkPeering -VirtualNetwork $vnet -RemoteVirtualNetworkId $remoteNet.id -Name "$($network.ResourceName)To$($peerName)"
+                        $null = Add-AzVirtualNetworkPeering -VirtualNetwork $vnet -RemoteVirtualNetworkId $remoteNet.id -Name "$($network.ResourceName)To$($peerName)"
                     }
                 }
             }

--- a/AutomatedLabCore/functions/Core/Install-Lab.ps1
+++ b/AutomatedLabCore/functions/Core/Install-Lab.ps1
@@ -196,6 +196,18 @@
                 New-LabVM -Name ($script:data.Machines | Where-Object SkipDeployment -eq $false) -CreateCheckPoints:$CreateCheckPoints
             }
 
+            if ($engine -eq 'Azure') {                
+                foreach ($network in $script:data.VirtualNetworks) {
+                    $remoteNet = Get-AzVirtualNetwork -Name $network.ResourceName
+                    foreach ($externalPeer in $network.PeeringVnetResourceIds) {
+                        $peerName = $externalPeer -split '/' | Select-Object -Last 1
+                        $vNet = Get-AzResource -Id $externalPeer | Get-AzVirtualNetwork
+                        Write-ScreenInfo -Type Verbose -Message ('Adding peering from {0} to {1} to VNet' -f $network.ResourceName, $peerName)
+                        Add-AzVirtualNetworkPeering -VirtualNetwork $vnet -RemoteVirtualNetworkId $remoteNet.id -Name "$($network.ResourceName)To$($peerName)"
+                    }
+                }
+            }
+
             #VMs created, export lab definition again to update MAC addresses
             Set-LabDefinition -Machines $Script:data.Machines
             Export-LabDefinition -Force -ExportDefaultUnattendedXml -Silent

--- a/AutomatedLabCore/functions/Core/Remove-Lab.ps1
+++ b/AutomatedLabCore/functions/Core/Remove-Lab.ps1
@@ -86,7 +86,7 @@
                         $peerName = $externalPeer -split '/' | Select-Object -Last 1
                         $vNet = Get-AzResource -Id $externalPeer | Get-AzVirtualNetwork
                         Write-ScreenInfo -Type Verbose -Message ('Adding peering from {0} to {1} to VNet' -f $network.ResourceName, $peerName)
-                        Remove-AzVirtualNetworkPeering -VirtualNetworkName $vnet.Name -ResourceGroupname $vnet.ResourceGroupName -Name "$($network.ResourceName)To$($peerName)" -Force
+                        $null = Remove-AzVirtualNetworkPeering -VirtualNetworkName $vnet.Name -ResourceGroupname $vnet.ResourceGroupName -Name "$($network.ResourceName)To$($peerName)" -Force
                     }
                 }
                 

--- a/AutomatedLabCore/internal/scripts/Types.ps1
+++ b/AutomatedLabCore/internal/scripts/Types.ps1
@@ -892,6 +892,7 @@ $gpoType = @'
                         }
                         catch (COMException e)
                         {
+                            var error = e.ErrorCode;
                             RegCloseKey(gphSubKey);
                             RegCloseKey(gphKey);
                             return ResultCode.SaveFailed;

--- a/AutomatedLabDefinition/functions/Network/Add-LabVirtualNetworkDefinition.ps1
+++ b/AutomatedLabDefinition/functions/Network/Add-LabVirtualNetworkDefinition.ps1
@@ -27,7 +27,7 @@
         Add-LabAzureSubscription
     }
 
-    $azurePropertiesValidKeys = 'Subnets', 'LocationName', 'DnsServers', 'ConnectToVnets', 'DnsLabel'
+    $azurePropertiesValidKeys = 'Subnets', 'LocationName', 'DnsServers', 'ConnectToVnets', 'DnsLabel', 'PeeringVnetResourceIds'
     $hypervPropertiesValidKeys = 'SwitchType', 'AdapterName', 'ManagementAdapter'
 
     if (-not (Get-LabDefinition))
@@ -141,6 +141,11 @@
 	if($AzureProperties.ConnectToVnets)
 	{
 		$network.ConnectToVnets = $AzureProperties.ConnectToVnets
+	}
+
+	if($AzureProperties.PeeringVnetResourceIds)
+	{
+		$network.PeeringVnetResourceIds = $AzureProperties.PeeringVnetResourceIds
 	}
 
 	if($AzureProperties.DnsServers)

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
@@ -367,7 +367,6 @@
                 )
                 type       = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
                 name       = "$($network.ResourceName)/$($network.ResourceName)To$($peer)"
-                location   = "[resourceGroup().location]"
                 properties = @{
                     allowVirtualNetworkAccess = $true
                     allowForwardedTraffic     = $false
@@ -375,6 +374,24 @@
                     useRemoteGateways         = $false
                     remoteVirtualNetwork      = @{
                         id = "[resourceId('Microsoft.Network/virtualNetworks', '$peer')]"
+                    }
+                }
+            }
+            $template.Resources += @{
+                apiVersion = $apiVersions['VirtualNetworkApi']
+                dependsOn  = @(
+                    "[resourceId('Microsoft.Network/virtualNetworks', '$($network.ResourceName)')]"
+                    "[resourceId('Microsoft.Network/virtualNetworks', '$($peer)')]"
+                )
+                type       = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+                name       = "$($peer)/$($peer)To$($network.ResourceName)"
+                properties = @{
+                    allowVirtualNetworkAccess = $true
+                    allowForwardedTraffic     = $false
+                    allowGatewayTransit       = $false
+                    useRemoteGateways         = $false
+                    remoteVirtualNetwork      = @{
+                        id = "[resourceId('Microsoft.Network/virtualNetworks', '$($network.ResourceName)')]"
                     }
                 }
             }
@@ -387,10 +404,10 @@
                 apiVersion = $apiVersions['VirtualNetworkApi']
                 dependsOn  = @(
                     "[resourceId('Microsoft.Network/virtualNetworks', '$($network.ResourceName)')]"
+                    $externalPeer
                 )
                 type       = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
                 name       = "$($network.ResourceName)/$($network.ResourceName)To$($peerName)"
-                location   = "[resourceGroup().location]"
                 properties = @{
                     allowVirtualNetworkAccess = $true
                     allowForwardedTraffic     = $false
@@ -398,6 +415,24 @@
                     useRemoteGateways         = $false
                     remoteVirtualNetwork      = @{
                         id = $externalPeer
+                    }
+                }
+            }
+            $template.Resources += @{
+                apiVersion = $apiVersions['VirtualNetworkApi']
+                dependsOn  = @(
+                    "[resourceId('Microsoft.Network/virtualNetworks', '$($network.ResourceName)')]"
+                    $externalPeer
+                )
+                type       = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+                name       = "$($peerName)/$($peerName)To$($network.ResourceName)"
+                properties = @{
+                    allowVirtualNetworkAccess = $true
+                    allowForwardedTraffic     = $false
+                    allowGatewayTransit       = $false
+                    useRemoteGateways         = $false
+                    remoteVirtualNetwork      = @{
+                        id = "[resourceId('Microsoft.Network/virtualNetworks', '$($network.ResourceName)')]"
                     }
                 }
             }

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
@@ -379,6 +379,29 @@
                 }
             }
         }
+
+        foreach ($externalPeer in $network.PeeringVnetResourceIds) {
+            $peerName = $externalPeer -split '/' | Select-Object -Last 1
+            Write-ScreenInfo -Type Verbose -Message ('Adding peering from {0} to {1} to VNet template' -f $network.ResourceName, $peerName)
+            $template.Resources += @{
+                apiVersion = $apiVersions['VirtualNetworkApi']
+                dependsOn  = @(
+                    "[resourceId('Microsoft.Network/virtualNetworks', '$($network.ResourceName)')]"
+                )
+                type       = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+                name       = "$($network.ResourceName)/$($network.ResourceName)To$($peerName)"
+                location   = "[resourceGroup().location]"
+                properties = @{
+                    allowVirtualNetworkAccess = $true
+                    allowForwardedTraffic     = $false
+                    allowGatewayTransit       = $false
+                    useRemoteGateways         = $false
+                    remoteVirtualNetwork      = @{
+                        id = $externalPeer
+                    }
+                }
+            }
+        }
         #endregion
 
         #region Public Ip

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
@@ -404,7 +404,6 @@
                 apiVersion = $apiVersions['VirtualNetworkApi']
                 dependsOn  = @(
                     "[resourceId('Microsoft.Network/virtualNetworks', '$($network.ResourceName)')]"
-                    $externalPeer
                 )
                 type       = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
                 name       = "$($network.ResourceName)/$($network.ResourceName)To$($peerName)"

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/New-LabAzureResourceGroupDeployment.ps1
@@ -418,24 +418,6 @@
                     }
                 }
             }
-            $template.Resources += @{
-                apiVersion = $apiVersions['VirtualNetworkApi']
-                dependsOn  = @(
-                    "[resourceId('Microsoft.Network/virtualNetworks', '$($network.ResourceName)')]"
-                    $externalPeer
-                )
-                type       = "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
-                name       = "$($peerName)/$($peerName)To$($network.ResourceName)"
-                properties = @{
-                    allowVirtualNetworkAccess = $true
-                    allowForwardedTraffic     = $false
-                    allowGatewayTransit       = $false
-                    useRemoteGateways         = $false
-                    remoteVirtualNetwork      = @{
-                        id = "[resourceId('Microsoft.Network/virtualNetworks', '$($network.ResourceName)')]"
-                    }
-                }
-            }
         }
         #endregion
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+- Allow very basic peering with unmnanaged VNETs (#1653), given that the account running the lab script has the appropriate permissions.
+
 ### Bugs
 
 - Improved message in validator 'AzureSpecifiedRoleSizeNotFound'.

--- a/Help/AutomatedLabDefinition/en-us/Add-LabVirtualNetworkDefinition.md
+++ b/Help/AutomatedLabDefinition/en-us/Add-LabVirtualNetworkDefinition.md
@@ -90,12 +90,13 @@ Accept wildcard characters: False
 
 ### -AzureProperties
 Extra properties for Azure based virtual network.
-Options are:   SubnetName:           Name of subnet to be create inside the virtual network. 
-SubnetAddressPrefix:  If a subnet of another size than the virtual network is desired, use this parameter to specify this. 
-LocationName:         Azure Datacenter of where to create the virtual network. 
-DnsServers:           DNS servers for the virtual network.
-All machines in the virtual network will be configured to use these DNS servers if they are not configured manually. 
-ConnectToVnets:       If specified, a VPN gateway will be created and configure to connect the network being created with the network(s) specified by this parameter.
+Options are:
+SubnetName: The name of the subnet to create in the virtual network. AL does not segment virtual networks into subnets. One virtual network per network definition will be created
+SubnetAddressPrefix: The address prefix (e.g. 24) of the subnet that will be created.
+LocationName: The Azure location name (e.g. westeurope). Bear in mind that this should not differ from your lab's default location.
+DnsServers: Comma-separated DNS servers for the network.
+ConnectToVnets: Connections to other Lab VNETs by leveraging VNET peering. When connecting two or more lab networks through this parameter, please also specifiy this for all additional network definitions
+PeeringVnetResourceIds: Connections to VNETs not managed by AutomatedLab. A list of resource IDs for the peering is required in the form /subscriptions/<GUID>/resourceGroups/<RGNAME>/providers/Microsoft.Network/virtualNetworks/<VNETNAME>. All peerings will be created with VNET access, no GW transit, no forwarding and no remote gateways.
 
 ```yaml
 Type: Hashtable[]

--- a/Help/Wiki/Basic/networksandaddresses.md
+++ b/Help/Wiki/Basic/networksandaddresses.md
@@ -23,7 +23,8 @@ Additionally, the parameters AzureProperties and HyperVProperties can be used to
 * SubnetAddressPrefix: The address prefix (e.g. 24) of the subnet that will be created.
 * LocationName: The Azure location name (e.g. westeurope). Bear in mind that this should not differ from your lab's default location.
 * DnsServers: Comma-separated DNS servers for the network.
-* ConnectToVnets: Connections to other VNETs by leveraging VNET peering. When connecting two or more lab networks through this parameter, please also specifiy this for all additional network definitions
+* ConnectToVnets: Connections to other Lab VNETs by leveraging VNET peering. When connecting two or more lab networks through this parameter, please also specifiy this for all additional network definitions
+* PeeringVnetResourceIds: Connections to VNETs not managed by AutomatedLab. A list of resource IDs for the peering is required in the form /subscriptions/<GUID>/resourceGroups/<RGNAME>/providers/Microsoft.Network/virtualNetworks/<VNETNAME>. All peerings will be created with VNET access, no GW transit, no forwarding and no remote gateways.
 
 For HyperV, the following properties are valid:
 

--- a/LabXml/Network/VirtualNetwork.cs
+++ b/LabXml/Network/VirtualNetwork.cs
@@ -87,6 +87,9 @@ namespace AutomatedLab
             set { connectToVnets = value; }
         }
 
+        // Allowing Azure users to peer to a non-AL-managed VNET
+        public List<string> PeeringVnetResourceIds { get; set; }
+
         public List<IPAddress> DnsServers
         {
             get { return dnsServers; }


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixed #1653 in a very basic manner: By allowing a list of resource IDs to peer to. Including arbitrary existing resources is currently out of scope for me, as this would include loads of additional checks and additional handling in many of our convenience functions.

Also fixed an issue with the current peering of vnets in the same lab which was only ever established one-way. Seems like noone used that feature though...

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
```powershell
$externalVnet = Get-AzVirtualNetwork -Name MyVirtualNetwork -ResourceGroupName MyResourceGroup -ErrorAction SilentlyContinue
if (-not $externalVnet) {
    $rg = New-AzResourceGroup -Name MyResourceGroup -Location 'West Europe'
    $externalVnet = New-AzVirtualNetwork -Name MyVirtualNetwork -ResourceGroupName MyResourceGroup -Location 'West Europe' -AddressPrefix 10.0.0.0/16
}

New-LabDefinition -Name ExternalResourceTest -DefaultVirtualizationEngine Azure
Add-LabAzureSubscription -DefaultLocationName 'west europe'
Add-LabDomainDefinition -Name contoso.com -AdminUser install -AdminPassword S00perS3cur1!
Set-LabInstallationCredential -Username install -Password S00perS3cur1!
Add-LabVirtualNetworkDefinition -Name ExternalResourceTest -AzureProperties @{
    PeeringVnetResourceIds = $externalVnet.Id
} -AddressSpace 192.168.111.0/24
Add-LabVirtualNetworkDefinition -Name PeeringInternalTest -AzureProperties @{
    ConnectToVnets = 'ExternalResourceTest'
} -AddressSpace 192.168.121.0/24
Add-LabMachineDefinition -Name DC1 -Roles RootDC -AzureRoleSize Standard_B4s_v2 -Network ExternalResourceTest -IpAddress 192.168.111.99 -OperatingSystem 'Windows Server 2022 Datacenter' -DomainName contoso.com
Install-Lab
```