### PR TITLE
Fix/azure image selection

### DIFF
--- a/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableRoleSize.ps1
+++ b/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableRoleSize.ps1
@@ -46,15 +46,15 @@
     {
         $rsInfo = $availableRoleSizes | Where-Object Name -eq $vms.Name
 
-            [AutomatedLab.Azure.AzureRmVmSize]@{
-                NumberOfCores = $vms.NumberOfCores
-                MemoryInMB = $vms.MemoryInMB
-                Name = $vms.Name
-                MaxDataDiskCount = $vms.MaxDataDiskCount
-                ResourceDiskSizeInMB = $vms.ResourceDiskSizeInMB
-                OSDiskSizeInMB = $vms.OSDiskSizeInMB
-                Gen1Supported = ($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -like '*v1*'
-                Gen2Supported = ($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -like '*v2*'
-            }
+        [AutomatedLab.Azure.AzureRmVmSize]@{
+            NumberOfCores = $vms.NumberOfCores
+            MemoryInMB = $vms.MemoryInMB
+            Name = $vms.Name
+            MaxDataDiskCount = $vms.MaxDataDiskCount
+            ResourceDiskSizeInMB = $vms.ResourceDiskSizeInMB
+            OSDiskSizeInMB = $vms.OSDiskSizeInMB
+            Gen1Supported = ($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -like '*v1*'
+            Gen2Supported = ($rsInfo.Capabilities | Where-Object Name -eq HyperVGenerations).Value -like '*v2*'
+        }
     }
 }

--- a/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableRoleSize.ps1
+++ b/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableRoleSize.ps1
@@ -19,8 +19,8 @@
     {
         $param = @{
             UseDeviceAuthentication = $true
-            ErrorAction             = 'SilentlyContinue' 
-            WarningAction           = 'Continue'            
+            ErrorAction             = 'SilentlyContinue'
+            WarningAction           = 'Continue'
         }
 
         if ($script:lab.AzureSettings.Environment)
@@ -38,19 +38,9 @@
         return
     }
 
-    $availableRoleSizes = if ((Get-Command Get-AzComputeResourceSku).Parameters.ContainsKey('Location'))
-    {
-        Get-AzComputeResourceSku -Location $azLocation.Location | Where-Object {
-            $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription' -and ($_.Capabilities | Where-Object Name -eq CpuArchitectureType).Value -notlike '*arm*'
-        }
+    $availableRoleSizes = Get-AzComputeResourceSku -Location $azLocation.Location | Where-Object {
+        $_.ResourceType -eq 'virtualMachines' -and ($_.Restrictions | Where-Object Type -eq Location).ReasonCode -ne 'NotAvailableForSubscription' -and ($_.Capabilities | Where-Object Name -eq CpuArchitectureType).Value -notlike '*arm*'
     }
-    else
-    {
-        Get-AzComputeResourceSku | Where-Object {
-            $_.Locations -contains $azLocation.Location -and $_.ResourceType -eq 'virtualMachines' -and $_.Restrictions.ReasonCode -notcontains 'NotAvailableForSubscription' -and ($_.Capabilities | Where-Object Name -eq CpuArchitectureType).Value -notlike '*arm*'
-        }
-    }
-    
 
     foreach ($vms in (Get-AzVMSize -Location $azLocation.Location | Where-Object -Property Name -in $availableRoleSizes.Name))
     {

--- a/AutomatedLabCore/internal/scripts/Initialization.ps1
+++ b/AutomatedLabCore/internal/scripts/Initialization.ps1
@@ -176,7 +176,7 @@ Set-PSFConfig -Module 'AutomatedLab' -Name SkipHostFileModification -Value $fals
 
 #Azure
 Set-PSFConfig -Module 'AutomatedLab' -Name MinimumAzureModuleVersion -Value '4.1.0' -Initialize -Validation string -Description 'The minimum expected Azure module version'
-Set-PSFConfig -Module 'AutomatedLab' -Name DefaultAzureRoleSize -Value 'D' -Initialize -Validation string -Description 'The default Azure role size, e.g. from Get-LabAzureAvailableRoleSize'
+Set-PSFConfig -Module 'AutomatedLab' -Name DefaultAzureRoleSize -Value 'DS' -Initialize -Validation string -Description 'The default Azure role size, e.g. from Get-LabAzureAvailableRoleSize'
 Set-PSFConfig -Module 'AutomatedLab' -Name LabSourcesMaxFileSizeMb -Value 50 -Initialize -Validation integer -Description 'The default file size for Sync-LabAzureLabSources'
 Set-PSFConfig -Module 'AutomatedLab' -Name AutoSyncLabSources -Value $false -Initialize -Validation bool -Description 'Toggle auto-sync of Azure lab sources in Azure labs'
 Set-PSFConfig -Module 'AutomatedLab' -Name LabSourcesSyncIntervalDays -Value 60 -Initialize -Validation integerpositive -Description 'Interval in days for lab sources auto-sync'

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
@@ -35,31 +35,22 @@
     {
         $pattern = switch ($lab.AzureSettings.DefaultRoleSize)
         {
-            'A' { '^Standard_A\d{1,2}(_v\d{1,3})|Basic_A\d{1,2})' }
+            'A' { '^Standard_A\d{1,2}(_v\d{1,3})|Basic_A\d{1,2}' }
             'AS' { '^Standard_AS\d{1,2}(_v\d{1,3})' }
             'AC' { '^Standard_AC\d{1,2}(_v\d{1,3})' }
-            'D' { '^Standard_D\d{1,2}(_v\d{1,3})' }
-            'DS' { '^Standard_DS\d{1,2}(_v\d{1,3})' }
-            'DC' { '^Standard_DC\d{1,2}(_v\d{1,3})' }
-            "E" { '^Standard_E\d{1,2}(_v\d{1,3})' }
-            "ES" { '^Standard_ES\d{1,2}(_v\d{1,3})' }
-            "EC" { '^Standard_EC\d{1,2}(_v\d{1,3})' }
-            'F' { '^Standard_F\d{1,2}(_v\d{1,3})' }
-            'FS' { '^Standard_FS\d{1,2}(_v\d{1,3})' }
-            'FC' { '^Standard_FC\d{1,2}(_v\d{1,3})' }
-            'G' { '^Standard_G\d{1,2}(_v\d{1,3})' }
-            'GS' { '^Standard_GS\d{1,2}(_v\d{1,3})' }
-            'GC' { '^Standard_GC\d{1,2}(_v\d{1,3})' }
-            'H' { '^Standard_H\d{1,2}(_v\d{1,3})' }
-            'HS' { '^Standard_HS\d{1,2}(_v\d{1,3})' }
-            'HC' { '^Standard_HC\d{1,2}(_v\d{1,3})' }
-            'L' { '^Standard_L\d{1,2}(_v\d{1,3})' }
-            'LS' { '^Standard_LS\d{1,2}(_v\d{1,3})' }
-            'LC' { '^Standard_LC\d{1,2}(_v\d{1,3})' }
-            'N' { '^Standard_N\d{1,2}(_v\d{1,3})' }
-            'NS' { '^Standard_NS\d{1,2}(_v\d{1,3})' }
-            'NC' { '^Standard_NC\d{1,2}(_v\d{1,3})' }
-            default { '^(Standard_A\d{1,2}(_v\d{1,3})|Basic_A\d{1,2})' }
+            'D' { '^Standard_D\d{1,2}s?(_v\d{1,3})' }
+            'DS' { '^Standard_DS\d{1,2}(-\d\d?)?(_v\d{1,3})' }
+            'DC' { '^Standard_DC\d{1,2}s(_v\d{1,3})' }
+            "E" { '^Standard_E\d{1,2}s(_v\d{1,3})' }
+            "EC" { '^Standard_EC\d{1,2}([a-z]+)(_cc)?(_v\d{1,3})' }
+            'F' { '^Standard_F\d{1,2}s(_v\d{1,3})' }
+            'G' { '^Standard_G\d{1,2}(-\d{1,2})?' }
+            'GS' { '^Standard_GS\d{1,2}(-\d{1,2})?' }
+            'HB' { '^Standard_HB(\d{1,3})(-\d{1,3})?rs(_v\d{1,3})' }
+            'L' { '^Standard_L\d{1,2}s(_v\d{1,3})' }
+            'NV' { '^Standard_NV(\d{1,3})adm?s_(V\d{3})(_v\d{1,3})' }
+            'NC' { '^Standard_NC(\d{1,3})ad?s_([A|T]\d{1,3})(_v\d{1,3})'}
+            default { '^Standard_DS\d{1,2}(-\d\d?)?(_v\d{1,3})' }
         }
 
         $roleSize = $lab.AzureSettings.RoleSizes |

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
@@ -54,10 +54,18 @@
         }
 
         $roleSize = $lab.AzureSettings.RoleSizes |
-        Where-Object { $_.Name -Match $pattern -and $_.Name -notlike '*promo*' } |
-        Where-Object { $_.MemoryInMB -ge ($machine.Memory / 1MB) -and $_.NumberOfCores -ge $machine.Processors } |
-        Sort-Object -Property MemoryInMB, NumberOfCores, @{ Expression = { if ($_.Name -match '.+_v(?<Version>\d{1,2})') { $Matches.Version } }; Ascending = $false } |
-        Select-Object -First 1
+            Where-Object { $_.Name -Match $pattern -and $_.Name -notlike '*promo*' } |
+            Where-Object { $_.MemoryInMB -ge ($machine.Memory / 1MB) -and $_.NumberOfCores -ge $machine.Processors } |
+            Where-Object { 
+                if ($Machine.VmGeneration -eq 2) {
+                    $_.Gen2Supported -eq $true
+                }
+                elseif ($Machine.VmGeneration -eq 1) {
+                    $_.Gen1Supported -eq $true
+                }
+            } |
+            Sort-Object -Property MemoryInMB, NumberOfCores, @{ Expression = { if ($_.Name -match '.+_v(?<Version>\d{1,2})') { $Matches.Version } }; Ascending = $false } |
+            Select-Object -First 1
 
         Write-PSFMessage -Message "Using specified role size of '$($roleSize.Name)' out of role sizes '$pattern'"
     }

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
@@ -25,7 +25,7 @@
     {
         $DefaultAzureRoleSize = Get-LabConfigurationItem -Name DefaultAzureRoleSize
         $roleSize = $lab.AzureSettings.RoleSizes |
-        Where-Object { $_.MemoryInMB -ge $machine.Memory -and $_.NumberOfCores -ge $machine.Processors -and $machine.Disks.Count -le $_.MaxDataDiskCount } |
+        Where-Object { $_.MemoryInMB -ge ($machine.Memory / 1MB) -and $_.NumberOfCores -ge $machine.Processors -and $machine.Disks.Count -le $_.MaxDataDiskCount } |
         Sort-Object -Property MemoryInMB, NumberOfCores |
         Select-Object -First 1
 

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Get-LWAzureVmSize.ps1
@@ -38,7 +38,7 @@
             'A' { '^Standard_A\d{1,2}(_v\d{1,3})|Basic_A\d{1,2}' }
             'AS' { '^Standard_AS\d{1,2}(_v\d{1,3})' }
             'AC' { '^Standard_AC\d{1,2}(_v\d{1,3})' }
-            'D' { '^Standard_D\d{1,2}s?(_v\d{1,3})' }
+            'D' { '^Standard_D\d{1,2}s(_v\d{1,3})' }
             'DS' { '^Standard_DS\d{1,2}(-\d\d?)?(_v\d{1,3})' }
             'DC' { '^Standard_DC\d{1,2}s(_v\d{1,3})' }
             "E" { '^Standard_E\d{1,2}s(_v\d{1,3})' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ### Enhancements
 
+- 'DefaultAzureRoleSize' is not 'DS'.
+- Not all Skus with a restriction 'NotAvailableForSubscription' will be ignored, only the
+  ones that have a 'NotAvailableForSubscription'-restriction for the location.
+- Taking VM generation into account when selecting an Azure role size / image.
+
+### Bugs
+
+- Updated selection of Azure VM role sizes. It was outdated.
+
+### Enhancements
+
 - Added product keys for Windows Server 2025.
 
 ### Bugs


### PR DESCRIPTION
## Description

### Enhancements

- 'DefaultAzureRoleSize' is not 'DS'.
- Not all Skus with a restriction 'NotAvailableForSubscription' will be ignored, only the
  ones that have a 'NotAvailableForSubscription'-restriction for the location.
- Taking VM generation into account when selecting an Azure role size / image.

### Bugs

- Updated selection of Azure VM role sizes. It was outdated.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
DscWorkshop Deployments