### PR TITLE
make test host connected faster

### DIFF
--- a/AutomatedLabCore/functions/Core/Test-LabHostConnected.ps1
+++ b/AutomatedLabCore/functions/Core/Test-LabHostConnected.ps1
@@ -24,27 +24,11 @@
         {
             $null -ne (Get-NetConnectionProfile | Where-Object {$_.IPv4Connectivity -eq 'Internet' -or $_.IPv6Connectivity -eq 'Internet'})
         }
-        elseif ((Get-ChildItem -Path env:\ACC_OID,env:\ACC_VERSION,env:\ACC_TID -ErrorAction SilentlyContinue).Count -eq 3)
-        {
-            # Assuming that we are in Azure Cloud Console aka Cloud Shell which is connected but cannot send ICMP packages
-            $true
-        }
-        elseif ($IsLinux)
-        {
-            # Due to an unadressed issue with Test-Connection on Linux
-            $portOpen = Test-Port -ComputerName automatedlab.org -Port 443
-            if (-not $portOpen.Open)
-            {
-                [System.Net.NetworkInformation.Ping]::new().Send('automatedlab.org').Status -eq 'Success'
-            }
-            else
-            {
-                $portOpen.Open
-            }
-        }
         else
         {
-            Test-Connection -ComputerName automatedlab.org -Count 4 -Quiet -ErrorAction SilentlyContinue -InformationAction Ignore
+            # Do a quick check with HEAD only, more reliable across OSes
+            $response = Invoke-WebRequest -Method Head -Uri https://automatedlab.org -TimeoutSec 5 -ErrorAction SilentlyContinue
+            $null -ne $response
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased (yyyy-MM-dd)
 
+### Enhancements
+
+- Fixed issue with Linux and Test-LabHostConnected sometimes not able to reliably ping
+
+### Bugs
+
 ## 5.56.0 (2025-01-26)
 
 ### Enhancements


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

On Fedora with pwsh 7.5, Test-LabHostConnected was not able to reach our domain on 443. Replaced it with Invoke-WebRequest with operation HEAD to get a response quickly. That should work across all systems.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
