### PR TITLE
Fix referencetype bug

### DIFF
--- a/AutomatedLabDefinition/functions/Core/Get-LabMachineDefinition.ps1
+++ b/AutomatedLabDefinition/functions/Core/Get-LabMachineDefinition.ps1
@@ -1,5 +1,4 @@
-﻿function Get-LabMachineDefinition
-{
+﻿function Get-LabMachineDefinition {
     [CmdletBinding(DefaultParameterSetName = 'ByName')]
     [OutputType([AutomatedLab.Machine])]
 
@@ -15,59 +14,49 @@
         [switch]$All
     )
 
-    begin
-    {
+    begin {
         #required to suporess verbose messages, warnings and errors
         Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
         Write-LogFunctionEntry
 
-        $result = @()
+        [System.Collections.Generic.List[AutomatedLab.Machine]]$result = [System.Collections.Generic.List[AutomatedLab.Machine]]::new()
     }
 
-    process
-    {
-        if ($PSCmdlet.ParameterSetName -eq 'ByName')
-        {
-            if ($ComputerName)
-            {
-                foreach ($n in $ComputerName)
-                {
+    process {
+        if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            if ($ComputerName) {
+                foreach ($n in $ComputerName) {
                     $machine = $Script:machines | Where-Object Name -in $n
-                    if (-not $machine)
-                    {
+                    if (-not $machine) {
                         continue
                     }
 
-                    $result += $machine
+                    $result.Add($machine)
                 }
             }
-            else
-            {
-                $result = $Script:machines
+            else {
+                $result.AddRange($Script:machines)
             }
         }
 
-        if ($PSCmdlet.ParameterSetName -eq 'ByRole')
-        {
-            $result = $Script:machines |
+        if ($PSCmdlet.ParameterSetName -eq 'ByRole') {
+            $Script:machines |
             Where-Object { $_.Roles.Name } |
-            Where-Object { $_.Roles | Where-Object { $Role.HasFlag([AutomatedLab.Roles]$_.Name) } }
+            Where-Object { $_.Roles | Where-Object { $Role.HasFlag([AutomatedLab.Roles]$_.Name) } } |
+            ForEach-Object { $result.Add($_) }
 
-            if (-not $result)
-            {
+            if (-not $result) {
                 return
             }
         }
 
-        if ($PSCmdlet.ParameterSetName -eq 'All')
-        {
-            $result = $Script:machines
+        if ($PSCmdlet.ParameterSetName -eq 'All') {
+            $result.AddRange($Script:machines)
         }
     }
 
-    end
-    {
+    end {
         $result
     }
 }

--- a/AutomatedLabDefinition/functions/Core/Remove-LabMachineDefinition.ps1
+++ b/AutomatedLabDefinition/functions/Core/Remove-LabMachineDefinition.ps1
@@ -1,24 +1,27 @@
-﻿function Remove-LabMachineDefinition
-{
+﻿function Remove-LabMachineDefinition {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [string]$Name
     )
 
-    Write-LogFunctionEntry
-
-    $machine = $script:machines | Where-Object Name -eq $Name
-
-    if (-not $machine)
-    {
-        Write-ScreenInfo "There is no machine defined with the name '$Name'" -Type Warning
-    }
-    else
-    {
-        [Void]$script:machines.Remove($machine)
-        Write-PSFMessage "Machine '$Name' removed. Lab has $($Script:machines.Count) machine(s) defined"
+    begin {
+        Write-LogFunctionEntry
     }
 
-    Write-LogFunctionExit
+    process {
+        $machine = $script:machines | Where-Object Name -eq $Name
+
+        if (-not $machine) {
+            Write-ScreenInfo "There is no machine defined with the name '$Name'" -Type Warning
+        }
+        else {
+            [Void]$script:machines.Remove($machine)
+            Write-PSFMessage "Machine '$Name' removed. Lab has $($Script:machines.Count) machine(s) defined"
+        }
+    }
+
+    end {
+        Write-LogFunctionExit
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   - Fixed module behavior to only import that are not yet loaded ([#1793](https://github.com/AutomatedLab/AutomatedLab/issues/1793)).
   - Fixed error handling so the function returns $false in case of a module load error ([#1794](https://github.com/AutomatedLab/AutomatedLab/issues/1794)).
 - Remove dependcy on International module by generating language list statically (#1640)
+- Fix bug in `Remove-LabMachineDefinition` in which the function accepts pipeline input but does not process it.
 
 ## [5.59.0] - 2025-08-18
 


### PR DESCRIPTION
<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Fixes #1803 

We had not only an issue with a function accepting pipeline input and not using process{} but also an
issue due to us copying a referencetype, which is now also fixed.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

Any lab definition with more than 1 VM -> Get-LabMachineDefinition | Remove-LabMachineDefinition