### PR TITLE
Write-ScreenInfo in Variables.ps1 - Fixes #1648

### DIFF
--- a/AutomatedLabCore/internal/scripts/Variables.ps1
+++ b/AutomatedLabCore/internal/scripts/Variables.ps1
@@ -169,7 +169,7 @@ $adInstallFirstChildDc2012 = {
         }
         else
         {
-            Write-ScreenInfo "Domain $ParentDomainName was not reachable ($count)" -Type Warning
+            Write-Warning "Domain $ParentDomainName was not reachable ($count)"
         }
 
         Start-Sleep -Seconds 1
@@ -201,7 +201,7 @@ $adInstallFirstChildDc2012 = {
     $retriesDone = 0
     do
     {
-        Write-Verbose "The first try to promote '$(HOSTNAME.EXE)' did not work. The error was '$($result.Message)'. Retrying after $SecondsBetweenRetries seconds. Retry count $retriesDone of $Retries." -Type Warning
+        Write-Verbose "The first try to promote '$(HOSTNAME.EXE)' did not work. The error was '$($result.Message)'. Retrying after $SecondsBetweenRetries seconds. Retry count $retriesDone of $Retries."
         ipconfig.exe /flushdns | Out-Null
 
         try
@@ -323,7 +323,7 @@ $adInstallFirstChildDcPre2012 = {
         }
         else
         {
-            Write-ScreenInfo "Domain $ParentDomainName was not reachable ($count)" -Type Warning
+            Write-Warning "Domain $ParentDomainName was not reachable ($count)"
         }
 
         Start-Sleep -Seconds 1
@@ -410,7 +410,7 @@ $adInstallFirstChildDcPre2012 = {
     $retriesDone = 0
     while ($LASTEXITCODE -ge 11 -and $retriesDone -lt $Retries)
     {
-        Write-ScreenInfo "Promoting the Domain Controller '$(HOSTNAME.EXE)' did not work. The error code was '$LASTEXITCODE'. Retrying after $SecondsBetweenRetries seconds. Retry count $retriesDone of $Retries." -Type Warning
+        Write-Warning "Promoting the Domain Controller '$(HOSTNAME.EXE)' did not work. The error code was '$LASTEXITCODE'. Retrying after $SecondsBetweenRetries seconds. Retry count $retriesDone of $Retries."
         ipconfig.exe /flushdns | Out-Null
 
         Start-Sleep -Seconds $SecondsBetweenRetries
@@ -480,7 +480,7 @@ $adInstallDc2012 = {
         }
         else
         {
-            Write-ScreenInfo "Domain $DomainName was not reachable ($count)" -Type Warning
+            Write-Warning "Domain $DomainName was not reachable ($count)"
         }
 
         Start-Sleep -Seconds 1
@@ -559,7 +559,7 @@ $adInstallDc2012 = {
     $retriesDone = 0
     while ($result.Status -eq 'Error' -and $retriesDone -lt $Retries)
     {
-        Write-ScreenInfo "The first try to promote '$(HOSTNAME.EXE)' did not work. The error was '$($result.Message)'. Retrying after $SecondsBetweenRetries seconds. Retry count $retriesDone of $Retries." -Type Warning
+        Write-Warning "The first try to promote '$(HOSTNAME.EXE)' did not work. The error was '$($result.Message)'. Retrying after $SecondsBetweenRetries seconds. Retry count $retriesDone of $Retries."
         ipconfig.exe /flushdns | Out-Null
 
         Start-Sleep -Seconds $SecondsBetweenRetries
@@ -693,7 +693,7 @@ $adInstallDcPre2012 = {
         }
         else
         {
-            Write-ScreenInfo "Domain $DomainName was not reachable ($count)" -Type Warning
+            Write-Warning "Domain $DomainName was not reachable ($count)"
         }
 
         Start-Sleep -Seconds 1
@@ -718,7 +718,7 @@ $adInstallDcPre2012 = {
     $retriesDone = 0
     while ($LASTEXITCODE -ge 11 -and $retriesDone -lt $Retries)
     {
-        Write-ScreenInfo "The first try to promote '$(HOSTNAME.EXE)' did not work. The error code was '$LASTEXITCODE'. Retrying after $SecondsBetweenRetries seconds. Retry count $retriesDone of $Retries." -Type Warning
+        Write-Warning "The first try to promote '$(HOSTNAME.EXE)' did not work. The error code was '$LASTEXITCODE'. Retrying after $SecondsBetweenRetries seconds. Retry count $retriesDone of $Retries."
         ipconfig.exe /flushdns | Out-Null
 
         Start-Sleep -Seconds $SecondsBetweenRetries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Improved message in validator 'AzureSpecifiedRoleSizeNotFound'.
 - Remove deprecated functions from help and manifest.
+- Fix Write-ScreenInfo (fixes #1648)
 
 ## 5.53.0 (2024-06-08)
 


### PR DESCRIPTION
## Description

Changed Write-ScreenInfo to appropriate Write-Warning/Verbose Removed invalid -Type param from Write-Verbose

- [X] - I have tested my changes.  
- [X] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [X] - The PR has a meaningful title.  
- [X] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [X] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Made same changes from variables.ps1 to AutomatedLabCore.psm1in my lab and validated that these specific errors ceased with the lab script in the issue.
