### PR TITLE
Filter Skus on deprecation in case version sort fails

### DIFF
--- a/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableSku.ps1
+++ b/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableSku.ps1
@@ -30,8 +30,8 @@
     Get-AzVMImageSku |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 
     # Linux
     # Ubuntu - official
@@ -43,8 +43,8 @@
     Where-Object Skus -notmatch 'arm64' |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 
     # RedHat - official
     $publishers |
@@ -55,8 +55,8 @@
     Where-Object Skus -notmatch '(RAW|LVM|CI)' |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 
     # CentOS - Roguewave, sounds slightly suspicious
     $publishers |
@@ -66,8 +66,8 @@
     Get-AzVMImageSku |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 
     # Kali
     $publishers |
@@ -76,8 +76,8 @@
     Get-AzVMImageSku |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 
     # Desktop
     $publishers |
@@ -86,8 +86,8 @@
     Get-AzVMImageSku |
     Get-AzVMImage |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 
     # SQL
     $publishers |
@@ -97,8 +97,8 @@
     Get-AzVMImage |
     Where-Object Skus -in 'Standard','Enterprise' |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 
     # VisualStudio
     $publishers |
@@ -108,8 +108,8 @@
     Get-AzVMImage |
     Where-Object Offer -eq 'VisualStudio' |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 
     # Client OS
     $publishers |
@@ -119,8 +119,8 @@
     Get-AzVMImage |
     Where-Object Offer -eq 'Windows' |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 
     # Sharepoint 2013 and 2016
     $publishers |
@@ -130,6 +130,6 @@
     Get-AzVMImage |
     Where-Object Offer -eq 'MicrosoftSharePointServer' |
     Group-Object -Property Skus, Offer |
-    ForEach-Object { $_.Group | Sort-Object -Property PublishedDate -Descending | Select-Object -First 1 | Get-AzVmImage } |
-    Where-Object PurchasePlan -eq $null
+    ForEach-Object { $_.Group | Sort-Object -Property {$_.Version -as [Version]} -Descending | Select-Object -First 1 | Get-AzVmImage } |
+    Where-Object {$_.PurchasePlan -eq $null -and $_.ImageDeprecationStatus.ImageState -eq 'Active'}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs
 
+- Fixed issue with Get-LabAzureAvailableSku returning deprecated images (#1712)
+
 ## 5.56.0 (2025-01-26)
 
 ### Enhancements


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #1712 

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Ran `Get-LabAzureAvailableSku` and verified that we still get our previous list of OSes (Windows since 2012 and so on), but with more recent image versions.