### PR TITLE
fix(Install-LabADDSTrust): stop duplicate trust creation attempts (Fixes #1850)

### DIFF
--- a/AutomatedLabCore/functions/ADDS/Install-LabADDSTrust.ps1
+++ b/AutomatedLabCore/functions/ADDS/Install-LabADDSTrust.ps1
@@ -68,14 +68,24 @@
                     '$($domainAdministrator.Password -replace "'","''" )')
                 `$otherForest = [System.DirectoryServices.ActiveDirectory.Forest]::GetForest(`$otherForestCtx)
 
-                Write-Verbose "Creating forest trust between forests '`$(`$thisForest.Name)' and '`$(`$otherForest.Name)'"
+                if (@(`$thisForest.GetAllTrustRelationships()).TargetName -contains `$otherForest.Name)
+                {
+                    Write-Verbose "Forest trust between forests '`$(`$thisForest.Name)' and '`$(`$otherForest.Name)' already exists"
+                }
+                else
+                {
+                    Write-Verbose "Creating forest trust between forests '`$(`$thisForest.Name)' and '`$(`$otherForest.Name)'"
 
-                `$thisForest.CreateTrustRelationship(
-                    `$otherForest,
-                    [System.DirectoryServices.ActiveDirectory.TrustDirection]::Bidirectional
-                )
+                    `$thisForest.CreateTrustRelationship(
+                        `$otherForest,
+                        [System.DirectoryServices.ActiveDirectory.TrustDirection]::Bidirectional
+                    )
 
-                Write-Verbose 'Forest trust created'
+                    Write-Verbose 'Forest trust created'
+                }
+
+                # Invoke-LWCommand retries a script block that returns nothing.
+                "`$(`$thisForest.Name) -> `$(`$otherForest.Name)"
 "@
 
             Invoke-LabCommand -ComputerName $rootDc -ScriptBlock ([scriptblock]::Create($cmd)) -NoDisplay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed `New-LWReferenceVHDX` silently producing unbootable base images when `bcdboot` fails (#1662, #1805)
 - DSC Pull Server lab validator (`DscSqlServerPresent`) now accepts SQL Server 2022 and 2025 in addition to 2016/2017/2019 as the backend database engine, and the validation error message has been clarified accordingly (#1844).
+- Fixed `Install-LabADDSTrust` emitting `MethodInvocationException: ... A forest trust relationship exists between ...` for every forest pair during the `Configuring AD trusts` phase of multi-forest labs. The trust script block now skips `CreateTrustRelationship` when the trust already exists and returns a string, so `Invoke-LWCommand` no longer retries it as a command that never ran. This also makes re-running `Install-LabADDSTrust` on an existing lab safe.
 
 ## [5.61.0] - 2026-05-12
 


### PR DESCRIPTION
## Description

`Install-Lab` printed a `MethodInvocationException` for every forest pair during
the `Configuring AD trusts` phase:

    MethodInvocationException: Exception calling "CreateTrustRelationship" with "2" argument(s): "A forest trust relationship exists between "forest1.net" and "forest2.net"."

The trusts were created correctly, so the errors were noise, but a successful
multi-forest deployment looked broken.

`Invoke-LWCommand` decides whether a script block ran by inspecting the
`RunspaceId` of the objects it returned. A script block that writes nothing to
the success stream returns no objects, so the session is never removed from
`$internalSession` and the command is executed again until
`AutomatedLab.InvokeLabCommandRetries` (default `3`) is exhausted.

The trust script block in `Install-LabADDSTrust` was exactly that: it only
called `Write-Verbose`, and `Forest.CreateTrustRelationship()` returns `void`.
So attempt 1 created the trust silently, and attempts 2 and 3 failed with
"a forest trust relationship exists" - two errors per forest pair, six for a
three-forest lab.

This change makes the trust script block idempotent and gives it a return value:

- It skips creation when `GetAllTrustRelationships()` already lists the target
  forest, so re-running `Install-LabADDSTrust` on an existing lab is now safe.
- It emits `"<source forest> -> <target forest>"`, so `Invoke-LWCommand`
  recognises the run as successful and does not retry.

Scope is deliberately narrow. The underlying problem is that `Invoke-LWCommand`
treats "returned no objects" as "did not run", which is unsound for any command
whose purpose is a side effect. Fixing that is a much larger change with a wide
blast radius across every caller, so it is not attempted here. Filed as a
follow-up in #1850.

- [x] - I have tested my changes.
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change

- [x] Bug fix
- [ ] New functionality
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?

Tested against a live three-forest Hyper-V lab (`forest1.net`, `forest2.net`,
`forest3.net`, one `RootDC` each plus two `FirstChildDC`) on a Windows Server
2025 host with Windows Server 2025 guests, PowerShell 7.6.3.

**Reproduction of the defect before the change**

1. `Install-Lab` on the `Multi-AD Forest with Trusts` sample emitted six
   `MethodInvocationException` errors, two per forest pair.
2. Re-running `Install-LabADDSTrust` with the trusts already present emitted
   nine errors, three per pair. That is the predicted three-attempt pattern
   without a silent first success, which confirms the retry loop rather than a
   defect in `CreateTrustRelationship` itself.
3. A minimal, lab-independent check isolated the retry behaviour. One
   `Invoke-LabCommand` with a script block that writes nothing to the success
   stream but appends a line to a file on the target produced three lines:

   ```powershell
   Invoke-LabCommand -ComputerName F1DC1 -ScriptBlock {
       Add-Content -Path C:\invocation-count.txt -Value ([datetime]::UtcNow.ToString('o'))
   } -NoDisplay
   # C:\invocation-count.txt then contains 3 lines.
   ```

4. Ruled out unrelated causes. Deleting the `forest1.net` / `forest2.net` trust
   from both sides and running the generated script block once returned without
   error and created the trust on both sides, so neither Windows Server 2025 nor
   the .NET API is at fault. `Get-FullMesh -List <three forests> -OneWay`
   returns three pairs, so the mesh is not duplicated.

**Verification after the change**

Ran the patched `Install-LabADDSTrust` against the same lab in a fresh
PowerShell session, with all trusts already present - the worst case for the old
code, which produced nine errors there:

    New errors raised            : 0      (was 9)
    'ran to completion' entries  : 9      (was 6)

All six directed forest trusts remained `Bidirectional` / `Forest`, and
`nltest /sc_verify:` from each root DC returned `Status = 0 0x0 NERR_Success`.

**Not covered**

No unit test is added. `Install-LabADDSTrust` has no seam for one - it builds a
here-string and hands it to `Invoke-LabCommand`, and the assertion that matters
is the retry count observed on a real multi-forest deployment.

The `repadmin /SyncAll` block in the same function is also output-less and still
runs three times per root DC. It produces no errors, only redundant replication
passes, so it is left alone here to keep this change reviewable.
