### PR TITLE
Fix Get-LabVirtualNetwork parameter type for -Name to support multipl…

### DIFF
--- a/AutomatedLabDefinition/functions/Core/Get-LabVirtualNetwork.ps1
+++ b/AutomatedLabDefinition/functions/Core/Get-LabVirtualNetwork.ps1
@@ -3,7 +3,7 @@
     [cmdletBinding(DefaultParameterSetName = 'ByName')]
     param (
         [Parameter(ParameterSetName = 'ByName')]
-        [string]$Name,
+        [string[]]$Name,
 
         [Parameter(ParameterSetName = 'All')]
         [switch]$All

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Fixed
 
-- Issue with labs using NAT and defining a Gateway in which the gateway was incorrectly set to 0.0.0.0
+- Issue with labs using NAT and defining a Gateway in which the gateway was incorrectly set to 0.0.0.0.
 - Issue with AutoLogon when using Add-LabMachineDefinition -InstallationUserCredential. Local and domain accounts were confused (#1816).
+- Fix `Get-LabVirtualNetwork` parameter `-Name` typed as `[string]` instead of `[string[]]`, which caused `Remove-Lab` to fail removing virtual network switches in multi-network labs.
 
 ## [5.60.0] - 2026-03-05
 


### PR DESCRIPTION
## Description

`Get-LabVirtualNetwork` in `AutomatedLabDefinition` defines `-Name` as `[string]`, but `Remove-LabNetworkSwitches` in `AutomatedLabCore` passes `$virtualNetworks.Name` which is an `Object[]` when multiple networks exist. PowerShell cannot coerce the array to `[string]`, causing parameter binding to fail. This results in all virtual network switches failing removal with "lab meta data for this object could not be retrieved".

Changed `[string]$Name` to `[string[]]$Name` in `Get-LabVirtualNetwork`. The function body already handles arrays correctly (`$Name | foreach { Get-VMSwitch -Name $_ }`).

- [x] - I have tested my changes.
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix
- [ ] New functionality
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

Dagger