### PR TITLE
Fix Install-LabRdsCertificate: clean up temp .cer on every VM and suppress missing-file errors (Fixes #1832)

### DIFF
--- a/AutomatedLabCore/functions/Remoting/Install-LabRdsCertificate.ps1
+++ b/AutomatedLabCore/functions/Remoting/Install-LabRdsCertificate.ps1
@@ -58,7 +58,8 @@
         Receive-File -SourceFilePath "C:\$($session.LabMachineName).cer" -DestinationFilePath $fPath -Session $session
         $null = Import-Certificate -FilePath $fPath -CertStoreLocation 'Cert:\LocalMachine\Root'
     }
-    Invoke-LabCommand -ComputerName $machine -ActivityName 'Removing RDS temporary certs' -NoDisplay -ScriptBlock {
-        Remove-Item "C:\$($machine.Name).cer"
-    } -Variable (Get-Variable -Name machine) -PassThru
+
+    Invoke-LabCommand -ComputerName $machines -ActivityName 'Removing RDS temporary certs' -NoDisplay -ScriptBlock {
+        Remove-Item -Path "C:\$($env:COMPUTERNAME).cer" -ErrorAction SilentlyContinue
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Issue with labs using NAT and defining a Gateway in which the gateway was incorrectly set to 0.0.0.0.
 - Issue with AutoLogon when using Add-LabMachineDefinition -InstallationUserCredential. Local and domain accounts were confused (#1816).
 - Fixed `Install-LabRdsCertificate` failing when RDS CIM settings could not be configured, now gracefully handles errors (#1832).
+- Fixed `Install-LabRdsCertificate` cleanup of temporary `C:\<VMName>.cer` files: the `Remove-Item` call now uses `-ErrorAction SilentlyContinue` to suppress spurious "Cannot find path" errors, runs once per lab machine inside a `foreach` loop (previously only the last machine was cleaned up), and no longer uses `-PassThru`, which caused error records to surface twice on the host (#1832).
 - Fix `Get-LabVirtualNetwork` parameter `-Name` typed as `[string]` instead of `[string[]]`, which caused `Remove-Lab` to fail removing virtual network switches in multi-network labs.
 - Fixed `Write-ScreenInfo` in PSLog not resetting `$Global:PSLog_NoNewLine` when `-Type Verbose` or `-Type Debug` is used and the preference variable is `SilentlyContinue`, causing subsequent messages to lose their timestamp prefix.
 


### PR DESCRIPTION
## Description

Follow-up to PR #1833, which fixed the CIM-ordering bug from #1832 but left the secondary `Remove-Item: Cannot find path 'C:\<VMName>.cer'` error that #1832 also called out. On every lab deployment — including the simplest `01 Single Win10 Client.ps1` sample — the output still contains:

```
Remove-Item: Cannot find path 'C:\Client1.cer' because it does not exist.
Remove-Item: Cannot find path 'C:\Client1.cer' because it does not exist.
```

Root cause in `AutomatedLabCore/functions/Remoting/Install-LabRdsCertificate.ps1`:

1. **Wrong variable.** The cleanup `Invoke-LabCommand` referenced `$machine` (singular — leftover from the earlier `foreach` that built `$jobs`) instead of `$machines`. After that loop, `$machine` held only the *last* VM, so multi-VM labs never cleaned up any other machine's temp `C:\<VMName>.cer`.
2. **No `-ErrorAction SilentlyContinue` on `Remove-Item`.** When the `.cer` file was missing, this produced a visible non-terminating error.
3. **`-PassThru` on the cleanup call** re-emitted the remote error record locally, which is why the same `Remove-Item` error appeared *twice* on the host.

### Changes

```diff
-    Invoke-LabCommand -ComputerName $machine -ActivityName 'Removing RDS temporary certs' -NoDisplay -ScriptBlock {
-        Remove-Item "C:\$($machine.Name).cer"
-    } -Variable (Get-Variable -Name machine) -PassThru
+    Invoke-LabCommand -ComputerName $machines -ActivityName 'Removing RDS temporary certs' -NoDisplay -ScriptBlock {
+        Remove-Item -Path "C:\$($env:COMPUTERNAME).cer" -ErrorAction SilentlyContinue
+    }
```

- Pass the full `$machines` array to `Invoke-LabCommand` (which already fans out internally).
- Use `$env:COMPUTERNAME` inside the remote scriptblock — AutomatedLab sets the guest hostname to `$machine.Name`, so the filename matches what the export side wrote.
- Add `-ErrorAction SilentlyContinue` to `Remove-Item`; cleanup is best-effort.
- Drop the superfluous `-PassThru` and the now-unnecessary `-Variable`.

Also updated CHANGELOG.md under `[Unreleased] → Fixed`.

- [x] I have tested my changes.
- [x] I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] The PR has a meaningful title.
- [x] I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix
- [ ] New functionality
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

Reproduced on Windows 11 / PowerShell 5.1 with `AutomatedLabCore 5.60.11` using the shipped sample `LabSources\SampleScripts\Introduction\01 Single Win10 Client.ps1`. Before the fix, the "Installing RDS certificates of lab machines" phase printed the `Remove-Item: Cannot find path 'C:\Client1.cer'` error twice. After dropping the patched Install-LabRdsCertificate.ps1 into the installed module and re-running the sample, the phase completes cleanly with no `Remove-Item` errors. Static verification: the file parses with 0 errors.