### PR TITLE
Skip init of initialized vms

### DIFF
--- a/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Initialize-LWAzureVM.ps1
+++ b/AutomatedLabWorker/functions/AzureWorkerVirtualMachines/Initialize-LWAzureVM.ps1
@@ -11,6 +11,13 @@
 
     $azureRetryCount = Get-LabConfigurationItem -Name AzureRetryCount
     $lab = Get-Lab
+    $azvms = Get-LWAzureVm -ComputerName $Machine | Where-Object {-not $_.Tags['InitDone']}
+
+    if ($azvms.Count -eq 0) {
+        Write-ScreenInfo -Message "Azure VMs already initialized" -Type Verbose
+        Write-LogFunctionExit
+        return
+    }
 
     $initScript = {
         param(
@@ -509,6 +516,12 @@ sudo systemctl restart sshd
     }
 
     Send-ModuleToPSSession -Module (Get-Module -ListAvailable -Name AutomatedLab.Common | Select-Object -First 1) -Session $sessions -IncludeDependencies -Force
+
+    $null = $azvms | ForEach-Object {
+        $_.Tags['InitDone'] = Get-Date -Format u
+        $_ | Update-AzVM
+    }
+
     Write-ScreenInfo -Message 'Finished' -TaskEnd
 
     Write-ScreenInfo -Message 'Stopping all new machines except domain controllers'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support Oracle Linux 7 and 8. Oracle Linux 9 does not yet work (#1722).
 - The `Az.Compute` cmdlet `Get-AzVMSize` got replaced by `Get-AzComputeResourceSku`. Making the necessary changes.
 - Update Az module versions for public Azure
+- Skip init of initialized VMs
 
 ### Bugs
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Make it faster :) Previously, re-running a lab would re-initialize. Since Invoke-AzVmRunCommand takes forever, this took forever.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->
Ran `Install-Lab` twice