### PR TITLE
Bugfix in AutomatedLabSQL.psm1 to separate domain- & username.

### DIFF
--- a/AutomatedLabCore/internal/functions/New-LabSqlAccount.ps1
+++ b/AutomatedLabCore/internal/functions/New-LabSqlAccount.ps1
@@ -116,8 +116,8 @@
 
         if ($kvp.Key.Contains("\"))
         {
-            $domain = ($kvp.Key -split "\\")[0]
-            $user = ($kvp.Key -split "\\")[1]
+            $domain = ($kvp.Key -split "\\\\")[0]
+            $user = ($kvp.Key -split "\\\\")[1]
         }
 
         if ($kvp.Key.Contains("@"))
@@ -171,8 +171,8 @@
     {
         if ($group.Contains("\"))
         {
-            $domain = ($group -split "\\")[0]
-            $groupName = ($group -split "\\")[1]
+            $domain = ($group -split "\\\\")[0]
+            $groupName = ($group -split "\\\\")[1]
         }
         elseif ($group.Contains("@"))
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased (yyyy-MM-dd)
 
+### Enhancements
+
+### Bugs
+
+- Bugfix in AutomatedLabSQL.psm1 to separate domain- & username.
+
 ## 5.56.0 (2025-01-26)
 
 ### Enhancements


### PR DESCRIPTION
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [?] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Tested in my lab and now the
SQLSYSADMINACCOUNTS            "DomainName\DomainAccount"
from MSSQL configfile are correct separated in $domain and $group.
 -->
