### PR TITLE
Fixed issues when deploying DscWorkshop to Azure

### DIFF
--- a/AutomatedLabCore/functions/Remoting/Remove-LabPSSession.ps1
+++ b/AutomatedLabCore/functions/Remoting/Remove-LabPSSession.ps1
@@ -46,16 +46,16 @@
             $param['Port'] = 5985
         }
 
-        if (((Get-Command New-PSSession).Parameters.Values.Name -contains 'HostName') )
-        {
-            $param['HostName'] = $param['ComputerName']
-            $param['Port'] = if ($m.HostType -eq 'Azure') {$m.AzureConnectionInfo.SshPort} else { 22 }
-            $param.Remove('ComputerName')
-            $param.Remove('PSSessionOption')
-            $param.Remove('Authentication')
-            $param.Remove('Credential')
-            $param.Remove('UseSsl')
-        }
+        #if (((Get-Command New-PSSession).Parameters.Values.Name -contains 'HostName') )
+        #{
+        #    $param['HostName'] = $param['ComputerName']
+        #    $param['Port'] = if ($m.HostType -eq 'Azure') {$m.AzureConnectionInfo.SshPort} else { 22 }
+        #    $param.Remove('ComputerName')
+        #    $param.Remove('PSSessionOption')
+        #    $param.Remove('Authentication')
+        #    $param.Remove('Credential')
+        #    $param.Remove('UseSsl')
+        #}
 
         Get-PSSession | Where-Object {
             (($_.ComputerName -eq $param.ComputerName) -or ($_.ComputerName -eq $param.HostName)) -and

--- a/AutomatedLabCore/functions/Tfs/Get-LabTfsFeed.ps1
+++ b/AutomatedLabCore/functions/Tfs/Get-LabTfsFeed.ps1
@@ -7,24 +7,33 @@
         $ComputerName,
 
         [string]
-        $FeedName
+        $FeedName,
+
+        [switch]$UseAzureUrl
     )
-    
+
     $lab = Get-Lab
     $tfsVm = Get-LabVM -ComputerName $ComputerName
     $defaultParam = Get-LabTfsParameter -ComputerName $ComputerName
-    
+
     $defaultParam['FeedName']   = $FeedName
     $defaultParam['ApiVersion'] = '5.0-preview.1'
-    
+
     $feed = Get-TfsFeed @defaultParam
-        
+
     if (-not $tfsVm.SkipDeployment -and $(Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
     {
-        if ($feed.url -match 'http(s?)://(?<Host>[\w\.]+):(?<Port>\d+)/')
+        if ($feed.url -match 'http(s?)://(?<Host>[\w\.-]+):(?<Port>\d+)/')
         {
-            $feed.url = $feed.url.Replace($Matches.Host, $tfsVm.AzureConnectionInfo.DnsName)
-            $feed.url = $feed.url.Replace($Matches.Port, $defaultParam.Port)
+            if ($UseAzureUrl)
+            {
+                $feed.url = $feed.url.Replace($Matches.Host, $tfsVm.AzureConnectionInfo.DnsName)
+                $feed.url = $feed.url.Replace($Matches.Port, $defaultParam.Port)
+            }
+            else
+            {
+                $feed.url = $feed.url.Replace($Matches.Host, $tfsVm.Name)
+            }
         }
     }
 
@@ -32,12 +41,12 @@
     {
         $nugetV2Url = '{0}/_packaging/{1}/nuget/v2' -f $Matches.url, $feed.name
         $feed | Add-Member -Name NugetV2Url -MemberType NoteProperty $nugetV2Url
-        
+
         $feed | Add-Member -Name NugetCredential -MemberType NoteProperty ($tfsVm.GetCredential($lab))
-        
+
         $nugetApiKey = '{0}@{1}:{2}' -f $feed.NugetCredential.GetNetworkCredential().UserName, $feed.NugetCredential.GetNetworkCredential().Domain, $feed.NugetCredential.GetNetworkCredential().Password
         $feed | Add-Member -Name NugetApiKey -MemberType NoteProperty -Value $nugetApiKey
     }
-    
+
     $feed
 }

--- a/AutomatedLabCore/functions/Tfs/Install-LabBuildWorker.ps1
+++ b/AutomatedLabCore/functions/Tfs/Install-LabBuildWorker.ps1
@@ -2,7 +2,10 @@
 {
     [CmdletBinding()]
     param
-    ( )
+    (
+        [Parameter()]
+        [switch]$UseAzureUrl
+    )
 
     $buildWorkers = Get-LabVM -Role TfsBuildWorker
     if (-not $buildWorkers)
@@ -83,7 +86,7 @@
 
         [string]$machineName = $tfsServer
 
-        if ((Get-Lab).DefaultVirtualizationEngine -eq 'Azure' -and -not ($tfsServer.Roles.Name -eq 'AzDevOps' -and $tfsServer.SkipDeployment))
+        if ((Get-Lab).DefaultVirtualizationEngine -eq 'Azure' -and -not ($tfsServer.Roles.Name -eq 'AzDevOps' -and $tfsServer.SkipDeployment -and $UseAzureUrl))
         {
             $tfsPort = (Get-LabAzureLoadBalancedPort -DestinationPort $tfsPort -ComputerName $tfsServer -ErrorAction SilentlyContinue).Port
             $machineName = $tfsServer.AzureConnectionInfo.DnsName

--- a/AutomatedLabCore/functions/Tfs/New-LabReleasePipeline.ps1
+++ b/AutomatedLabCore/functions/Tfs/New-LabReleasePipeline.ps1
@@ -76,7 +76,7 @@
     if ($CodeUploadMethod -eq 'git' -and -not $tfsVm.SkipDeployment -and $(Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
     {
         $repository.remoteUrl = $repository.remoteUrl -replace $originalPort, $defaultParam.Port
-        if ($repository.remoteUrl -match 'http(s?)://(?<Host>[\w\.]+):')
+        if ($repository.remoteUrl -match 'http(s?)://(?<Host>[\w\.-]+):')
         {
             $repository.remoteUrl = $repository.remoteUrl.Replace($Matches.Host, $tfsVm.AzureConnectionInfo.DnsName)
         }
@@ -84,7 +84,7 @@
 
     if ($CodeUploadMethod -eq 'FileCopy' -and -not $tfsVm.SkipDeployment -and $(Get-Lab).DefaultVirtualizationEngine -eq 'Azure')
     {
-        if ($repository.remoteUrl -match 'http(s?)://(?<Host>[\w\.]+):')
+        if ($repository.remoteUrl -match 'http(s?)://(?<Host>[\w\.-]+):')
         {
             $repository.remoteUrl = $repository.remoteUrl.Replace($Matches.Host, $tfsVm.FQDN)
         }

--- a/AutomatedLabCore/internal/scripts/Initialization.ps1
+++ b/AutomatedLabCore/internal/scripts/Initialization.ps1
@@ -176,7 +176,7 @@ Set-PSFConfig -Module 'AutomatedLab' -Name SkipHostFileModification -Value $fals
 
 #Azure
 Set-PSFConfig -Module 'AutomatedLab' -Name MinimumAzureModuleVersion -Value '4.1.0' -Initialize -Validation string -Description 'The minimum expected Azure module version'
-Set-PSFConfig -Module 'AutomatedLab' -Name DefaultAzureRoleSize -Value 'DS' -Initialize -Validation string -Description 'The default Azure role size, e.g. from Get-LabAzureAvailableRoleSize'
+Set-PSFConfig -Module 'AutomatedLab' -Name DefaultAzureRoleSize -Value 'D' -Initialize -Validation string -Description 'The default Azure role size, e.g. from Get-LabAzureAvailableRoleSize'
 Set-PSFConfig -Module 'AutomatedLab' -Name LabSourcesMaxFileSizeMb -Value 50 -Initialize -Validation integer -Description 'The default file size for Sync-LabAzureLabSources'
 Set-PSFConfig -Module 'AutomatedLab' -Name AutoSyncLabSources -Value $false -Initialize -Validation bool -Description 'Toggle auto-sync of Azure lab sources in Azure labs'
 Set-PSFConfig -Module 'AutomatedLab' -Name LabSourcesSyncIntervalDays -Value 60 -Initialize -Validation integerpositive -Description 'Interval in days for lab sources auto-sync'

--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Initialize-LWAzureVM.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Initialize-LWAzureVM.ps1
@@ -251,8 +251,14 @@ $finalErrorCode = $LASTEXITCODE
         #Add *.windows.net to Local Intranet Zone
         $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Domains\windows.net'
         New-Item -Path $path -Force
-
         New-ItemProperty $path -Name http -Value 1 -Type DWORD
+        New-ItemProperty $path -Name file -Value 1 -Type DWORD
+
+        #Add *.azure.com to Local Intranet Zone
+        $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Domains\azure.com'
+        New-Item -Path $path -Force
+        New-ItemProperty $path -Name http -Value 1 -Type DWORD
+        New-ItemProperty $path -Name https -Value 1 -Type DWORD
         New-ItemProperty $path -Name file -Value 1 -Type DWORD
 
         if (-not $Disks) { $null = try { Stop-Transcript -ErrorAction Stop } catch { }; return }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,8 @@
 
 ## Unreleased (yyyy-MM-dd)
 
-## 5.55.0 (2024-12-31)
-
 ### Enhancements
 
-- 'DefaultAzureRoleSize' is not 'DS'.
 - Not all Skus with a restriction 'NotAvailableForSubscription' will be ignored, only the
   ones that have a 'NotAvailableForSubscription'-restriction for the location.
 - Taking VM generation into account when selecting an Azure role size / image.
@@ -14,6 +11,8 @@
 ### Bugs
 
 - Updated selection of Azure VM role sizes. It was outdated.
+
+## 5.55.0 (2024-12-31)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@
 - Not all Skus with a restriction 'NotAvailableForSubscription' will be ignored, only the
   ones that have a 'NotAvailableForSubscription'-restriction for the location.
 - Taking VM generation into account when selecting an Azure role size / image.
+- Added parameter 'UseAzureUrl' to 'Get-LabTfsFeed'.
+- Add *.azure.com to Local Intranet Zone in Azure VM initialization.
 
 ### Bugs
 
 - Updated selection of Azure VM role sizes. It was outdated.
+- Fix regex pattern to match hostnames in remote URL for Azure deployments.
+- The SSH code in 'Remove-LabPSSession' has been removed, it needs to be revised.
 
 ## 5.55.0 (2024-12-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   ones that have a 'NotAvailableForSubscription'-restriction for the location.
 - Taking VM generation into account when selecting an Azure role size / image.
 - Added parameter 'UseAzureUrl' to 'Get-LabTfsFeed'.
+- Added parameter 'UseAzureUrl' to 'Install-LabBuildWorker' because of unexpected results in the DscWorkshop.
 - Add *.azure.com to Local Intranet Zone in Azure VM initialization.
 
 ### Bugs

--- a/Help/AutomatedLabCore/en-us/Get-LabTfsFeed.md
+++ b/Help/AutomatedLabCore/en-us/Get-LabTfsFeed.md
@@ -13,7 +13,7 @@ List or locate Artifact feed details of an Azure DevOps/TFS instance
 ## SYNTAX
 
 ```
-Get-LabTfsFeed [-ComputerName] <String> [[-FeedName] <String>] [<CommonParameters>]
+Get-LabTfsFeed [-ComputerName] <String> [[-FeedName] <String>] [-UseAzureUrl] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -56,6 +56,21 @@ Aliases:
 Required: False
 Position: 1
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseAzureUrl
+Use the hostname in the feed's url instead of the external Azure name.
+
+```yaml
+Type: switch
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/Help/AutomatedLabCore/en-us/Install-LabBuildWorker.md
+++ b/Help/AutomatedLabCore/en-us/Install-LabBuildWorker.md
@@ -13,7 +13,7 @@ Install build worker roles
 ## SYNTAX
 
 ```
-Install-LabBuildWorker [<CommonParameters>]
+Install-LabBuildWorker [-UseAzureUrl] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,6 +29,21 @@ PS C:\> Install-LabBuildWorker
 Install build worker roles
 
 ## PARAMETERS
+
+### -UseAzureUrl
+Use the hostname in the feed's url instead of the external Azure name.
+
+```yaml
+Type: switch
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: None
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).


### PR DESCRIPTION
## Description

### Enhancements

- Added parameter 'UseAzureUrl' to 'Get-LabTfsFeed'.
- Added parameter 'UseAzureUrl' to 'Install-LabBuildWorker' because of unexpected results in the DscWorkshop.
- Add *.azure.com to Local Intranet Zone in Azure VM initialization.

### Bugs

- Fix regex pattern to match hostnames in remote URL for Azure deployments.
- The SSH code in 'Remove-LabPSSession' has been removed, it needs to be revised.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Deployment of DscWorkshop.