### PR TITLE
Invoke-LabDscConfiguration can now handle MetaMof files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 ### Enhancements
 
 - Allow very basic peering with unmnanaged VNETs (#1653), given that the account running the lab script has the appropriate permissions.
+- 'Invoke-LabDscConfiguration' can now deal with MetaMofs additionally to MOFs (fixes #1651).
 
 ### Bugs
 
 - Improved message in validator 'AzureSpecifiedRoleSizeNotFound'.
-- Remove deprecated functions from help and manifest
+- Remove deprecated functions from help and manifest.
 
 ## 5.53.0 (2024-06-08)
 


### PR DESCRIPTION
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
```powershell
$LabName = 'DscWorkshop'
$DomainName = 'contoso.com'
$HostName = 'DSCHost01'
$User = 'Install'

Import-Lab -Name $LabName -NoValidation

Configuration Test
{
    Import-DscResource -ModuleName PSDesiredStateConfiguration

    node $AllNodes.NodeName
    {
        LocalConfigurationManager
        {
            ConfigurationMode = 'ApplyOnly'
            RebootNodeIfNeeded = $true
            ConfigurationModeFrequencyMins = 38
        }
        
        #File TestFile1
        #{
        #    DestinationPath = 'C:\TestFile1.txt'
        #    Type = 'File'
        #    Contents = '123'
        #}
    }
}

$ConfigurationData = @{
    AllNodes = @(
        @{
            NodeName = $hostname
            PSDscAllowPlainTextPassword = $true
            PSDscAllowDomainUser = $true
        }
    )
}

[string[]]$hostArray = @() 
$hostArray += $Hostname
Invoke-LabDscConfiguration -Configuration (Get-Command -Name Test) -ConfigurationData $ConfigurationData -ComputerName $hostarray -Wait
```
