### PR TITLE
fix: update DSC Pull Server lab validator to support SQL Server 2022 …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- DSC Pull Server lab validator (`DscSqlServerPresent`) now accepts SQL Server 2022 and 2025 in addition to 2016/2017/2019 as the backend database engine, and the validation error message has been clarified accordingly (#1844).
+
 ## [5.61.0] - 2026-05-12
 
 ### Fixed

--- a/LabXml/Validator/DscPullServer/DscSqlServerPresent.cs
+++ b/LabXml/Validator/DscPullServer/DscSqlServerPresent.cs
@@ -17,7 +17,7 @@ namespace AutomatedLab.Validator.FailoverCluster
         {
             var role = Roles.DSCPullServer;
             var machines = lab.Machines.Where(m => m.Roles.Where(r => r.Name == role).Count() > 0);
-            var sqlServers = lab.Machines.Where(m => m.Roles.Where(r => r.Name == Roles.SQLServer2016 || r.Name == Roles.SQLServer2017 || r.Name == Roles.SQLServer2019).Count() > 0);
+            var sqlServers = lab.Machines.Where(m => m.Roles.Where(r => r.Name == Roles.SQLServer2016 || r.Name == Roles.SQLServer2017 || r.Name == Roles.SQLServer2019 || r.Name == Roles.SQLServer2022 || r.Name == Roles.SQLServer2025).Count() > 0);
 
             foreach (var machine in machines)
             {
@@ -31,7 +31,7 @@ namespace AutomatedLab.Validator.FailoverCluster
                         {
                             yield return new ValidationMessage
                             {
-                                Message = string.Format("The database server for the DSC Pull Server role is '{0}' but there is no SQL Server 2016 or 2017 defined inthe lab with that name", targetedSqlServer),
+                                Message = string.Format("The database server for the DSC Pull Server role is '{0}' but there is no supported SQL Server (2016, 2017, 2019, 2022 or 2025) defined in the lab with that name", targetedSqlServer),
                                 Type = MessageType.Error,
                                 TargetObject = machine.Name
                             };


### PR DESCRIPTION
## Description

Fixes #1844.

The DSC Pull Server lab validator (`DscSqlServerPresent`) only accepted SQL Server 2016/2017/2019 as the backend database engine and failed lab validation when a `SQLServer2022` (or `SQLServer2025`) machine was referenced via the `SqlServer` role property — even though both roles are valid in `AutomatedLab.Roles`. The error message was also misleading ("no SQL Server 2016 or 2017 defined inthe lab").

Changes:

- `LabXml/Validator/DscPullServer/DscSqlServerPresent.cs` — added `Roles.SQLServer2022` and `Roles.SQLServer2025` to the SQL role filter and clarified the validation error message.
- `CHANGELOG.md` — entry under `[Unreleased] / Fixed`.

- [x] - I have tested my changes.
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix
- [ ] New functionality
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

Rebuilt `LabXml` and re-ran the failing lab definition (DSC Pull Server with `SqlServer = 'DSCCASQL01'` where `DSCCASQL01` has role `SQLServer2022`). `Validating lab definition` now passes without the spurious `DscSqlServerPresent` error.