### PR TITLE
Fix Write-ScreenInfo not resetting NoNewLine flag for Verbose/Debug types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Issue with labs using NAT and defining a Gateway in which the gateway was incorrectly set to 0.0.0.0.
 - Issue with AutoLogon when using Add-LabMachineDefinition -InstallationUserCredential. Local and domain accounts were confused (#1816).
 - Fix `Get-LabVirtualNetwork` parameter `-Name` typed as `[string]` instead of `[string[]]`, which caused `Remove-Lab` to fail removing virtual network switches in multi-network labs.
+- Fixed `Write-ScreenInfo` in PSLog not resetting `$Global:PSLog_NoNewLine` when `-Type Verbose` or `-Type Debug` is used and the preference variable is `SilentlyContinue`, causing subsequent messages to lose their timestamp prefix.
 
 ### Changed
 

--- a/PSLog/functions/Core/Write-ScreenInfo.ps1
+++ b/PSLog/functions/Core/Write-ScreenInfo.ps1
@@ -130,16 +130,16 @@
                     if ($VerbosePreference -eq 'Continue')
                     {
                         $Message | ForEach-Object { Microsoft.PowerShell.Utility\Write-Host $_ -ForegroundColor Cyan }
-                        $Global:PSLog_NoNewLine = $false
                     }
+                    $Global:PSLog_NoNewLine = $false
                 }
                 Debug
                 {
                     if ($DebugPreference -eq 'Continue')
                     {
                         $Message | ForEach-Object { Microsoft.PowerShell.Utility\Write-Host $_ -ForegroundColor Cyan }
-                        $Global:PSLog_NoNewLine = $false
                     }
+                    $Global:PSLog_NoNewLine = $false
                 }
             }
         }


### PR DESCRIPTION
## Description

**Bug fix: `Write-ScreenInfo` does not reset `$Global:PSLog_NoNewLine` when `-Type Verbose` or `-Type Debug` is used and the corresponding preference variable is `SilentlyContinue`.**

When `Write-ScreenInfo` is called with `-NoNewLine -Type Verbose`, it sets `$Global:PSLog_NoNewLine = $true`. A subsequent call **without** `-NoNewLine` (intended to close the line) should reset the flag to `$false`. However, for the `Verbose` and `Debug` type cases, the reset is inside the `if ($VerbosePreference -eq 'Continue')` / `if ($DebugPreference -eq 'Continue')` block. When the preference is `SilentlyContinue` (the default), the flag is never reset.

This causes the **next** `Write-ScreenInfo` call (even with `-Type Info`) to be treated as a continuation line — printing **without the timestamp prefix**.

**Example output before fix:**
```
14:54:02|00:45:49|00:00:19.693| Removing Proxmox VM 'VCMPDC001'
Stopping Proxmox VM 'VCMPDC001' before removal        <-- missing prefix
14:54:22|00:46:09|00:00:18.703| Lab VM 'VCMPDC001' has been removed
```

**After fix:**
```
14:54:02|00:45:49|00:00:19.693| Removing Proxmox VM 'VCMPDC001'
14:54:02|00:45:49|00:00:19.695| Stopping Proxmox VM 'VCMPDC001' before removal
14:54:22|00:46:09|00:00:18.703| Lab VM 'VCMPDC001' has been removed
```

The fix moves `$Global:PSLog_NoNewLine = $false` **outside** the preference check for both `Verbose` and `Debug` cases, so the flag is always reset regardless of whether the message is actually displayed.

- [x] - I have tested my changes.
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.
- [ ] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix
- [ ] New functionality
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

Tested by deploying and removing Proxmox lab VMs (`Remove-Lab`) after applying the fix to PSLog.psm1. Confirmed that the "Stopping Proxmox VM" message now displays with the correct timestamp prefix, consistent with all other `Write-ScreenInfo -Type Info` messages.
