### PR TITLE
Remove debug output for VM size capabilities in Get-LabAzureAvailableRoleSize function

### DIFF
--- a/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableRoleSize.ps1
+++ b/AutomatedLabCore/functions/Azure/Get-LabAzureAvailableRoleSize.ps1
@@ -45,7 +45,6 @@
     foreach ($vms in (Get-AzComputeResourceSku -Location $azLocation.Location | Where-Object -Property Name -in $availableRoleSizes.Name))
     {
         $rsInfo = $availableRoleSizes | Where-Object Name -eq $vms.Name
-        Write-Host "$($vms.Name) - $($rsInfo.Capabilities.Where({$_.Name -eq 'HyperVGenerations'}).Value)"
 
         [AutomatedLab.Azure.AzureRmVmSize]@{
             NumberOfCores        = $rsInfo.Capabilities.Where({ $_.Name -eq 'vCPUs' }).Value


### PR DESCRIPTION
## Description

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
NA