### PR TITLE
Fix Install-LabRdsCertificate failing on RDS CIM settings (Fixes #1832)

### DIFF
--- a/AutomatedLabCore/functions/Remoting/Install-LabRdsCertificate.ps1
+++ b/AutomatedLabCore/functions/Remoting/Install-LabRdsCertificate.ps1
@@ -38,7 +38,7 @@
             $null = $cert | Export-Certificate -FilePath "C:\$($machine.Name).cer" -Type CERT -Force
             try
             {
-                $rdsSettings = Get-CimInstance -ClassName Win32_TSGeneralSetting -Namespace ROOT\CIMV2\TerminalServices
+                $rdsSettings = Get-CimInstance -ClassName Win32_TSGeneralSetting -Namespace ROOT\CIMV2\TerminalServices -ErrorAction Stop
                 $rdsSettings.SSLCertificateSHA1Hash = $cert.Thumbprint
                 $rdsSettings | Set-CimInstance
             }

--- a/AutomatedLabCore/functions/Remoting/Install-LabRdsCertificate.ps1
+++ b/AutomatedLabCore/functions/Remoting/Install-LabRdsCertificate.ps1
@@ -35,11 +35,18 @@
             {
                 New-SelfSignedCertificate -DnsName $SANs -CertStoreLocation 'Cert:\LocalMachine\my'
             }
-            $rdsSettings = Get-CimInstance -ClassName Win32_TSGeneralSetting -Namespace ROOT\CIMV2\TerminalServices
-            $rdsSettings.SSLCertificateSHA1Hash = $cert.Thumbprint
-            $rdsSettings | Set-CimInstance
             $null = $cert | Export-Certificate -FilePath "C:\$($machine.Name).cer" -Type CERT -Force
-        } -Variable (Get-Variable machine) -AsJob -PassThru
+            try
+            {
+                $rdsSettings = Get-CimInstance -ClassName Win32_TSGeneralSetting -Namespace ROOT\CIMV2\TerminalServices
+                $rdsSettings.SSLCertificateSHA1Hash = $cert.Thumbprint
+                $rdsSettings | Set-CimInstance
+            }
+            catch
+            {
+                Write-Warning -Message "Failed to configure RDS certificate for $($machine.Name): $_"
+            }
+        } -Variable (Get-Variable -Name machine) -AsJob -PassThru
     }
 
     Wait-LWLabJob -Job $jobs -NoDisplay
@@ -53,5 +60,5 @@
     }
     Invoke-LabCommand -ComputerName $machine -ActivityName 'Removing RDS temporary certs' -NoDisplay -ScriptBlock {
         Remove-Item "C:\$($machine.Name).cer"
-    } -Variable (Get-Variable machine) -PassThru
+    } -Variable (Get-Variable -Name machine) -PassThru
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Issue with labs using NAT and defining a Gateway in which the gateway was incorrectly set to 0.0.0.0.
 - Issue with AutoLogon when using Add-LabMachineDefinition -InstallationUserCredential. Local and domain accounts were confused (#1816).
+- Fixed `Install-LabRdsCertificate` failing when RDS CIM settings could not be configured, now gracefully handles errors (#1832).
 - Fix `Get-LabVirtualNetwork` parameter `-Name` typed as `[string]` instead of `[string[]]`, which caused `Remove-Lab` to fail removing virtual network switches in multi-network labs.
 - Fixed `Write-ScreenInfo` in PSLog not resetting `$Global:PSLog_NoNewLine` when `-Type Verbose` or `-Type Debug` is used and the preference variable is `SilentlyContinue`, causing subsequent messages to lose their timestamp prefix.
 


### PR DESCRIPTION
## Description

`Install-LabRdsCertificate` failed when the RDS CIM settings (`Win32_TSGeneralSetting`) could not be configured on a target machine. The certificate was exported successfully, but the subsequent `Set-CimInstance` call would terminate the entire remote job without recovery.

This PR wraps the RDS CIM configuration in a `try/catch` block so that a failure to set the SSL certificate thumbprint on the Terminal Services settings is handled gracefully with a warning instead of a terminating error. The certificate export now also runs before the CIM configuration attempt, ensuring partial progress is preserved.

Additionally, `Get-Variable machine` calls are corrected to use the explicit `-Name` parameter (`Get-Variable -Name machine`) for clarity and to avoid positional parameter ambiguity.

- [x] - I have tested my changes.
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix
- [ ] New functionality
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

Deployed some simple labs from the introduction folder.