### PR TITLE
Setting 'DefaultAzureRoleSize' back to 'D'

### DIFF
--- a/AutomatedLabCore/internal/scripts/Initialization.ps1
+++ b/AutomatedLabCore/internal/scripts/Initialization.ps1
@@ -176,7 +176,7 @@ Set-PSFConfig -Module 'AutomatedLab' -Name SkipHostFileModification -Value $fals
 
 #Azure
 Set-PSFConfig -Module 'AutomatedLab' -Name MinimumAzureModuleVersion -Value '4.1.0' -Initialize -Validation string -Description 'The minimum expected Azure module version'
-Set-PSFConfig -Module 'AutomatedLab' -Name DefaultAzureRoleSize -Value 'DS' -Initialize -Validation string -Description 'The default Azure role size, e.g. from Get-LabAzureAvailableRoleSize'
+Set-PSFConfig -Module 'AutomatedLab' -Name DefaultAzureRoleSize -Value 'D' -Initialize -Validation string -Description 'The default Azure role size, e.g. from Get-LabAzureAvailableRoleSize'
 Set-PSFConfig -Module 'AutomatedLab' -Name LabSourcesMaxFileSizeMb -Value 50 -Initialize -Validation integer -Description 'The default file size for Sync-LabAzureLabSources'
 Set-PSFConfig -Module 'AutomatedLab' -Name AutoSyncLabSources -Value $false -Initialize -Validation bool -Description 'Toggle auto-sync of Azure lab sources in Azure labs'
 Set-PSFConfig -Module 'AutomatedLab' -Name LabSourcesSyncIntervalDays -Value 60 -Initialize -Validation integerpositive -Description 'Interval in days for lab sources auto-sync'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Enhancements
 
-- 'DefaultAzureRoleSize' is not 'DS'.
 - Not all Skus with a restriction 'NotAvailableForSubscription' will be ignored, only the
   ones that have a 'NotAvailableForSubscription'-restriction for the location.
 - Taking VM generation into account when selecting an Azure role size / image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased (yyyy-MM-dd)
 
-## 5.55.0 (2024-12-31)
-
 ### Enhancements
 
 - 'DefaultAzureRoleSize' is not 'DS'.
@@ -14,6 +12,8 @@
 ### Bugs
 
 - Updated selection of Azure VM role sizes. It was outdated.
+
+## 5.55.0 (2024-12-31)
 
 ### Enhancements
 


### PR DESCRIPTION
## Description

Setting 'DefaultAzureRoleSize' back to 'D'. 'D' images are updated faster and support more features, for example nested virtualization.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
DscWorkshop Deployment