### PR TITLE
Removed the colum 'LastUpdated' from the table 'RegistrationData' in the DSC database.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased (yyyy-MM-dd)
 
+### Bugs
+
+- Removed the colum 'LastUpdated' from the table 'RegistrationData' in the DSC database.
+
 ## 5.54.0 (2024-08-16)
 
 ### Enhancements

--- a/LabSources/PostInstallationActivities/SetupDscPullServer/CreateDscSqlDatabase.ps1
+++ b/LabSources/PostInstallationActivities/SetupDscPullServer/CreateDscSqlDatabase.ps1
@@ -225,7 +225,6 @@ CREATE TABLE [dbo].[RegistrationData](
 	[NodeName] [nvarchar](255) NULL,
 	[IPAddress] [nvarchar](255) NULL,
 	[ConfigurationNames] [nvarchar](max) NULL,
-    [LastUpdated] [date] NULL,
  CONSTRAINT [PK_RegistrationData] PRIMARY KEY CLUSTERED 
 (
     [AgentId] ASC


### PR DESCRIPTION
## Description

Removed the colum 'LastUpdated' from the table 'RegistrationData' in the DSC database. The column causes DSC nodes registrations to fail.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
DscWorkshop